### PR TITLE
-m32が無いコンパイラのためのCMakeの修正

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ project(C2A_CORE)
 # user config
 option(USE_ALL_C2A_CORE_APPS    "use C2A-core all Applications" ON)
 option(USE_ALL_C2A_CORE_LIB     "use C2A-core all Library" ON)
+option(USE_32BIT_COMPILER       "use 32bit compiler" OFF)
 
 set(C2A_CORE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/common.cmake
+++ b/common.cmake
@@ -28,8 +28,10 @@ else()
   endif()
 
   # 32bit
-  target_compile_options(${PROJECT_NAME} PUBLIC "-m32")
-  target_link_options(${PROJECT_NAME} PRIVATE "-m32")
+  if(NOT USE_32BIT_COMPILER)
+    target_compile_options(${PROJECT_NAME} PUBLIC "-m32")
+    target_link_options(${PROJECT_NAME} PRIVATE "-m32")
+  endif()
 
   # debug
   target_compile_options(${PROJECT_NAME} PUBLIC "-g")


### PR DESCRIPTION
## 概要
32bit専用のGCCなどは`-m32`が無いことがあるので，コンパイラが32bitであることが分かる場合は明示的にそれを指定した上で`-m32`などをコンパイルオプションに追加しないようにする

## Issue
NA

## 検証結果
別環境で確認

