### PR TITLE
C89のWallででるWarningをすべて消す

### DIFF
--- a/CmdTlm/telemetry_frame.c
+++ b/CmdTlm/telemetry_frame.c
@@ -148,7 +148,7 @@ CCP_EXEC_STS Cmd_TF_REGISTER_TLM(const CTCP* packet)
   endian_memcpy(&index, param, 1);
   endian_memcpy(&tlm_func, param + 1, 4);
 
-  if (index >= TF_MAX_TLMS)
+  if ((int)index >= TF_MAX_TLMS)
   {
     // 登録指定位置がテレメトリ数上限を超えている場合は異常判定
     return CCP_EXEC_ILLEGAL_PARAMETER;

--- a/Examples/minimum_user_for_s2e/src/src_user/Applications/UserDefined/debug_apps.c
+++ b/Examples/minimum_user_for_s2e/src/src_user/Applications/UserDefined/debug_apps.c
@@ -74,7 +74,7 @@ void APP_DBG_print_cmd_status_(void)
   Printf("CMD: GS %3d, RT %3d, Ack %3d, Code 0x%02x, Sts %3d\n",
          (PL_count_executed_nodes(&PH_gs_cmd_list) & 0xff),
          (PL_count_executed_nodes(&PH_rt_cmd_list) & 0xff),
-         gs_driver->info[GS_PORT_TYPE_NUM].cmd_ack, gs_command_dispatcher->prev.code, gs_command_dispatcher->prev.sts);
+         gs_driver->info[gs_driver->tlm_tx_port_type].cmd_ack, gs_command_dispatcher->prev.code, gs_command_dispatcher->prev.sts);
 }
 
 void APP_DBG_print_git_rev_(void)


### PR DESCRIPTION
## 概要
C89のWallででるWarningをすべて消す

## Issue
- https://github.com/ut-issl/c2a-core/issues/94

## 詳細
NA

## 検証結果
WerrorのCIが通るようになればOK

## 備考
- GSのバグも直しているので，このCoreをuser側で取り込む場合はそこも反映させること！