### PR TITLE
初期化中の get clock の動作変更

### DIFF
--- a/Examples/minimum_user_for_s2e/src/src_user/c2a_main.c
+++ b/Examples/minimum_user_for_s2e/src/src_user/c2a_main.c
@@ -60,7 +60,7 @@ static void C2A_init_(void)
   C2A_core_init();
 
   // TaskDispatcherでの大量のアノマリを避けるために、一度時刻を初期化する。
-  TMGR_init();
+  TMGR_clear();
   Printf("C2A_init: TMGR_init done.\n");
 }
 #pragma section

--- a/System/ApplicationManager/app_manager.c
+++ b/System/ApplicationManager/app_manager.c
@@ -126,9 +126,9 @@ static AM_ACK AM_initialize_app_(size_t id)
 #ifdef SILS_FW
   app_manager_.ais[id].initializer();
 #else
-  start = TMGR_get_clock_from_boot();
+  start = TMGR_get_master_clock_from_boot();
   app_manager_.ais[id].initializer();
-  finish = TMGR_get_clock_from_boot();
+  finish = TMGR_get_master_clock_from_boot();
 
   // 処理時間情報アップデート
   app_manager_.ais[id].init_duration = OBCT_diff_in_step(&start, &finish);

--- a/System/ApplicationManager/app_manager.c
+++ b/System/ApplicationManager/app_manager.c
@@ -126,9 +126,9 @@ static AM_ACK AM_initialize_app_(size_t id)
 #ifdef SILS_FW
   app_manager_.ais[id].initializer();
 #else
-  start = TMGR_get_master_clock();
+  start = TMGR_get_clock_from_boot();
   app_manager_.ais[id].initializer();
-  finish = TMGR_get_master_clock();
+  finish = TMGR_get_clock_from_boot();
 
   // 処理時間情報アップデート
   app_manager_.ais[id].init_duration = OBCT_diff_in_step(&start, &finish);

--- a/System/TimeManager/obc_time.c
+++ b/System/TimeManager/obc_time.c
@@ -139,6 +139,21 @@ ObcTime OBCT_diff(const ObcTime* before,
   return diff;
 }
 
+ObcTime OBCT_add(const ObcTime* left, const ObcTime* right)
+{
+  ObcTime ret;
+
+  ret.total_cycle = left->total_cycle + right->total_cycle;
+  ret.mode_cycle = left->mode_cycle + right->mode_cycle;
+  ret.step = left->step + right->step;
+
+  ret.total_cycle += ret.step / OBCT_STEPS_PER_CYCLE;
+  ret.mode_cycle += ret.step / OBCT_STEPS_PER_CYCLE;
+  ret.step %= OBCT_STEPS_PER_CYCLE;
+
+  return ret;
+}
+
 step_t OBCT_diff_in_step(const ObcTime* before,
                          const ObcTime* after)
 {

--- a/System/TimeManager/obc_time.h
+++ b/System/TimeManager/obc_time.h
@@ -49,6 +49,7 @@ cycle_t  OBCT_msec2cycle(uint32_t msec);      // ìKìñÇ…ä€ÇﬂÇÁÇÍÇÈÇ±Ç∆Ç…íçà”
 uint32_t OBCT_cycle2msec(cycle_t cycle);      // ìKìñÇ…ä€ÇﬂÇÁÇÍÇÈÇ±Ç∆Ç…íçà”
 ObcTime OBCT_diff(const ObcTime* before,
                   const ObcTime* after);
+ObcTime OBCT_add(const ObcTime* left, const ObcTime* right);
 step_t OBCT_diff_in_step(const ObcTime* before,
                          const ObcTime* after);
 uint32_t OBCT_diff_in_msec(const ObcTime* before,

--- a/System/TimeManager/time_manager.c
+++ b/System/TimeManager/time_manager.c
@@ -1,8 +1,6 @@
 #pragma section REPRO
 #include "time_manager.h"
-
 #include <string.h>
-
 #include <src_user/CmdTlm/Ccsds/TCPacket.h>
 #include "../TaskManager/task_dispatcher.h"
 #include "../../Library/endian_memcpy.h"

--- a/System/TimeManager/time_manager.c
+++ b/System/TimeManager/time_manager.c
@@ -18,7 +18,7 @@ static void TMGR_set_master_total_cycle_(cycle_t total_cycle);
 
 void TMGR_init(void)
 {
-  OBCT_clear(&time_manager_.init_time);
+  OBCT_clear(&time_manager_.initializing_time);
   time_manager_.initializing_flag = 1;
   TMGR_clear();
 }
@@ -31,7 +31,7 @@ void TMGR_clear(void)
 
 void TMGR_down_initializing_flag(void)
 {
-  memcpy(&time_manager_.init_time, &master_clock_, sizeof(ObcTime));
+  memcpy(&time_manager_.initializing_time, &master_clock_, sizeof(ObcTime));
   time_manager_.initializing_flag = 0;
   
   TMGR_clear();
@@ -166,9 +166,9 @@ CCP_EXEC_STS Cmd_TMGR_SET_UNIXTIME(const CTCP* packet)
   return CCP_EXEC_SUCCESS;
 }
 
-ObcTime TMGR_get_clock_from_boot(void)
+ObcTime TMGR_get_master_clock_from_boot(void)
 {
-  return OBCT_add(&time_manager_.init_time, &master_clock_);
+  return OBCT_add(&time_manager_.initializing_time, &master_clock_);
 }
 
 #pragma section

--- a/System/TimeManager/time_manager.c
+++ b/System/TimeManager/time_manager.c
@@ -29,7 +29,7 @@ void TMGR_clear(void)
   OBCT_clear_unix_time_info(&OBCT_unix_time_info_);
 }
 
-void TMGR_lower_initializing_flag(void)
+void TMGR_down_initializing_flag(void)
 {
   memcpy(&time_manager_.init_time, &master_clock_, sizeof(ObcTime));
   time_manager_.initializing_flag = 0;

--- a/System/TimeManager/time_manager.c
+++ b/System/TimeManager/time_manager.c
@@ -14,7 +14,7 @@ static OBCT_UnixTimeInfo OBCT_unix_time_info_;
 const OBCT_UnixTimeInfo* const OBCT_unix_time_info = &OBCT_unix_time_info_;
 
 static TimeManager time_manager_;
-extern const TimeManager* const time_manager = &time_manager_;
+const TimeManager* const time_manager = &time_manager_;
 
 static void TMGR_set_master_total_cycle_(cycle_t total_cycle);
 

--- a/System/TimeManager/time_manager.c
+++ b/System/TimeManager/time_manager.c
@@ -21,7 +21,7 @@ static void TMGR_set_master_total_cycle_(cycle_t total_cycle);
 void TMGR_init(void)
 {
   OBCT_clear(&time_manager_.init_time);
-  time_manager_.init_flag = 1;
+  time_manager_.initializing_flag = 1;
   TMGR_clear();
 }
 
@@ -31,10 +31,12 @@ void TMGR_clear(void)
   OBCT_clear_unix_time_info(&OBCT_unix_time_info_);
 }
 
-void TMGR_lower_init_flag(void)
+void TMGR_lower_initializing_flag(void)
 {
   memcpy(&time_manager_.init_time, &master_clock_, sizeof(ObcTime));
-  time_manager_.init_flag = 0;
+  time_manager_.initializing_flag = 0;
+  
+  TMGR_clear();
 }
 
 void TMGR_clear_master_mode_cycle(void)
@@ -64,7 +66,7 @@ uint32_t TMGR_get_master_mode_cycle_in_msec(void)
 
 ObcTime TMGR_get_master_clock(void)
 {
-  if (time_manager_.init_flag)
+  if (time_manager_.initializing_flag)
   {
     return OBCT_create(0, 0, 0);
   }

--- a/System/TimeManager/time_manager.c
+++ b/System/TimeManager/time_manager.c
@@ -8,10 +8,8 @@
 #include "../../Library/endian_memcpy.h"
 
 static ObcTime master_clock_;
-const ObcTime* const master_clock = &master_clock_;
 
 static OBCT_UnixTimeInfo OBCT_unix_time_info_;
-const OBCT_UnixTimeInfo* const OBCT_unix_time_info = &OBCT_unix_time_info_;
 
 static TimeManager time_manager_;
 const TimeManager* const time_manager = &time_manager_;
@@ -72,7 +70,7 @@ ObcTime TMGR_get_master_clock(void)
   }
   else
   {
-    return *master_clock;
+    return master_clock_;
   }
 }
 
@@ -115,12 +113,12 @@ static void TMGR_set_master_total_cycle_(cycle_t total_cycle)
 double TMGR_get_unix_time_from_ObcTime(const ObcTime* time)
 {
   ObcTime ti0 = OBCT_create(0, 0, 0);
-  return OBCT_unix_time_info->unix_time_on_ti0 + OBCT_diff_in_sec(&ti0, time);
+  return OBCT_unix_time_info_.unix_time_on_ti0 + OBCT_diff_in_sec(&ti0, time);
 }
 
 ObcTime TMGR_get_ObcTime_from_unix_time(const double unix_time)
 {
-  double diff_double = unix_time - OBCT_unix_time_info->unix_time_on_ti0;
+  double diff_double = unix_time - OBCT_unix_time_info_.unix_time_on_ti0;
   ObcTime res;
   uint32_t diff;
   cycle_t cycle_diff;
@@ -149,7 +147,7 @@ void TMGR_modify_unix_time_criteria(const double unix_time, const ObcTime time)
 
 OBCT_UnixTimeInfo TMGR_get_obct_unix_time_info(void)
 {
-  return *OBCT_unix_time_info;
+  return OBCT_unix_time_info_;
 }
 
 CCP_EXEC_STS Cmd_TMGR_SET_UNIXTIME(const CTCP* packet)
@@ -170,7 +168,7 @@ CCP_EXEC_STS Cmd_TMGR_SET_UNIXTIME(const CTCP* packet)
 
 ObcTime TMGR_get_clock_from_boot(void)
 {
-  return OBCT_add(&time_manager_.init_time, master_clock);
+  return OBCT_add(&time_manager_.init_time, &master_clock_);
 }
 
 #pragma section

--- a/System/TimeManager/time_manager.c
+++ b/System/TimeManager/time_manager.c
@@ -33,7 +33,7 @@ void TMGR_down_initializing_flag(void)
 {
   memcpy(&time_manager_.initializing_time, &master_clock_, sizeof(ObcTime));
   time_manager_.initializing_flag = 0;
-  
+
   TMGR_clear();
 }
 

--- a/System/TimeManager/time_manager.h
+++ b/System/TimeManager/time_manager.h
@@ -12,7 +12,17 @@
 // などを用いてアクセス（read only）する
 // extern const ObcTime* master_clock;
 
+typedef struct
+{
+  ObcTime init_time;
+  uint8_t init_flag;
+} TimeManager;
+
+extern const TimeManager* const time_manager;
+
 void TMGR_init(void);
+void TMGR_clear(void);
+void TMGR_lower_init_flag(void);
 void TMGR_clear_master_mode_cycle(void);
 void TMGR_count_up_master_clock(void);
 uint32_t TMGR_get_master_total_cycle_in_msec(void);  // 計算上はstepも考慮（オーバーフローに注意）
@@ -25,6 +35,7 @@ double TMGR_get_unix_time_from_ObcTime(const ObcTime* time);
 ObcTime TMGR_get_ObcTime_from_unix_time(const double unix_time);
 void TMGR_modify_unix_time_criteria(const double unix_time, const ObcTime time);
 OBCT_UnixTimeInfo TMGR_get_obct_unix_time_info(void);
+ObcTime TMGR_get_clock_from_boot(void);
 
 CCP_EXEC_STS Cmd_TMGR_SET_TIME(const CTCP* packet);
 CCP_EXEC_STS Cmd_TMGR_SET_UNIXTIME(const CTCP* packet);

--- a/System/TimeManager/time_manager.h
+++ b/System/TimeManager/time_manager.h
@@ -22,7 +22,7 @@ extern const TimeManager* const time_manager;
 
 void TMGR_init(void);
 void TMGR_clear(void);
-void TMGR_lower_initializing_flag(void);
+void TMGR_down_initializing_flag(void);
 void TMGR_clear_master_mode_cycle(void);
 void TMGR_count_up_master_clock(void);
 uint32_t TMGR_get_master_total_cycle_in_msec(void);  // 計算上はstepも考慮（オーバーフローに注意）

--- a/System/TimeManager/time_manager.h
+++ b/System/TimeManager/time_manager.h
@@ -4,14 +4,6 @@
 #include "obc_time.h"
 #include "../../CmdTlm/common_tlm_cmd_packet.h"
 
-// 2020-05-26
-// master_clock の公開を中止した．
-// 今後は，
-//   + ObcTime TMGR_get_master_clock();
-//   + cycle_t TMGR_get_master_cycle();
-// などを用いてアクセス（read only）する
-// extern const ObcTime* master_clock;
-
 typedef struct
 {
   ObcTime initializing_time;
@@ -40,4 +32,4 @@ ObcTime TMGR_get_master_clock_from_boot(void);
 CCP_EXEC_STS Cmd_TMGR_SET_TIME(const CTCP* packet);
 CCP_EXEC_STS Cmd_TMGR_SET_UNIXTIME(const CTCP* packet);
 
-#endif // TIME_MANAGER_H_
+#endif

--- a/System/TimeManager/time_manager.h
+++ b/System/TimeManager/time_manager.h
@@ -15,14 +15,14 @@
 typedef struct
 {
   ObcTime init_time;
-  uint8_t init_flag;
+  uint8_t initializing_flag;
 } TimeManager;
 
 extern const TimeManager* const time_manager;
 
 void TMGR_init(void);
 void TMGR_clear(void);
-void TMGR_lower_init_flag(void);
+void TMGR_lower_initializing_flag(void);
 void TMGR_clear_master_mode_cycle(void);
 void TMGR_count_up_master_clock(void);
 uint32_t TMGR_get_master_total_cycle_in_msec(void);  // 計算上はstepも考慮（オーバーフローに注意）

--- a/System/TimeManager/time_manager.h
+++ b/System/TimeManager/time_manager.h
@@ -14,7 +14,7 @@
 
 typedef struct
 {
-  ObcTime init_time;
+  ObcTime initializing_time;
   uint8_t initializing_flag;
 } TimeManager;
 
@@ -35,7 +35,7 @@ double TMGR_get_unix_time_from_ObcTime(const ObcTime* time);
 ObcTime TMGR_get_ObcTime_from_unix_time(const double unix_time);
 void TMGR_modify_unix_time_criteria(const double unix_time, const ObcTime time);
 OBCT_UnixTimeInfo TMGR_get_obct_unix_time_info(void);
-ObcTime TMGR_get_clock_from_boot(void);
+ObcTime TMGR_get_master_clock_from_boot(void);
 
 CCP_EXEC_STS Cmd_TMGR_SET_TIME(const CTCP* packet);
 CCP_EXEC_STS Cmd_TMGR_SET_UNIXTIME(const CTCP* packet);

--- a/c2a_core_main.c
+++ b/c2a_core_main.c
@@ -45,7 +45,8 @@ void C2A_core_init(void)
   Printf("C2A_init: TDSP_initialize done.\n");
   // DebugOutInit();             // Debug‚Ìinit          // LVTTL UART ch1‚Å‚Ìo—ÍD×–‚‚È‚Ì‚ÅPrintf‚Ì’†g‚Æ‚Æ‚à‚É–³Œø‰» (2019-04-09)
   // Printf("C2A_init: DebugOutInit done.\n");
-  TMGR_lower_init_flag(); // init ‚ğ‰º‚°‚é
+
+  TMGR_lower_initializing_flag();
 }
 
 void C2A_core_main(void)

--- a/c2a_core_main.c
+++ b/c2a_core_main.c
@@ -46,7 +46,7 @@ void C2A_core_init(void)
   // DebugOutInit();             // Debug‚Ìinit          // LVTTL UART ch1‚Å‚Ìo—ÍD×–‚‚È‚Ì‚ÅPrintf‚Ì’†g‚Æ‚Æ‚à‚É–³Œø‰» (2019-04-09)
   // Printf("C2A_init: DebugOutInit done.\n");
 
-  TMGR_lower_initializing_flag();
+  TMGR_down_initializing_flag();
 }
 
 void C2A_core_main(void)

--- a/c2a_core_main.c
+++ b/c2a_core_main.c
@@ -6,6 +6,7 @@
 #include "./System/ApplicationManager/app_manager.h"
 #include "./System/EventManager/event_manager.h"
 #include "./System/AnomalyLogger/anomaly_logger.h"
+#include "./System/TimeManager/time_manager.h"
 #include "./System/ModeManager/mode_manager.h"
 #include "./System/WatchdogTimer/watchdog_timer.h"
 #include "./CmdTlm/packet_handler.h"
@@ -44,11 +45,11 @@ void C2A_core_init(void)
   Printf("C2A_init: TDSP_initialize done.\n");
   // DebugOutInit();             // Debugのinit          // LVTTL UART ch1での出力．邪魔なのでPrintfの中身とともに無効化 (2019-04-09)
   // Printf("C2A_init: DebugOutInit done.\n");
+  TMGR_lower_init_flag(); // init を下げる
 }
 
 void C2A_core_main(void)
 {
-  // 2018/09/09 コメント追記
   // ここでいうtask dispatcherは，TL0とかではなく，
   // task listのBlockCommandをdispatchしている．
   // TL0などのPLをdispatchしているのは，tlc_dispatcher @ App/timeline_command_dispatcher である．


### PR DESCRIPTION
## 概要
初期化中の get clock の動作変更

## Issue
* https://github.com/ut-issl/c2a-core/issues/47

## 詳細
TMGR の初期化に Initializing flag を設けて get_master_clock の動作を変えた。また get_clock_from_boot を新設

## 検証結果
SILS動作を確認した

## 影響範囲
大 (初期化にかかわるので)

