### PR TITLE
TFの変数の型を修正し，Wextraを消す

### DIFF
--- a/CmdTlm/telemetry_frame.c
+++ b/CmdTlm/telemetry_frame.c
@@ -107,7 +107,7 @@ void TF_copy_float(uint8_t* ptr,
                    float data)
 {
   uint8_t* temp = (uint8_t*)&data;
-  int i;
+  size_t i;
 
   for (i = 0; i < sizeof(float); ++i)
   {
@@ -125,7 +125,7 @@ void TF_copy_double(uint8_t* ptr,
                     double data)
 {
   uint8_t* temp = (uint8_t*)&data;
-  int i;
+  size_t i;
 
   for (i = 0; i < sizeof(double); ++i)
   {


### PR DESCRIPTION
## 概要
TFの変数の型を修正し，Wextraを消す

## Issue
- https://github.com/ut-issl/c2a-core/issues/27

## 検証結果
適当にSILSを動かして問題なかった
