### PR TITLE
Fix CMakeLists.txt for Printf

### DIFF
--- a/Examples/minimum_user_for_s2e/CMakeLists.txt
+++ b/Examples/minimum_user_for_s2e/CMakeLists.txt
@@ -37,6 +37,14 @@ set(C2A_USER_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/src_user)
 include_directories(src)
 add_definitions(-DSILS_FW)
 
+# Output debug print to SILS console window
+option(SHOW_DEBUG_PRINT_ON_SILS "Show debug print")
+set(SHOW_DEBUG_PRINT_ON_SILS ON)
+if(SHOW_DEBUG_PRINT_ON_SILS)
+  add_definitions(-DSHOW_DEBUG_PRINT_ON_SILS)
+  message("Show debug print")
+endif()
+
 add_subdirectory(${C2A_CORE_DIR})
 
 add_subdirectory(${C2A_USER_DIR}/Applications)
@@ -57,7 +65,6 @@ endif()
 
 add_library(${PROJECT_NAME} STATIC ${C2A_SRCS})
 
-
 target_link_libraries(${PROJECT_NAME} C2A_CORE
   C2A_USER_APPS
   C2A_USER_CMD_TLM
@@ -67,15 +74,6 @@ target_link_libraries(${PROJECT_NAME} C2A_CORE
   C2A_USER_SETTINGS
 )
 
-
-
-# Output debug print to SILS console window
-option(SHOW_DEBUG_PRINT_ON_SILS "Show debug print")
-set(SHOW_DEBUG_PRINT_ON_SILS ON)
-if(SHOW_DEBUG_PRINT_ON_SILS)
-  add_definitions(-DSHOW_DEBUG_PRINT_ON_SILS)
-  message("Show debug print")
-endif()
 
 if(WIN32)
   add_custom_command(TARGET ${PROJECT_NAME}

--- a/Library/CMakeLists.txt
+++ b/Library/CMakeLists.txt
@@ -10,7 +10,6 @@ set(C2A_SRCS
   exor.c
   majority_vote_for3.c
   matrix.c
-  print.c
   quaternion.c
   c2a_round.c
   sum.c


### PR DESCRIPTION
## 概要
S2EでPrintfが出力されない問題を修正

## Issue
NA

## 詳細
- `SHOW_DEBUG_PRINT_ON_SILS` の設定場所を `add_subdirectory` のCMakeLists読み込み前にしないと効かない？
- `Printf` はuser側のものをつかうので，coreをビルド対象から外す
  - https://github.com/ut-issl/c2a-core/blob/cac210693b2b3bbcdca8f2cd5ec0002b5ad6eadf/Library/print.c#L7-L8

## 検証結果
手元でS2Eを回し，Printfが正しく出力されることを確認

## その他
`Printf` が２つ存在していたことになるのに，なんで今までリンク時にエラーが出なかったのか？適当にリンクされる？
