### PR TITLE
EHでの二分探索をbsearchで書き直した

### DIFF
--- a/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/EventManager/test_event_handler.py
+++ b/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/EventManager/test_event_handler.py
@@ -70,6 +70,8 @@ conv_to_match_flag = {0: "NO", 1: "YES"}
 conv_to_active = {0: "INACTIVE", 1: "ACTIVE"}
 conv_to_condition_type = {0: "SINGLE", 1: "CONTINUOUS", 2:"CUMULATIVE"}
 
+# TODO: カウンタのクリアを入れたら足す
+# TODO: EH対応EL発行を入れたら，色々変えないとダメ
 
 # 各種設定の確認など
 @pytest.mark.real
@@ -581,6 +583,9 @@ def test_event_handler_respond_single():
     )
     exec_eh()
     assert check_respend_eh() == "not_responded"
+
+
+# TODO: 複数同時発火のテストを入れる
 
 
 @pytest.mark.real

--- a/System/EventManager/event_handler.c
+++ b/System/EventManager/event_handler.c
@@ -617,7 +617,8 @@ static EH_RULE_SORTED_INDEX_ACK EH_search_rule_table_index_(EL_GROUP group,
   uint16_t found_idx = EH_RULE_MAX;
   EH_RuleSortedIndex* p_searched_sorted_idx = NULL;
   EH_RuleSortedIndex target_sorted_idx = { group, local, 0, (EH_RULE_ID)0 };
-  int i = 0;
+  uint16_t i;
+  uint16_t possible_num_of_id_duplicates;
 
   if (event_handler_.rule_table.registered_rule_num == 0)
   {
@@ -634,7 +635,12 @@ static EH_RULE_SORTED_INDEX_ACK EH_search_rule_table_index_(EL_GROUP group,
 
   // å©Ç¬Ç©Ç¡ÇΩÅDå„ÇÕÅCÇ¢Ç≠Ç¬Ç†ÇÈÇ©ÅH
   *found_id_num = 0;
-  for (i = 0; i < EH_MAX_RULE_NUM_OF_EL_ID_DUPLICATES; ++i)
+  possible_num_of_id_duplicates = EH_MAX_RULE_NUM_OF_EL_ID_DUPLICATES;
+  if (possible_num_of_id_duplicates > EH_MAX_RULE_NUM_OF_EL_ID_DUPLICATES - found_idx)
+  {
+    possible_num_of_id_duplicates = EH_MAX_RULE_NUM_OF_EL_ID_DUPLICATES - found_idx;
+  }
+  for (i = 0; i < possible_num_of_id_duplicates; ++i)
   {
     EH_RuleSortedIndex* p_idx = &event_handler_.sorted_idxes[found_idx + i];
     if ( !(p_idx->group == group && p_idx->local == local) )

--- a/System/EventManager/event_handler.c
+++ b/System/EventManager/event_handler.c
@@ -179,6 +179,7 @@ static EH_RULE_SORTED_INDEX_ACK EH_search_rule_table_index_(EL_GROUP group,
 
 /**
  * @brief  bsearch —p‚Ì EH_RuleSortedIndex ”äŠrŠÖ”
+ * @note   duplicate_id ‚ª 0 ‚Å‚ ‚é‚à‚Ì‚ðŒ©‚Â‚¯‚é‘z’è
  * @param[in]  key:  bsearch ‚ÅŒŸõ‚·‚é EH_RuleSortedIndex
  * @param[in]  elem: bsearch ŒŸõ‘ÎÛ‚Ì EH_RuleSortedIndex ”z—ñ—v‘f
  * @retval 1:  key > elem
@@ -615,7 +616,7 @@ static EH_RULE_SORTED_INDEX_ACK EH_search_rule_table_index_(EL_GROUP group,
 
   uint16_t found_idx = EH_RULE_MAX;
   EH_RuleSortedIndex* p_searched_sorted_idx = NULL;
-  const EH_RuleSortedIndex target_sorted_idx = { group, local, 0, (EH_RULE_ID)0 };
+  EH_RuleSortedIndex target_sorted_idx = { group, local, 0, (EH_RULE_ID)0 };
   int i = 0;
 
   if (event_handler_.rule_table.registered_rule_num == 0)
@@ -625,7 +626,7 @@ static EH_RULE_SORTED_INDEX_ACK EH_search_rule_table_index_(EL_GROUP group,
 
   p_searched_sorted_idx = (EH_RuleSortedIndex*)bsearch(&target_sorted_idx,
                                                event_handler_.sorted_idxes,
-                                               EH_RULE_MAX,
+                                               event_handler_.rule_table.registered_rule_num,
                                                sizeof(EH_RuleSortedIndex),
                                                EH_compare_sorted_index_for_bsearch_);
   if (p_searched_sorted_idx == NULL) return EH_RULE_SORTED_INDEX_ACK_NOT_FOUND;

--- a/System/EventManager/event_handler.c
+++ b/System/EventManager/event_handler.c
@@ -639,9 +639,9 @@ static EH_RULE_SORTED_INDEX_ACK EH_search_rule_table_index_(EL_GROUP group,
   // Œ©‚Â‚©‚Á‚½DŒã‚ÍC‚¢‚­‚Â‚ ‚é‚©H
   *found_id_num = 0;
   possible_num_of_id_duplicates = EH_MAX_RULE_NUM_OF_EL_ID_DUPLICATES;
-  if (possible_num_of_id_duplicates > EH_MAX_RULE_NUM_OF_EL_ID_DUPLICATES - found_idx)
+  if (possible_num_of_id_duplicates > event_handler_.rule_table.registered_rule_num - found_idx)
   {
-    possible_num_of_id_duplicates = EH_MAX_RULE_NUM_OF_EL_ID_DUPLICATES - found_idx;
+    possible_num_of_id_duplicates = event_handler_.rule_table.registered_rule_num - found_idx;
   }
   for (i = 0; i < possible_num_of_id_duplicates; ++i)
   {

--- a/System/EventManager/event_handler.c
+++ b/System/EventManager/event_handler.c
@@ -616,7 +616,7 @@ static EH_RULE_SORTED_INDEX_ACK EH_search_rule_table_index_(EL_GROUP group,
 
   uint16_t found_idx = EH_RULE_MAX;
   EH_RuleSortedIndex* p_searched_sorted_idx = NULL;
-  EH_RuleSortedIndex target_sorted_idx = { group, local, 0, (EH_RULE_ID)0 };
+  EH_RuleSortedIndex target_sorted_idx;
   uint16_t i;
   uint16_t possible_num_of_id_duplicates;
 
@@ -625,6 +625,9 @@ static EH_RULE_SORTED_INDEX_ACK EH_search_rule_table_index_(EL_GROUP group,
     return EH_RULE_SORTED_INDEX_ACK_NOT_FOUND;
   }
 
+  memset(&target_sorted_idx, 0x00, sizeof(EH_RuleSortedIndex));
+  target_sorted_idx.group = group;
+  target_sorted_idx.local = local;
   p_searched_sorted_idx = (EH_RuleSortedIndex*)bsearch(&target_sorted_idx,
                                                event_handler_.sorted_idxes,
                                                event_handler_.rule_table.registered_rule_num,


### PR DESCRIPTION
## 概要
EHでの二分探索をbsearchで書き直した

## Issue
- https://github.com/ut-issl/c2a-core/issues/50

## 詳細
他にも，issueにある `範囲外アクセスの可能性ありそう` も直した．

## 検証結果
https://github.com/ut-issl/c2a-core/tree/fb90df7b9c178911c794611923e52a1d93d86f21/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/EventManager

## 影響範囲
なし

## 補足
EHの改修が進んでいったら，1 eventで複数EH発火などもテストに入れたほうが良さそう