### PR TITLE
C89規格に準拠したワーニングを出す

### DIFF
--- a/.github/workflows/build_as_c89.yml
+++ b/.github/workflows/build_as_c89.yml
@@ -31,6 +31,9 @@ jobs:
         run: |
           sudo apt-get install -y libc6-dev-i386
 
+      - name: convert Shift-JIS to UTF-8
+        run: find . -type f \( -name '*.h' -or -name '*.c' \) -exec nkf --overwrite -S -w80 {} \;
+
       - name: setup
         shell: bash
         run: ./setup.sh

--- a/.github/workflows/build_as_c89.yml
+++ b/.github/workflows/build_as_c89.yml
@@ -18,12 +18,45 @@ on:
       - 'setup.sh'
 
 jobs:
+  gen_build_matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.gen-matrix.outputs.matrix }}
+    steps:
+      - name: generate matrix json
+        id: gen-matrix
+        shell: bash
+        run: |
+          compiler=(
+            "gcc"
+            "clang"
+          )
+          warning=(
+          "Werror"
+          "Wextra"
+          )
+          echo "[" > tmp
+          for c in "${compiler[@]}"; do
+            for w in "${warning[@]}"; do
+              if [ "$c" == "gcc" ] && [ "$w" == "Werror" ]; then
+                continue
+              fi
+              echo "{ \"compiler\": \"${c}\", \"warning\": \"${w}\" }" >> tmp
+              echo "," >> tmp
+            done
+          done
+          sed -i -e '$d' tmp # remove final comma
+          echo "]" >> tmp
+          sed -i -z 's/\n//g' tmp # remove newline
+          jq < tmp
+          echo "::set-output name=matrix::{\"include\": $(cat tmp) }"
+
   build_minimum_user_as_c89:
     runs-on: ubuntu-latest
+    needs: gen_build_matrix
     strategy:
-      matrix:
-        compiler: [gcc, clang]
-        warning: [Werror, Wextra]
+      fail-fast: false
+      matrix: ${{ fromJson(needs.gen_build_matrix.outputs.matrix) }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build_as_c89.yml
+++ b/.github/workflows/build_as_c89.yml
@@ -6,6 +6,7 @@ on:
       - '.github/workflows/build_as_c89.yml'
       - 'c2a_core_main.c'
       - 'c2a_core_main.h'
+      - 'common.cmake'
       - 'Applications/**'
       - 'CmdTlm/**'
       - 'Drivers/**'

--- a/.github/workflows/build_as_c89.yml
+++ b/.github/workflows/build_as_c89.yml
@@ -22,6 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        compiler: [gcc, clang]
         warning: [Werror, Wextra]
 
     steps:
@@ -32,6 +33,7 @@ jobs:
           sudo apt-get install -y libc6-dev-i386
 
       - name: convert Shift-JIS to UTF-8
+        if: matrix.compiler == 'clang'
         run: find . -type f \( -name '*.h' -or -name '*.c' \) -exec nkf --overwrite -S -w80 {} \;
 
       - name: setup
@@ -55,6 +57,8 @@ jobs:
 
       - name: cmake
         working-directory: ./Examples/minimum_user_for_s2e
+        env:
+          CC: ${{ matrix.compiler }}
         run: |
           mkdir build
           cd build

--- a/.github/workflows/build_as_c89.yml
+++ b/.github/workflows/build_as_c89.yml
@@ -63,11 +63,11 @@ jobs:
 
       - name: install deps
         run: |
-          sudo apt-get install -y libc6-dev-i386
+          sudo apt-get install -y libc6-dev-i386 nkf
 
       - name: convert Shift-JIS to UTF-8
         if: matrix.compiler == 'clang'
-        run: find . -type f \( -name '*.h' -or -name '*.c' \) -exec nkf --overwrite -S -w80 {} \;
+        run: find -- . -type f \( -name '*.h' -or -name '*.c' \) -exec nkf --overwrite -S -w80 "{}" \;
 
       - name: setup
         shell: bash

--- a/.github/workflows/build_as_cxx.yml
+++ b/.github/workflows/build_as_cxx.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'c2a_core_main.c'
       - 'c2a_core_main.h'
+      - 'common.cmake'
       - 'Applications/**'
       - 'CmdTlm/**'
       - 'Drivers/**'

--- a/Examples/minimum_user_for_s2e/CMakeLists.txt
+++ b/Examples/minimum_user_for_s2e/CMakeLists.txt
@@ -107,9 +107,3 @@ else()
 endif()
 
 include(${C2A_USER_DIR}/common.cmake)
-
-# Compile option
-if(NOT MSVC)
-  # disable warning to main()
-  target_compile_options(${PROJECT_NAME} PUBLIC "-Wno-main")
-endif()

--- a/Examples/minimum_user_for_s2e/src/src_user/c2a_main.c
+++ b/Examples/minimum_user_for_s2e/src/src_user/c2a_main.c
@@ -4,15 +4,16 @@
 #include <src_core/System/WatchdogTimer/watchdog_timer.h>
 #include "./Settings/sils_define.h"
 
-void main(void);
+int main(void);
 static void address_fixed_main_(void);
 static void C2A_init_(void);
 static void C2A_main_(void);
 static void timer_setting_(void);
 
-void main(void)
+int main(void)
 {
   address_fixed_main_();
+  return 0;
 }
 
 

--- a/common.cmake
+++ b/common.cmake
@@ -24,6 +24,7 @@ else()
 
   # warning
   target_compile_options(${PROJECT_NAME} PUBLIC "-Wpedantic")
+  target_compile_options(${PROJECT_NAME} PUBLIC "-Wno-comment")
   target_compile_options(${PROJECT_NAME} PUBLIC "-Wall")
   target_compile_options(${PROJECT_NAME} PUBLIC "-Wno-unknown-pragmas")
   if(ADD_WERROR_FLAGS)

--- a/common.cmake
+++ b/common.cmake
@@ -9,7 +9,11 @@ else()
     target_compile_options(${PROJECT_NAME} PUBLIC "-std=c90")
   else()
     set_target_properties(${PROJECT_NAME} PROPERTIES C_STANDARD 90) # C89
-    set_target_properties(${PROJECT_NAME} PROPERTIES C_EXTENSIONS FALSE) # no extensions(GNU)
+    # TODO: set always!
+    # GNU拡張を禁止すると1行コメントがエラーになる
+    if(NOT CMAKE_C_COMPILER_ID STREQUAL "GNU")
+      set_target_properties(${PROJECT_NAME} PROPERTIES C_EXTENSIONS FALSE) # no extensions(GNU)
+    endif()
   endif()
 endif()
 

--- a/common.cmake
+++ b/common.cmake
@@ -13,7 +13,9 @@ if(MSVC)
   target_compile_options(${PROJECT_NAME} PUBLIC "/TP") # Compile C codes as C++
 else()
   # SJIS
-  target_compile_options(${PROJECT_NAME} PUBLIC "-finput-charset=cp932")
+  if (NOT CMAKE_C_COMPILER_ID STREQUAL "Clang")
+    target_compile_options(${PROJECT_NAME} PUBLIC "-finput-charset=cp932")
+  endif()
 
   # 32bit
   target_compile_options(${PROJECT_NAME} PUBLIC "-m32")
@@ -21,7 +23,9 @@ else()
 
   # debug
   target_compile_options(${PROJECT_NAME} PUBLIC "-g")
-  target_compile_options(${PROJECT_NAME} PUBLIC "-rdynamic")
+  if (NOT CMAKE_C_COMPILER_ID STREQUAL "Clang")
+    target_compile_options(${PROJECT_NAME} PUBLIC "-rdynamic")
+  endif()
 
   # warning
   target_compile_options(${PROJECT_NAME} PUBLIC "-Wpedantic")

--- a/common.cmake
+++ b/common.cmake
@@ -23,6 +23,7 @@ else()
   target_compile_options(${PROJECT_NAME} PUBLIC "-rdynamic")
 
   # warning
+  target_compile_options(${PROJECT_NAME} PUBLIC "-Wpedantic")
   target_compile_options(${PROJECT_NAME} PUBLIC "-Wall")
   target_compile_options(${PROJECT_NAME} PUBLIC "-Wno-unknown-pragmas")
   if(ADD_WERROR_FLAGS)

--- a/common.cmake
+++ b/common.cmake
@@ -3,8 +3,14 @@ if(BUILD_C2A_AS_CXX)
   set_source_files_properties(${C2A_SRCS} PROPERTIES LANGUAGE CXX)  # C++
   set_target_properties(${PROJECT_NAME} PROPERTIES LANGUAGE CXX) # C++
 else()
-  set_target_properties(${PROJECT_NAME} PROPERTIES C_STANDARD 90) # C89
-  set_target_properties(${PROJECT_NAME} PROPERTIES C_EXTENSIONS FALSE) # no extensions(GNU)
+  if (CMAKE_C_COMPILER_ID STREQUAL "Clang")
+    # TODO: remove this!
+    # -Wno-commentが`std=c90`の後に来る必要があるのでC89のうちはこうするしかない
+    target_compile_options(${PROJECT_NAME} PUBLIC "-std=c90")
+  else()
+    set_target_properties(${PROJECT_NAME} PROPERTIES C_STANDARD 90) # C89
+    set_target_properties(${PROJECT_NAME} PROPERTIES C_EXTENSIONS FALSE) # no extensions(GNU)
+  endif()
 endif()
 
 # Build option
@@ -29,8 +35,11 @@ else()
 
   # warning
   target_compile_options(${PROJECT_NAME} PUBLIC "-Wpedantic")
-  target_compile_options(${PROJECT_NAME} PUBLIC "-Wno-comment")
   target_compile_options(${PROJECT_NAME} PUBLIC "-Wall")
+  if (CMAKE_C_COMPILER_ID STREQUAL "Clang")
+    # gccの-Wcommentは2重コメントにしか影響しない
+    target_compile_options(${PROJECT_NAME} PUBLIC "-Wno-comment")
+  endif()
   target_compile_options(${PROJECT_NAME} PUBLIC "-Wno-unknown-pragmas")
   if(ADD_WERROR_FLAGS)
     target_compile_options(${PROJECT_NAME} PUBLIC "-Werror")

--- a/common.cmake
+++ b/common.cmake
@@ -4,6 +4,7 @@ if(BUILD_C2A_AS_CXX)
   set_target_properties(${PROJECT_NAME} PROPERTIES LANGUAGE CXX) # C++
 else()
   set_target_properties(${PROJECT_NAME} PROPERTIES C_STANDARD 90) # C89
+  set_target_properties(${PROJECT_NAME} PROPERTIES C_EXTENSIONS FALSE) # no extensions(GNU)
 endif()
 
 # Build option


### PR DESCRIPTION
## 概要
`-Wpendatic`を付けないと真に規格に準拠したワーニングは出ないので，追加する

## Issue
- #94 

## 詳細
- 1行コメント(`// hoge~`)がC99だった(が，HEWは独自拡張でサポートされている)
  - clangでは`-Wno-comment`で↑のwarningを握り潰せる
  - gccではできない(`-Wcomment`は別の意味)ので，`gcc -Werror`ができない
  - `gcc -Werror`だけスキップして`-Werror`はclangでやる
- clangはShift JIS無理
  - clangでビルドする前にnkfでShift JIS->UTF-8
- C89に準拠させるのは別にやる

## 検証結果
CIが`-Werror`のやつは適切に落ちるようになり，それ以外は通ればよし
