### PR TITLE
Warning 消し

### DIFF
--- a/CmdTlm/command_analyze.c
+++ b/CmdTlm/command_analyze.c
@@ -139,7 +139,7 @@ int CA_has_raw_param(CMD_CODE cmd_code)
   uint8_t param_num = CA_get_cmd_param_num(cmd_code);
   if (param_num == 0) return 0;
 
-  return (CA_get_param_size_type_(cmd_code, param_num - 1) == CA_PARAM_SIZE_TYPE_RAW) ? 1 : 0;
+  return (CA_get_param_size_type_(cmd_code, (uint8_t)(param_num - 1)) == CA_PARAM_SIZE_TYPE_RAW) ? 1 : 0;
 }
 
 static CA_PARAM_SIZE_TYPE CA_get_param_size_type_(CMD_CODE cmd_code, uint8_t n)
@@ -161,7 +161,7 @@ CCP_EXEC_STS Cmd_CA_REGISTER_CMD(const CTCP* packet)
   uint8_t param_size_infos[(CA_MAX_CMD_PARAM_NUM + 1) / 2];
   CMD_CODE cmd_code = (CMD_CODE)CCP_get_param_from_packet(packet, 0, uint16_t);
   uint32_t cmd_func = CCP_get_param_from_packet(packet, 1, uint32_t);
-  uint8_t ret;
+  uint16_t ret;
   uint8_t i;
 
   // raw パラメタなので，引数長チェック

--- a/CmdTlm/common_tlm_cmd_packet_util.c
+++ b/CmdTlm/common_tlm_cmd_packet_util.c
@@ -114,7 +114,7 @@ uint8_t* CCP_get_1byte_param_from_packet(const CTCP* packet, uint8_t n)
 
   if (CA_get_cmd_param_size(cmd_id, n) != param_size) return &ret;
 
-  endian_memcpy(&ret, CCP_get_param_head(packet) + offset, param_size);
+  endian_memcpy(&ret, CCP_get_param_head(packet) + offset, (size_t)param_size);
   return &ret;
 }
 
@@ -133,7 +133,7 @@ uint16_t* CCP_get_2byte_param_from_packet(const CTCP* packet, uint8_t n)
 
   if (CA_get_cmd_param_size(cmd_id, n) != param_size) return &ret;
 
-  endian_memcpy(&ret, CCP_get_param_head(packet) + offset, param_size);
+  endian_memcpy(&ret, CCP_get_param_head(packet) + offset, (size_t)param_size);
   return &ret;
 }
 
@@ -152,7 +152,7 @@ uint32_t* CCP_get_4byte_param_from_packet(const CTCP* packet, uint8_t n)
 
   if (CA_get_cmd_param_size(cmd_id, n) != param_size) return &ret;
 
-  endian_memcpy(&ret, CCP_get_param_head(packet) + offset, param_size);
+  endian_memcpy(&ret, CCP_get_param_head(packet) + offset, (size_t)param_size);
   return &ret;
 }
 
@@ -171,7 +171,7 @@ uint64_t* CCP_get_8byte_param_from_packet(const CTCP* packet, uint8_t n)
 
   if (CA_get_cmd_param_size(cmd_id, n) != param_size) return &ret;
 
-  endian_memcpy(&ret, CCP_get_param_head(packet) + offset, param_size);
+  endian_memcpy(&ret, CCP_get_param_head(packet) + offset, (size_t)param_size);
   return &ret;
 }
 
@@ -184,7 +184,7 @@ uint16_t CCP_get_raw_param_from_packet(const CTCP* packet, void* dest, uint16_t 
 
   if (!CA_has_raw_param(cmd_id)) return 0;
 
-  ack = CCP_calc_param_offset_(cmd_id, CA_get_cmd_param_num(cmd_id) - 1, &offset);
+  ack = CCP_calc_param_offset_(cmd_id, (uint8_t)(CA_get_cmd_param_num(cmd_id) - 1), &offset);
   if (ack != CTCP_UTIL_ACK_OK) return 0;
 
   copy_len = CCP_get_param_len(packet) - offset;
@@ -194,7 +194,7 @@ uint16_t CCP_get_raw_param_from_packet(const CTCP* packet, void* dest, uint16_t 
     copy_len = max_copy_len;
   }
 
-  memcpy(dest,  CCP_get_param_head(packet) + offset, copy_len);
+  memcpy(dest,  CCP_get_param_head(packet) + offset, (size_t)copy_len);
   return (uint16_t)copy_len;
 }
 


### PR DESCRIPTION
## 概要
某IDE で出ていたWarning を削除する

## Issue
- https://github.com/ut-issl/c2a-core/issues/97
- https://github.com/ut-issl/c2a-core/issues/80

## 詳細
`CmdTlm/common_tlm_cmd_packet_util.c` と `CmdTlm/command_analyze.c` で出ていた Warning を削除した

## 検証結果
build出来ることを確認した

## 影響範囲
小

