### PR TITLE
Cmd_BCT_OVERWRITE_CMD を可変長 Cmd に対応

### DIFF
--- a/CmdTlm/block_command_table.c
+++ b/CmdTlm/block_command_table.c
@@ -485,20 +485,20 @@ CCP_EXEC_STS Cmd_BCT_OVERWRITE_CMD(const CTCP* packet)
 
   BCT_Pos  pos;
   BCT_CmdData bct_cmddata; // FIXME BCT_CmdData <-> CTCP
-  BCT_CmdData tmp_param;   // いったんここにparamをコピーする
+  uint8_t tmp_param[sizeof(BCT_CmdData) - TCP_PRM_HDR_LEN - TCP_CMD_2ND_HDR_LEN - TCP_CMD_USER_HDR_LEN];   // いったんここにparamをコピーする
   uint16_t real_param_len = CCP_get_param_len(packet);
-  uint16_t min_cmd_param_len = sizeof(uint16_t) + sizeof(uint32_t) + sizeof(bct_id_t) + sizeof(uint8_t);
-  uint16_t max_cmd_param_len = min_cmd_param_len + sizeof(BCT_CmdData);
+  uint16_t min_cmd_param_len = CA_get_cmd_param_min_len(Cmd_CODE_BCT_OVERWRITE_CMD);
+  uint16_t max_cmd_param_len = min_cmd_param_len + sizeof(tmp_param);
   uint16_t cmd_param_len;
 
   // raw なので引数長チェック
   if (real_param_len < min_cmd_param_len || real_param_len > max_cmd_param_len) return CCP_EXEC_ILLEGAL_LENGTH;
 
   cmd_param_len = real_param_len - min_cmd_param_len;
-  CCP_get_raw_param_from_packet(packet, &tmp_param, sizeof(BCT_CmdData));
+  CCP_get_raw_param_from_packet(packet, tmp_param, sizeof(tmp_param));
 
   BCT_make_pos(&pos, block, cmd);
-  CCP_form_tlc((CTCP*)&bct_cmddata, ti, (CMD_CODE)cmd_id, (const uint8_t*)&tmp_param, cmd_param_len);
+  CCP_form_tlc((CTCP*)&bct_cmddata, ti, (CMD_CODE)cmd_id, (const uint8_t*)tmp_param, cmd_param_len);
   BCT_overwrite_cmd(&pos, (CTCP*)&bct_cmddata);
 
   return CCP_EXEC_SUCCESS;

--- a/CmdTlm/block_command_table.c
+++ b/CmdTlm/block_command_table.c
@@ -487,7 +487,7 @@ CCP_EXEC_STS Cmd_BCT_OVERWRITE_CMD(const CTCP* packet)
   BCT_CmdData bct_cmddata; // FIXME BCT_CmdData <-> CTCP
   BCT_CmdData tmp_param;   // Ç¢Ç¡ÇΩÇÒÇ±Ç±Ç…paramÇÉRÉsÅ[Ç∑ÇÈ
   uint16_t real_param_len = CCP_get_param_len(packet);
-  uint16_t min_cmd_param_len = sizeof(CMD_CODE) + sizeof(cycle_t) + sizeof(bct_id_t) + sizeof(uint8_t);
+  uint16_t min_cmd_param_len = sizeof(uint16_t) + sizeof(uint32_t) + sizeof(bct_id_t) + sizeof(uint8_t);
   uint16_t max_cmd_param_len = min_cmd_param_len + sizeof(BCT_CmdData);
   uint16_t cmd_param_len;
 

--- a/CmdTlm/block_command_table.c
+++ b/CmdTlm/block_command_table.c
@@ -479,30 +479,28 @@ CCP_EXEC_STS Cmd_BCT_COPY_BCT(const CTCP* packet)
 CCP_EXEC_STS Cmd_BCT_OVERWRITE_CMD(const CTCP* packet)
 {
   const unsigned char* param = CCP_get_param_head(packet);
-  uint16_t cmd_id;
-  cycle_t  ti;
-  bct_id_t block;
-  uint8_t  cmd;
+  CMD_CODE cmd_id = (CMD_CODE)CCP_get_param_from_packet(packet, 0, uint16_t);
+  cycle_t  ti     = (cycle_t)CCP_get_param_from_packet(packet, 1, uint32_t);
+  bct_id_t block  = (bct_id_t)CCP_get_param_from_packet(packet, 2, bct_id_t);
+  uint8_t  cmd    = CCP_get_param_from_packet(packet, 3, uint8_t);
 
-  uint16_t param_len;
   BCT_Pos  pos;
-  BCT_CmdData bct_cmddta; // FIXME BCT_CmdData <-> CTCP
-  endian_memcpy(&cmd_id, param, sizeof(uint16_t));
-  param += sizeof(uint16_t);
+  BCT_CmdData bct_cmddata; // FIXME BCT_CmdData <-> CTCP
+  BCT_CmdData tmp_param;   // いったんここにparamをコピーする
+  uint16_t real_param_len = CCP_get_param_len(packet);
+  uint16_t min_cmd_param_len = sizeof(CMD_CODE) + sizeof(cycle_t) + sizeof(bct_id_t) + sizeof(uint8_t);
+  uint16_t max_cmd_param_len = min_cmd_param_len + sizeof(BCT_CmdData);
+  uint16_t cmd_param_len;
 
-  param_len = CA_get_cmd_param_min_len((CMD_CODE)cmd_id);     // FIXME: rawパラメタ対応
-  if (CCP_get_param_len(packet) != sizeof(uint16_t) + sizeof(cycle_t) + SIZE_OF_BCT_ID_T + 1 + param_len) return CCP_EXEC_ILLEGAL_LENGTH;
+  // raw なので引数長チェック
+  if (real_param_len < min_cmd_param_len || real_param_len > max_cmd_param_len) return CCP_EXEC_ILLEGAL_LENGTH;
 
-  endian_memcpy(&ti, param, sizeof(cycle_t));
-  param += sizeof(cycle_t);
-  endian_memcpy(&block, param, SIZE_OF_BCT_ID_T);
-  param += SIZE_OF_BCT_ID_T;
-  endian_memcpy(&cmd, param, 1);
-  param += 1;
+  cmd_param_len = real_param_len - min_cmd_param_len;
+  CCP_get_raw_param_from_packet(packet, &tmp_param, sizeof(BCT_CmdData));
 
   BCT_make_pos(&pos, block, cmd);
-  CCP_form_tlc((CTCP*)&bct_cmddta, ti, (CMD_CODE)cmd_id, param, param_len);
-  BCT_overwrite_cmd(&pos, (CTCP*)&bct_cmddta);
+  CCP_form_tlc((CTCP*)&bct_cmddata, ti, (CMD_CODE)cmd_id, &tmp_param, cmd_param_len);
+  BCT_overwrite_cmd(&pos, (CTCP*)&bct_cmddata);
 
   return CCP_EXEC_SUCCESS;
 }

--- a/CmdTlm/block_command_table.c
+++ b/CmdTlm/block_command_table.c
@@ -484,22 +484,22 @@ CCP_EXEC_STS Cmd_BCT_OVERWRITE_CMD(const CTCP* packet)
   uint8_t  cmd    = CCP_get_param_from_packet(packet, 3, uint8_t);
 
   BCT_Pos  pos;
-  BCT_CmdData bct_cmddata; // FIXME BCT_CmdData <-> CTCP
-  uint8_t tmp_param[sizeof(BCT_CmdData) - TCP_PRM_HDR_LEN - TCP_CMD_2ND_HDR_LEN - TCP_CMD_USER_HDR_LEN];   // いったんここにparamをコピーする
+  BCT_CmdData new_bct_cmddata; // FIXME: BCT_CmdData <-> CTCP
+  uint8_t new_cmd_param[sizeof(BCT_CmdData) - TCP_PRM_HDR_LEN - TCP_CMD_2ND_HDR_LEN - TCP_CMD_USER_HDR_LEN];   // いったんここにparamをコピーする, FIXME: TCPに依存させないように
   uint16_t real_param_len = CCP_get_param_len(packet);
   uint16_t min_cmd_param_len = CA_get_cmd_param_min_len(Cmd_CODE_BCT_OVERWRITE_CMD);
-  uint16_t max_cmd_param_len = min_cmd_param_len + sizeof(tmp_param);
+  uint16_t max_cmd_param_len = min_cmd_param_len + sizeof(new_cmd_param);
   uint16_t cmd_param_len;
 
   // raw なので引数長チェック
   if (real_param_len < min_cmd_param_len || real_param_len > max_cmd_param_len) return CCP_EXEC_ILLEGAL_LENGTH;
 
   cmd_param_len = real_param_len - min_cmd_param_len;
-  CCP_get_raw_param_from_packet(packet, tmp_param, sizeof(tmp_param));
+  CCP_get_raw_param_from_packet(packet, new_cmd_param, cmd_param_len);
 
   BCT_make_pos(&pos, block, cmd);
-  CCP_form_tlc((CTCP*)&bct_cmddata, ti, (CMD_CODE)cmd_id, (const uint8_t*)tmp_param, cmd_param_len);
-  BCT_overwrite_cmd(&pos, (CTCP*)&bct_cmddata);
+  CCP_form_tlc((CTCP*)&new_bct_cmddata, ti, cmd_id, new_cmd_param, cmd_param_len);
+  BCT_overwrite_cmd(&pos, (CTCP*)&new_bct_cmddata);
 
   return CCP_EXEC_SUCCESS;
 }

--- a/CmdTlm/block_command_table.c
+++ b/CmdTlm/block_command_table.c
@@ -478,7 +478,6 @@ CCP_EXEC_STS Cmd_BCT_COPY_BCT(const CTCP* packet)
 
 CCP_EXEC_STS Cmd_BCT_OVERWRITE_CMD(const CTCP* packet)
 {
-  const unsigned char* param = CCP_get_param_head(packet);
   CMD_CODE cmd_id = (CMD_CODE)CCP_get_param_from_packet(packet, 0, uint16_t);
   cycle_t  ti     = (cycle_t)CCP_get_param_from_packet(packet, 1, uint32_t);
   bct_id_t block  = (bct_id_t)CCP_get_param_from_packet(packet, 2, bct_id_t);
@@ -499,7 +498,7 @@ CCP_EXEC_STS Cmd_BCT_OVERWRITE_CMD(const CTCP* packet)
   CCP_get_raw_param_from_packet(packet, &tmp_param, sizeof(BCT_CmdData));
 
   BCT_make_pos(&pos, block, cmd);
-  CCP_form_tlc((CTCP*)&bct_cmddata, ti, (CMD_CODE)cmd_id, &tmp_param, cmd_param_len);
+  CCP_form_tlc((CTCP*)&bct_cmddata, ti, (CMD_CODE)cmd_id, (const uint8_t*)&tmp_param, cmd_param_len);
   BCT_overwrite_cmd(&pos, (CTCP*)&bct_cmddata);
 
   return CCP_EXEC_SUCCESS;


### PR DESCRIPTION
## 概要
Cmd_BCT_OVERWRITE_CMD を可変長 Cmd に対応

## Issue
- https://github.com/ut-issl/c2a-core/issues/71

## 詳細
Cmd_BCT_OVERWRITE_CMD を可変長 Cmd に対応するようにした

## 検証結果
テストに全部通った & SILS でテストした結果BCTが書き換わった

## 影響範囲
小
