### PR TITLE
clang-tidyでreviewdogにビルドCIのerror,warningを出させる

### DIFF
--- a/.github/workflows/build_as_c89.yml
+++ b/.github/workflows/build_as_c89.yml
@@ -140,4 +140,13 @@ jobs:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cp ./Examples/minimum_user_for_s2e/build/clang_tidy.log .
-          reviewdog -efm="%f:%l:%c: %tarning: %m" -diff="git diff FETCH_HEAD" -reporter=github-pr-check -name 'clang-tidy' -level warning < clang_tidy.log
+          reviewdog \
+            -name 'clang-tidy' \
+            -level warning \
+            -filter-mode=nofilter \
+            -diff="git diff FETCH_HEAD" \
+            -reporter=github-pr-check \
+            -efm="%-Gclang-tidy%s" \
+            -efm="%W%f:%l:%c: warning: %m" \
+            -efm="%C%m" \
+            < clang_tidy.log

--- a/.github/workflows/build_as_c89.yml
+++ b/.github/workflows/build_as_c89.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: build
         id: build
-        continue-on-error: ${{ matrix.compiler == 'clang' && matrix.warning == 'Wextra' }}
+        continue-on-error: ${{ matrix.compiler == 'clang' }}
         working-directory: ./Examples/minimum_user_for_s2e/build
         run: cmake --build .
 
@@ -116,15 +116,15 @@ jobs:
 
 
       - name: install reviewdog
-        if: matrix.compiler == 'clang' && matrix.warning == 'Wextra'
+        if: matrix.compiler == 'clang'
         uses: reviewdog/action-setup@v1.0.3
 
       - name: install clang-tidy
-        if: matrix.compiler == 'clang' && matrix.warning == 'Wextra'
+        if: matrix.compiler == 'clang'
         run: sudo apt-get install -y clang-tidy-11
 
       - name: clang-tidy
-        if: matrix.compiler == 'clang' && matrix.warning == 'Wextra'
+        if: matrix.compiler == 'clang'
         working-directory: ./Examples/minimum_user_for_s2e/build
         run: |
           run-clang-tidy-11 \
@@ -133,18 +133,18 @@ jobs:
             > clang_tidy.log
 
       - name: clang-tidy result
-        if: matrix.compiler == 'clang' && matrix.warning == 'Wextra'
+        if: matrix.compiler == 'clang'
         working-directory: ./Examples/minimum_user_for_s2e/build
         run: cat clang_tidy.log
 
       - name: reviewdog clang-tidy (github-pr-review)
-        if: matrix.compiler == 'clang' && matrix.warning == 'Wextra'
+        if: matrix.compiler == 'clang' && matrix.warning == 'Werror'
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cp ./Examples/minimum_user_for_s2e/build/clang_tidy.log .
           reviewdog \
-            -name 'clang-tidy' \
+            -name 'clang-tidy(Werror)' \
             -level warning \
             -fail-on-error=true \
             -filter-mode=added \
@@ -164,7 +164,7 @@ jobs:
         run: |
           cp ./Examples/minimum_user_for_s2e/build/clang_tidy.log .
           reviewdog \
-            -name 'clang-tidy' \
+            -name 'clang-tidy(Wextra)' \
             -level warning \
             -fail-on-error=true \
             -filter-mode=nofilter \

--- a/.github/workflows/build_as_c89.yml
+++ b/.github/workflows/build_as_c89.yml
@@ -147,6 +147,8 @@ jobs:
             -diff="git diff FETCH_HEAD" \
             -reporter=github-pr-check \
             -efm="%-Gclang-tidy%s" \
+            -efm="%-GError while processing%s" \
             -efm="%W%f:%l:%c: warning: %m" \
+            -efm="%E%f:%l:%c: error: %m" \
             -efm="%C%m" \
             < clang_tidy.log

--- a/.github/workflows/build_as_c89.yml
+++ b/.github/workflows/build_as_c89.yml
@@ -124,7 +124,10 @@ jobs:
         if: matrix.compiler == 'clang' && matrix.warning == 'Wextra'
         working-directory: ./Examples/minimum_user_for_s2e/build
         run: |
-          run-clang-tidy-11 > clang_tidy.log
+          run-clang-tidy-11 \
+            | sed 's/\/home\/runner\/work\/c2a-core\/c2a-core\///g' \
+            | sed 's/Examples\/minimum_user_for_s2e\/src\/src_core\///g' \
+            > clang_tidy.log
 
       - name: clang-tidy result
         if: matrix.compiler == 'clang' && matrix.warning == 'Wextra'
@@ -135,6 +138,6 @@ jobs:
         if: matrix.compiler == 'clang' && matrix.warning == 'Wextra'
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        working-directory: ./Examples/minimum_user_for_s2e/build
         run: |
+          cp ./Examples/minimum_user_for_s2e/build/clang_tidy.log .
           reviewdog -efm="%f:%l:%c: %tarning: %m" -diff="git diff FETCH_HEAD" -reporter=github-pr-check -name 'clang-tidy' -level warning < clang_tidy.log

--- a/.github/workflows/build_as_c89.yml
+++ b/.github/workflows/build_as_c89.yml
@@ -100,7 +100,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -DUSE_SILS_MOCKUP=ON -DADD_WERROR_FLAGS=${{ steps.compile_flags.outputs.WERROR }} -DADD_WEXTRA_FLAGS=${{ steps.compile_flags.outputs.WEXTRA }}
+          cmake .. -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DUSE_SILS_MOCKUP=ON -DADD_WERROR_FLAGS=${{ steps.compile_flags.outputs.WERROR }} -DADD_WEXTRA_FLAGS=${{ steps.compile_flags.outputs.WEXTRA }}
 
       - name: build
         working-directory: ./Examples/minimum_user_for_s2e/build
@@ -110,3 +110,25 @@ jobs:
         working-directory: ./Examples/minimum_user_for_s2e/build
         shell: bash
         run: timeout 3 ./C2A || exit 0
+
+
+      - name: install reviewdog
+        if: matrix.compiler == 'clang' && matrix.warning == 'Wextra'
+        uses: reviewdog/action-setup@v1.0.3
+
+      - name: clang-tidy
+        if: matrix.compiler == 'clang' && matrix.warning == 'Wextra'
+        working-directory: ./Examples/minimum_user_for_s2e/build
+        run: |
+          run-clang-tidy > clang_tidy.log
+
+      - name: clang-tidy result
+        if: matrix.compiler == 'clang' && matrix.warning == 'Wextra'
+        working-directory: ./Examples/minimum_user_for_s2e/build
+        run: cat clang_tidy.log
+
+      - name: reviewdog clang-tidy
+        if: matrix.compiler == 'clang' && matrix.warning == 'Wextra'
+        working-directory: ./Examples/minimum_user_for_s2e/build
+        run: |
+          cat clang_tidy.log | reviewdog -efm="%f:%l:%c: %tarning: %m" -diff="git diff FETCH_HEAD" -reporter=github-pr-check -name 'clang-tidy' -level warning

--- a/.github/workflows/build_as_c89.yml
+++ b/.github/workflows/build_as_c89.yml
@@ -133,6 +133,8 @@ jobs:
 
       - name: reviewdog clang-tidy
         if: matrix.compiler == 'clang' && matrix.warning == 'Wextra'
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         working-directory: ./Examples/minimum_user_for_s2e/build
         run: |
           reviewdog -efm="%f:%l:%c: %tarning: %m" -diff="git diff FETCH_HEAD" -reporter=github-pr-check -name 'clang-tidy' -level warning < clang_tidy.log

--- a/.github/workflows/build_as_c89.yml
+++ b/.github/workflows/build_as_c89.yml
@@ -137,7 +137,7 @@ jobs:
         working-directory: ./Examples/minimum_user_for_s2e/build
         run: cat clang_tidy.log
 
-      - name: reviewdog clang-tidy
+      - name: reviewdog clang-tidy (github-pr-review)
         if: matrix.compiler == 'clang' && matrix.warning == 'Wextra'
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -150,6 +150,26 @@ jobs:
             -filter-mode=added \
             -diff="git diff FETCH_HEAD" \
             -reporter=github-pr-review \
+            -efm="%-Gclang-tidy%s" \
+            -efm="%-GError while processing%s" \
+            -efm="%W%f:%l:%c: warning: %m" \
+            -efm="%E%f:%l:%c: error: %m" \
+            -efm="%C%m" \
+            < clang_tidy.log
+
+      - name: reviewdog clang-tidy (github-check)
+        if: matrix.compiler == 'clang' && matrix.warning == 'Wextra'
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cp ./Examples/minimum_user_for_s2e/build/clang_tidy.log .
+          reviewdog \
+            -name 'clang-tidy' \
+            -level warning \
+            -fail-on-error=true \
+            -filter-mode=nofilter \
+            -diff="git diff FETCH_HEAD" \
+            -reporter=github-check \
             -efm="%-Gclang-tidy%s" \
             -efm="%-GError while processing%s" \
             -efm="%W%f:%l:%c: warning: %m" \

--- a/.github/workflows/build_as_c89.yml
+++ b/.github/workflows/build_as_c89.yml
@@ -116,11 +116,15 @@ jobs:
         if: matrix.compiler == 'clang' && matrix.warning == 'Wextra'
         uses: reviewdog/action-setup@v1.0.3
 
+      - name: install clang-tidy
+        if: matrix.compiler == 'clang' && matrix.warning == 'Wextra'
+        run: sudo apt-get install -y clang-tidy-11
+
       - name: clang-tidy
         if: matrix.compiler == 'clang' && matrix.warning == 'Wextra'
         working-directory: ./Examples/minimum_user_for_s2e/build
         run: |
-          run-clang-tidy > clang_tidy.log
+          run-clang-tidy-11 > clang_tidy.log
 
       - name: clang-tidy result
         if: matrix.compiler == 'clang' && matrix.warning == 'Wextra'
@@ -131,4 +135,4 @@ jobs:
         if: matrix.compiler == 'clang' && matrix.warning == 'Wextra'
         working-directory: ./Examples/minimum_user_for_s2e/build
         run: |
-          cat clang_tidy.log | reviewdog -efm="%f:%l:%c: %tarning: %m" -diff="git diff FETCH_HEAD" -reporter=github-pr-check -name 'clang-tidy' -level warning
+          reviewdog -efm="%f:%l:%c: %tarning: %m" -diff="git diff FETCH_HEAD" -reporter=github-pr-check -name 'clang-tidy' -level warning < clang_tidy.log

--- a/.github/workflows/build_as_c89.yml
+++ b/.github/workflows/build_as_c89.yml
@@ -103,10 +103,13 @@ jobs:
           cmake .. -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DUSE_SILS_MOCKUP=ON -DADD_WERROR_FLAGS=${{ steps.compile_flags.outputs.WERROR }} -DADD_WEXTRA_FLAGS=${{ steps.compile_flags.outputs.WEXTRA }}
 
       - name: build
+        id: build
+        continue-on-error: ${{ matrix.compiler == 'clang' && matrix.warning == 'Wextra' }}
         working-directory: ./Examples/minimum_user_for_s2e/build
         run: cmake --build .
 
       - name: run
+        if: steps.build.outcome == 'success'
         working-directory: ./Examples/minimum_user_for_s2e/build
         shell: bash
         run: timeout 3 ./C2A || exit 0
@@ -143,6 +146,7 @@ jobs:
           reviewdog \
             -name 'clang-tidy' \
             -level warning \
+            -fail-on-error=true \
             -filter-mode=added \
             -diff="git diff FETCH_HEAD" \
             -reporter=github-pr-review \

--- a/.github/workflows/build_as_c89.yml
+++ b/.github/workflows/build_as_c89.yml
@@ -143,9 +143,9 @@ jobs:
           reviewdog \
             -name 'clang-tidy' \
             -level warning \
-            -filter-mode=nofilter \
+            -filter-mode=added \
             -diff="git diff FETCH_HEAD" \
-            -reporter=github-pr-check \
+            -reporter=github-pr-review \
             -efm="%-Gclang-tidy%s" \
             -efm="%-GError while processing%s" \
             -efm="%W%f:%l:%c: warning: %m" \


### PR DESCRIPTION
## 概要
`clang -Wextra`の設定でclang-tidyにワーニングを出させ，それをreviewdogで表示する

## Issue
- #45 

## 詳細
詳しく

## 検証結果
test へのリンクや，検証結果へのリンク

## 影響範囲
XX系の動作がガラッと変わる，とか．

## 補足
何かあれば

## 注意
- 関連する Projects が存在する場合，それの紐付けを行うこと
- Assignees を設定すること
- 可能ならば Reviewers を設定すること
- 可能ならば `priority` ラベルを付けること
