### PR TITLE
Add link to discussion in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,6 @@
 - https://github.com/ut-issl/c2a-tlm-cmd-code-generator
 - https://github.com/ut-issl/python-wings-interface
 - https://github.com/ut-issl/c2a-enum-loader
+
+## 質問，問い合わせ，その他なんでも
+お気軽に [Discussions](https://github.com/ut-issl/c2a-core/discussions) に投稿してください．


### PR DESCRIPTION
## 概要
README に discussion のリンクを貼った
- https://github.com/ut-issl/c2a-core/discussions

## Issue
- https://github.com/ut-issl/c2a-core/issues/173

