### PR TITLE
ObcTimeとTMGRで関数の順番を変更

### DIFF
--- a/System/TimeManager/obc_time.c
+++ b/System/TimeManager/obc_time.c
@@ -16,16 +16,6 @@ ObcTime OBCT_create(cycle_t total_cycle,
   return time;
 }
 
-ObcTime OBCT_get_max(void)
-{
-  ObcTime max = {
-    OBCT_MAX_CYCLE - 1,
-    OBCT_MAX_CYCLE - 1,
-    OBCT_STEPS_PER_CYCLE - 1
-  };
-  return max;
-}
-
 void OBCT_clear(ObcTime* time)
 {
   time->total_cycle = 0;
@@ -55,6 +45,16 @@ void OBCT_count_up(ObcTime* time)
 
     time->step = 0;
   }
+}
+
+ObcTime OBCT_get_max(void)
+{
+  ObcTime max = {
+    OBCT_MAX_CYCLE - 1,
+    OBCT_MAX_CYCLE - 1,
+    OBCT_STEPS_PER_CYCLE - 1
+  };
+  return max;
 }
 
 cycle_t OBCT_get_total_cycle(const ObcTime* time)

--- a/System/TimeManager/obc_time.c
+++ b/System/TimeManager/obc_time.c
@@ -147,7 +147,7 @@ step_t OBCT_diff_in_step(const ObcTime* before,
 }
 
 uint32_t OBCT_diff_in_msec(const ObcTime* before,
-                               const ObcTime* after)
+                           const ObcTime* after)
 {
   return OBCT_STEP_IN_MSEC * OBCT_diff_in_step(before, after);
 }

--- a/System/TimeManager/obc_time.c
+++ b/System/TimeManager/obc_time.c
@@ -96,15 +96,6 @@ float OBCT_get_mode_cycle_in_sec(const ObcTime* time)
   return cycle_in_sec + step_in_sec;
 }
 
-cycle_t OBCT_sec2cycle(uint32_t sec)
-{
-  return (1000 * sec) / (OBCT_STEP_IN_MSEC * OBCT_STEPS_PER_CYCLE);
-}
-
-uint32_t OBCT_cycle2sec(cycle_t cycle) {
-  return (OBCT_STEP_IN_MSEC * OBCT_STEPS_PER_CYCLE * cycle) / 1000;
-}
-
 cycle_t OBCT_msec2cycle(uint32_t msec)
 {
   return (msec) / (OBCT_STEP_IN_MSEC * OBCT_STEPS_PER_CYCLE);
@@ -112,6 +103,15 @@ cycle_t OBCT_msec2cycle(uint32_t msec)
 
 uint32_t OBCT_cycle2msec(cycle_t cycle) {
   return (OBCT_STEP_IN_MSEC * OBCT_STEPS_PER_CYCLE * cycle);
+}
+
+cycle_t OBCT_sec2cycle(uint32_t sec)
+{
+  return (1000 * sec) / (OBCT_STEP_IN_MSEC * OBCT_STEPS_PER_CYCLE);
+}
+
+uint32_t OBCT_cycle2sec(cycle_t cycle) {
+  return (OBCT_STEP_IN_MSEC * OBCT_STEPS_PER_CYCLE * cycle) / 1000;
 }
 
 ObcTime OBCT_diff(const ObcTime* before,
@@ -139,21 +139,6 @@ ObcTime OBCT_diff(const ObcTime* before,
   return diff;
 }
 
-ObcTime OBCT_add(const ObcTime* left, const ObcTime* right)
-{
-  ObcTime ret;
-
-  ret.total_cycle = left->total_cycle + right->total_cycle;
-  ret.mode_cycle = left->mode_cycle + right->mode_cycle;
-  ret.step = left->step + right->step;
-
-  ret.total_cycle += ret.step / OBCT_STEPS_PER_CYCLE;
-  ret.mode_cycle += ret.step / OBCT_STEPS_PER_CYCLE;
-  ret.step %= OBCT_STEPS_PER_CYCLE;
-
-  return ret;
-}
-
 step_t OBCT_diff_in_step(const ObcTime* before,
                          const ObcTime* after)
 {
@@ -171,6 +156,21 @@ float OBCT_diff_in_sec(const ObcTime* before,
                        const ObcTime* after)
 {
   return 0.001f * OBCT_diff_in_msec(before, after);
+}
+
+ObcTime OBCT_add(const ObcTime* left, const ObcTime* right)
+{
+  ObcTime ret;
+
+  ret.total_cycle = left->total_cycle + right->total_cycle;
+  ret.mode_cycle = left->mode_cycle + right->mode_cycle;
+  ret.step = left->step + right->step;
+
+  ret.total_cycle += ret.step / OBCT_STEPS_PER_CYCLE;
+  ret.mode_cycle += ret.step / OBCT_STEPS_PER_CYCLE;
+  ret.step %= OBCT_STEPS_PER_CYCLE;
+
+  return ret;
 }
 
 int OBCT_compare(const ObcTime* t1, const ObcTime* t2)

--- a/System/TimeManager/obc_time.h
+++ b/System/TimeManager/obc_time.h
@@ -33,9 +33,9 @@ typedef struct
 ObcTime OBCT_create(cycle_t total_cycle,
                     cycle_t mode_cycle,
                     step_t step);
-ObcTime OBCT_get_max(void);
 void OBCT_clear(ObcTime* time);
 void OBCT_count_up(ObcTime* time);
+ObcTime OBCT_get_max(void);
 cycle_t OBCT_get_total_cycle(const ObcTime* time);
 cycle_t OBCT_get_mode_cycle(const ObcTime* time);
 step_t  OBCT_get_step(const ObcTime* time);
@@ -52,7 +52,7 @@ ObcTime OBCT_diff(const ObcTime* before,
 step_t OBCT_diff_in_step(const ObcTime* before,
                          const ObcTime* after);
 uint32_t OBCT_diff_in_msec(const ObcTime* before,
-                               const ObcTime* after);
+                           const ObcTime* after);
 float OBCT_diff_in_sec(const ObcTime* before,
                        const ObcTime* after);
 ObcTime OBCT_add(const ObcTime* left, const ObcTime* right);

--- a/System/TimeManager/obc_time.h
+++ b/System/TimeManager/obc_time.h
@@ -43,19 +43,19 @@ uint32_t OBCT_get_total_cycle_in_msec(const ObcTime* time);  // 計算上はstepも考
 uint32_t OBCT_get_mode_cycle_in_msec(const ObcTime* time);   // 計算上はstepも考慮
 float    OBCT_get_total_cycle_in_sec(const ObcTime* time);   // 計算上はstepも考慮（オーバーフローに注意）
 float    OBCT_get_mode_cycle_in_sec(const ObcTime* time);    // 計算上はstepも考慮（オーバーフローに注意）
-cycle_t  OBCT_sec2cycle(uint32_t sec);        // 適当に丸められることに注意
-uint32_t OBCT_cycle2sec(cycle_t cycle);       // 適当に丸められることに注意
 cycle_t  OBCT_msec2cycle(uint32_t msec);      // 適当に丸められることに注意
 uint32_t OBCT_cycle2msec(cycle_t cycle);      // 適当に丸められることに注意
+cycle_t  OBCT_sec2cycle(uint32_t sec);        // 適当に丸められることに注意
+uint32_t OBCT_cycle2sec(cycle_t cycle);       // 適当に丸められることに注意
 ObcTime OBCT_diff(const ObcTime* before,
                   const ObcTime* after);
-ObcTime OBCT_add(const ObcTime* left, const ObcTime* right);
 step_t OBCT_diff_in_step(const ObcTime* before,
                          const ObcTime* after);
 uint32_t OBCT_diff_in_msec(const ObcTime* before,
                                const ObcTime* after);
 float OBCT_diff_in_sec(const ObcTime* before,
                        const ObcTime* after);
+ObcTime OBCT_add(const ObcTime* left, const ObcTime* right);
 
 /**
  * @brief ObcTime の比較

--- a/System/TimeManager/time_manager.c
+++ b/System/TimeManager/time_manager.c
@@ -99,13 +99,13 @@ OBCT_UnixtimeInfo TMGR_get_obct_unixtime_info(void)
   return OBCT_unixtime_info_;
 }
 
-double TMGR_get_unixtime_from_obc_Time(const ObcTime* time)
+double TMGR_get_unixtime_from_obc_time(const ObcTime* time)
 {
   ObcTime ti0 = OBCT_create(0, 0, 0);
   return OBCT_unixtime_info_.unixtime_at_ti0 + OBCT_diff_in_sec(&ti0, time);
 }
 
-ObcTime TMGR_get_obc_Time_from_unixtime(const double unixtime)
+ObcTime TMGR_get_obc_time_from_unixtime(const double unixtime)
 {
   double diff_double = unixtime - OBCT_unixtime_info_.unixtime_at_ti0;
   ObcTime res;

--- a/System/TimeManager/time_manager.c
+++ b/System/TimeManager/time_manager.c
@@ -27,14 +27,6 @@ void TMGR_clear(void)
   OBCT_clear_unixtime_info(&OBCT_unixtime_info_);
 }
 
-void TMGR_down_initializing_flag(void)
-{
-  memcpy(&time_manager_.initializing_time, &master_clock_, sizeof(ObcTime));
-  time_manager_.initializing_flag = 0;
-
-  TMGR_clear();
-}
-
 void TMGR_clear_master_mode_cycle(void)
 {
   master_clock_.mode_cycle = 0;
@@ -49,6 +41,14 @@ void TMGR_count_up_master_clock(void)
 }
 #pragma section
 #pragma section REPRO
+
+void TMGR_down_initializing_flag(void)
+{
+  memcpy(&time_manager_.initializing_time, &master_clock_, sizeof(ObcTime));
+  time_manager_.initializing_flag = 0;
+
+  TMGR_clear();
+}
 
 ObcTime TMGR_get_master_clock(void)
 {
@@ -99,13 +99,13 @@ OBCT_UnixtimeInfo TMGR_get_obct_unixtime_info(void)
   return OBCT_unixtime_info_;
 }
 
-double TMGR_get_unixtime_from_ObcTime(const ObcTime* time)
+double TMGR_get_unixtime_from_obc_Time(const ObcTime* time)
 {
   ObcTime ti0 = OBCT_create(0, 0, 0);
   return OBCT_unixtime_info_.unixtime_at_ti0 + OBCT_diff_in_sec(&ti0, time);
 }
 
-ObcTime TMGR_get_ObcTime_from_unixtime(const double unixtime)
+ObcTime TMGR_get_obc_Time_from_unixtime(const double unixtime)
 {
   double diff_double = unixtime - OBCT_unixtime_info_.unixtime_at_ti0;
   ObcTime res;

--- a/System/TimeManager/time_manager.h
+++ b/System/TimeManager/time_manager.h
@@ -14,9 +14,9 @@ extern const TimeManager* const time_manager;
 
 void TMGR_init(void);
 void TMGR_clear(void);
-void TMGR_down_initializing_flag(void);
 void TMGR_clear_master_mode_cycle(void);
 void TMGR_count_up_master_clock(void);
+void TMGR_down_initializing_flag(void);
 
 ObcTime TMGR_get_master_clock(void);
 ObcTime TMGR_get_master_clock_from_boot(void);
@@ -27,8 +27,8 @@ uint32_t TMGR_get_master_total_cycle_in_msec(void);  // 計算上はstepも考慮（オー
 uint32_t TMGR_get_master_mode_cycle_in_msec(void);   // 計算上はstepも考慮（オーバーフローに注意）
 
 OBCT_UnixtimeInfo TMGR_get_obct_unixtime_info(void);
-double TMGR_get_unixtime_from_ObcTime(const ObcTime* time);
-ObcTime TMGR_get_ObcTime_from_unixtime(const double unixtime);
+double TMGR_get_unixtime_from_obc_Time(const ObcTime* time);
+ObcTime TMGR_get_obc_Time_from_unixtime(const double unixtime);
 void TMGR_modify_unixtime_criteria(const double unixtime, const ObcTime time);
 
 CCP_EXEC_STS Cmd_TMGR_SET_TIME(const CTCP* packet);

--- a/System/TimeManager/time_manager.h
+++ b/System/TimeManager/time_manager.h
@@ -17,17 +17,19 @@ void TMGR_clear(void);
 void TMGR_down_initializing_flag(void);
 void TMGR_clear_master_mode_cycle(void);
 void TMGR_count_up_master_clock(void);
-uint32_t TMGR_get_master_total_cycle_in_msec(void);  // 計算上はstepも考慮（オーバーフローに注意）
-uint32_t TMGR_get_master_mode_cycle_in_msec(void);   // 計算上はstepも考慮（オーバーフローに注意）
+
 ObcTime TMGR_get_master_clock(void);
+ObcTime TMGR_get_master_clock_from_boot(void);
 cycle_t TMGR_get_master_total_cycle(void);
 cycle_t TMGR_get_master_mode_cycle(void);
 step_t  TMGR_get_master_step(void);
+uint32_t TMGR_get_master_total_cycle_in_msec(void);  // 計算上はstepも考慮（オーバーフローに注意）
+uint32_t TMGR_get_master_mode_cycle_in_msec(void);   // 計算上はstepも考慮（オーバーフローに注意）
+
+OBCT_UnixtimeInfo TMGR_get_obct_unixtime_info(void);
 double TMGR_get_unixtime_from_ObcTime(const ObcTime* time);
 ObcTime TMGR_get_ObcTime_from_unixtime(const double unixtime);
 void TMGR_modify_unixtime_criteria(const double unixtime, const ObcTime time);
-OBCT_UnixtimeInfo TMGR_get_obct_unixtime_info(void);
-ObcTime TMGR_get_master_clock_from_boot(void);
 
 CCP_EXEC_STS Cmd_TMGR_SET_TIME(const CTCP* packet);
 CCP_EXEC_STS Cmd_TMGR_SET_UNIXTIME(const CTCP* packet);

--- a/System/TimeManager/time_manager.h
+++ b/System/TimeManager/time_manager.h
@@ -27,8 +27,8 @@ uint32_t TMGR_get_master_total_cycle_in_msec(void);  // 計算上はstepも考慮（オー
 uint32_t TMGR_get_master_mode_cycle_in_msec(void);   // 計算上はstepも考慮（オーバーフローに注意）
 
 OBCT_UnixtimeInfo TMGR_get_obct_unixtime_info(void);
-double TMGR_get_unixtime_from_obc_Time(const ObcTime* time);
-ObcTime TMGR_get_obc_Time_from_unixtime(const double unixtime);
+double TMGR_get_unixtime_from_obc_time(const ObcTime* time);
+ObcTime TMGR_get_obc_time_from_unixtime(const double unixtime);
 void TMGR_modify_unixtime_criteria(const double unixtime, const ObcTime time);
 
 CCP_EXEC_STS Cmd_TMGR_SET_TIME(const CTCP* packet);


### PR DESCRIPTION
## 概要
ObcTimeとTMGRで関数の順番を変更した。

## Issue
- https://github.com/ut-issl/c2a-core/issues/124

## 詳細
- ObcTime関連の関数→unixtime関連の関数→コマンド関数の順に並び替えた
- getter→変換系の関数→演算系の関数 の順にした
- 変換系の関数は msec→sec の順に統一した

diffが見にくくなりそうなので、関数の順番を整理するPRを分けて先にマージしたい。

## 検証結果
以下が通った。
https://github.com/ut-issl/c2a-core/blob/5a796cada870a51762555e5edb701a6dcdb1b9e8/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/TimeManager/test_time_manager.py
