### PR TITLE
Pre Release (v3.5.0-beta.1): UTL cmd のテストを追加する

### DIFF
--- a/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/TimeManager/test_time_manager.py
+++ b/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/TimeManager/test_time_manager.py
@@ -52,7 +52,7 @@ def test_tmgr_set_time():
 @pytest.mark.real
 def test_tmgr_set_unixtime():
 
-    #=====unixtime_at_ti0 が正しく更新できるか確認=====
+    #===== unixtime_at_ti0 が正しく更新できるか確認 =====
     current_unixtime = time.time()
     ti = 1000
     step = 60
@@ -71,7 +71,7 @@ def test_tmgr_set_unixtime():
     assert tlm_HK["HK.OBC_TM_UNIXTIME_AT_TI0"] ==  unixtime_at_ti0
 
 
-    #=====UTL_cmd が正しく打てるか確認=====
+    #===== UTL_cmd が正しく打てるか確認 =====
     # 最初にTL0をクリアしておく
     ret = wings.util.send_cmd_and_confirm(
         ope,
@@ -93,7 +93,7 @@ def test_tmgr_set_unixtime():
     # 重複を削除して時刻順に並べ替え
     ti_of_cmds = list(set(ti_of_cmds))
     ti_of_cmds.sort()
-    time.sleep(2)
+    time.sleep(1)
 
     # TL0 に正しく登録されているか確認
     tlm_TL = wings.util.generate_and_receive_tlm(
@@ -119,17 +119,73 @@ def test_tmgr_set_unixtime():
 @pytest.mark.real
 def test_tmgr_set_utl_unixtime_epoch():
 
-    epoch_set = time.time() # 現在のunixtimeをepochに設定する
-
+    # epoch を現在の unixtime に変更
+    new_epoch = time.time()
     ret = wings.util.send_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_TMGR_SET_UTL_UNIXTIME_EPOCH, (epoch_set,), c2a_enum.Tlm_CODE_HK
+        ope, c2a_enum.Cmd_CODE_TMGR_SET_UTL_UNIXTIME_EPOCH, (new_epoch,), c2a_enum.Tlm_CODE_HK
     )
     assert ret == "SUC"
 
     tlm_MOBC = wings.util.generate_and_receive_tlm(
         ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_MOBC
     )
-    assert tlm_MOBC["MOBC.TM_UTL_UNIXTIME_EPOCH"] == epoch_set
+    assert tlm_MOBC["MOBC.TM_UTL_UNIXTIME_EPOCH"] == new_epoch
+
+
+    #===== UTL_cmd が正しく打てるか確認 =====
+    unixtime_at_ti0 = time.time() + 10000  # epoch より大きな値を設定する必要がある
+    ret = wings.util.send_cmd_and_confirm(
+        ope,
+        c2a_enum.Cmd_CODE_TMGR_SET_UNIXTIME,
+        (unixtime_at_ti0, 0, 0),
+        c2a_enum.Tlm_CODE_HK,
+    )
+    assert ret == "SUC"
+
+    # 最初にTL0をクリアしておく
+    ret = wings.util.send_cmd_and_confirm(
+        ope,
+        c2a_enum.Cmd_CODE_TLCD_CLEAR_ALL_TIMELINE,
+        (0, ),
+        c2a_enum.Tlm_CODE_HK,
+    )
+    assert ret == "SUC"
+
+    # NOP を10個, 未来のランダムな時刻で登録する
+    # TODO: wingsがutl_cmdの時刻引数を0.1秒刻みで受け付けるように改修されたら, tiの10の倍数縛りをなくす
+    ti_60_sec_after = (tlm_MOBC["MOBC.SH.TI"] // 10) * 10 + 600
+    ti_of_cmds = [ti_60_sec_after + random.randrange(100) * 10 for i in range(10)]
+
+    unixtime_at_ti0 = (int)(unixtime_at_ti0)
+    for ti in ti_of_cmds:
+        ret = wings.util.send_utl_cmd(
+            ope, unixtime_at_ti0 + ti//10, c2a_enum.Cmd_CODE_NOP, (),
+        )
+    # 重複を削除して時刻順に並べ替え
+    ti_of_cmds = list(set(ti_of_cmds))
+    ti_of_cmds.sort()
+    time.sleep(1)
+
+    epoch_gap = (new_epoch - TMGR_DEFAULT_UNIXTIME_EPOCH_FOR_UTL) * 10
+
+    # TL0 に正しく登録されているか確認
+    tlm_TL = wings.util.generate_and_receive_tlm(
+        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_TL
+    )
+    assert tlm_TL["TL.LINE_NO"] == 0
+    for i, ti in enumerate(ti_of_cmds):
+        tlm_name = "TL.CMD" + str(i) + "_TI"
+        assert tlm_TL[tlm_name] <= ti + epoch_gap # FIXME: 0.1秒刻みになったら修正する
+        assert tlm_TL[tlm_name] > ti + epoch_gap - 10
+
+    # 最後にTL0をもう一度クリアする
+    ret = wings.util.send_cmd_and_confirm(
+        ope,
+        c2a_enum.Cmd_CODE_TLCD_CLEAR_ALL_TIMELINE,
+        (0, ),
+        c2a_enum.Tlm_CODE_HK,
+    )
+    assert ret == "SUC"
 
     # epochをデフォルトに戻す
     ret = wings.util.send_cmd_and_confirm(
@@ -145,6 +201,6 @@ def test_tmgr_set_utl_unixtime_epoch():
 
 if __name__ == "__main__":
     # test_tmgr_set_time()
-    test_tmgr_set_unixtime()
+    # test_tmgr_set_unixtime()
     # test_tmgr_set_utl_unixtime_epoch()
     pass

--- a/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/TimeManager/test_time_manager.py
+++ b/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/TimeManager/test_time_manager.py
@@ -19,6 +19,9 @@ ope = wings_utils.get_wings_operation()
 
 
 # C2Aでのdefine値
+OBCT_STEP_IN_MSEC = 1                                                    # 1 step で何 ms か
+OBCT_STEPS_PER_CYCLE = 100                                               # 何 step で 1 cycle か
+OBCT_CYCLES_PER_SEC = 1000 // OBCT_STEP_IN_MSEC // OBCT_STEPS_PER_CYCLE  # 1 s で何 cycle か
 TMGR_DEFAULT_UNIXTIME_EPOCH_FOR_UTL = 1577836800.0
 
 
@@ -26,10 +29,9 @@ TMGR_DEFAULT_UNIXTIME_EPOCH_FOR_UTL = 1577836800.0
 @pytest.mark.real
 def test_tmgr_set_time():
 
-    ret = wings.util.send_cmd_and_confirm(
+    assert "PRM" == wings.util.send_cmd_and_confirm(
         ope, c2a_enum.Cmd_CODE_TMGR_SET_TIME, (0xFFFFFFFF,), c2a_enum.Tlm_CODE_HK
     )
-    assert ret == "PRM"
 
     # TL2のテレメループが途切れないように、現在時刻より未来のTIに飛ばす
     tlm_HK = wings.util.generate_and_receive_tlm(
@@ -37,10 +39,9 @@ def test_tmgr_set_time():
     )
     target_ti = tlm_HK["HK.SH.TI"] + 1000
 
-    ret = wings.util.send_cmd_and_confirm(
+    assert "SUC" == wings.util.send_cmd_and_confirm(
         ope, c2a_enum.Cmd_CODE_TMGR_SET_TIME, (target_ti,), c2a_enum.Tlm_CODE_HK
     )
-    assert ret == "SUC"
     tlm_HK = wings.util.generate_and_receive_tlm(
         ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_HK
     )
@@ -52,67 +53,23 @@ def test_tmgr_set_time():
 @pytest.mark.real
 def test_tmgr_set_unixtime():
 
-    #===== unixtime_at_ti0 が正しく更新できるか確認 =====
+    # unixtime_at_ti0 を current_unixtime とランダムな TI で更新
     current_unixtime = time.time()
-    ti = 1000
-    step = 60
-    ret = wings.util.send_cmd_and_confirm(
+    ti = random.randrange(1000)
+    step = random.randrange(OBCT_STEPS_PER_CYCLE) # step は OBCT_STEPS_PER_CYCLE 未満 とすること
+    assert "SUC" == wings.util.send_cmd_and_confirm(
         ope,
         c2a_enum.Cmd_CODE_TMGR_SET_UNIXTIME,
         (current_unixtime, ti, step),
         c2a_enum.Tlm_CODE_HK,
     )
-    assert ret == "SUC"
 
     tlm_HK = wings.util.generate_and_receive_tlm(
         ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_HK
     )
-    unixtime_at_ti0 = current_unixtime - (ti / 10) - (step / 1000)
-    assert tlm_HK["HK.OBC_TM_UNIXTIME_AT_TI0"] ==  unixtime_at_ti0
-
-
-    #===== UTL_cmd が正しく打てるか確認 =====
-    # 最初にTL0をクリアしておく
-    ret = wings.util.send_cmd_and_confirm(
-        ope,
-        c2a_enum.Cmd_CODE_TLCD_CLEAR_ALL_TIMELINE,
-        (0, ),
-        c2a_enum.Tlm_CODE_HK,
-    )
-    assert ret == "SUC"
-
-    # NOP を10個, 未来のランダムな時刻で登録する
-    # TODO: wingsがutl_cmdの時刻引数を0.1秒刻みで受け付けるように改修されたら, tiの10の倍数縛りをなくす
-    ti_60_sec_after = (tlm_HK["HK.SH.TI"] // 10) * 10 + 600
-    ti_of_cmds = [ti_60_sec_after + random.randrange(100) * 10 for i in range(10)]
-    unixtime_at_ti0 = (int)(unixtime_at_ti0)
-    for ti in ti_of_cmds:
-        ret = wings.util.send_utl_cmd(
-            ope, unixtime_at_ti0 + ti//10, c2a_enum.Cmd_CODE_NOP, (),
-        )
-    # 重複を削除して時刻順に並べ替え
-    ti_of_cmds = list(set(ti_of_cmds))
-    ti_of_cmds.sort()
-    time.sleep(1)
-
-    # TL0 に正しく登録されているか確認
-    tlm_TL = wings.util.generate_and_receive_tlm(
-        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_TL
-    )
-    assert tlm_TL["TL.LINE_NO"] == 0
-    for i, ti in enumerate(ti_of_cmds):
-        tlm_name = "TL.CMD" + str(i) + "_TI"
-        assert tlm_TL[tlm_name] <= ti # FIXME: 0.1秒刻みになったら修正する
-        assert tlm_TL[tlm_name] > ti - 10
-
-    # 最後にTL0をもう一度クリアする
-    ret = wings.util.send_cmd_and_confirm(
-        ope,
-        c2a_enum.Cmd_CODE_TLCD_CLEAR_ALL_TIMELINE,
-        (0, ),
-        c2a_enum.Tlm_CODE_HK,
-    )
-    assert ret == "SUC"
+    unixtime_at_ti0 = current_unixtime - (ti / OBCT_CYCLES_PER_SEC) - (step / OBCT_CYCLES_PER_SEC / OBCT_STEPS_PER_CYCLE)
+    assert tlm_HK["HK.OBC_TM_UNIXTIME_AT_TI0"] < unixtime_at_ti0 + OBCT_STEP_IN_MSEC / 1000
+    assert tlm_HK["HK.OBC_TM_UNIXTIME_AT_TI0"] > unixtime_at_ti0 - OBCT_STEP_IN_MSEC / 1000
 
 
 @pytest.mark.sils
@@ -121,77 +78,19 @@ def test_tmgr_set_utl_unixtime_epoch():
 
     # epoch を現在の unixtime に変更
     new_epoch = time.time()
-    ret = wings.util.send_cmd_and_confirm(
+    assert "SUC" == wings.util.send_cmd_and_confirm(
         ope, c2a_enum.Cmd_CODE_TMGR_SET_UTL_UNIXTIME_EPOCH, (new_epoch,), c2a_enum.Tlm_CODE_HK
     )
-    assert ret == "SUC"
 
     tlm_MOBC = wings.util.generate_and_receive_tlm(
         ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_MOBC
     )
     assert tlm_MOBC["MOBC.TM_UTL_UNIXTIME_EPOCH"] == new_epoch
 
-
-    #===== UTL_cmd が正しく打てるか確認 =====
-    unixtime_at_ti0 = time.time() + 10000  # epoch より大きな値を設定する必要がある
-    ret = wings.util.send_cmd_and_confirm(
-        ope,
-        c2a_enum.Cmd_CODE_TMGR_SET_UNIXTIME,
-        (unixtime_at_ti0, 0, 0),
-        c2a_enum.Tlm_CODE_HK,
-    )
-    assert ret == "SUC"
-
-    # 最初にTL0をクリアしておく
-    ret = wings.util.send_cmd_and_confirm(
-        ope,
-        c2a_enum.Cmd_CODE_TLCD_CLEAR_ALL_TIMELINE,
-        (0, ),
-        c2a_enum.Tlm_CODE_HK,
-    )
-    assert ret == "SUC"
-
-    # NOP を10個, 未来のランダムな時刻で登録する
-    # TODO: wingsがutl_cmdの時刻引数を0.1秒刻みで受け付けるように改修されたら, tiの10の倍数縛りをなくす
-    ti_60_sec_after = (tlm_MOBC["MOBC.SH.TI"] // 10) * 10 + 600
-    ti_of_cmds = [ti_60_sec_after + random.randrange(100) * 10 for i in range(10)]
-
-    unixtime_at_ti0 = (int)(unixtime_at_ti0)
-    for ti in ti_of_cmds:
-        ret = wings.util.send_utl_cmd(
-            ope, unixtime_at_ti0 + ti//10, c2a_enum.Cmd_CODE_NOP, (),
-        )
-    # 重複を削除して時刻順に並べ替え
-    ti_of_cmds = list(set(ti_of_cmds))
-    ti_of_cmds.sort()
-    time.sleep(1)
-
-    epoch_gap = (new_epoch - TMGR_DEFAULT_UNIXTIME_EPOCH_FOR_UTL) * 10
-
-    # TL0 に正しく登録されているか確認
-    tlm_TL = wings.util.generate_and_receive_tlm(
-        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_TL
-    )
-    assert tlm_TL["TL.LINE_NO"] == 0
-    for i, ti in enumerate(ti_of_cmds):
-        tlm_name = "TL.CMD" + str(i) + "_TI"
-        assert tlm_TL[tlm_name] <= ti + epoch_gap # FIXME: 0.1秒刻みになったら修正する
-        assert tlm_TL[tlm_name] > ti + epoch_gap - 10
-
-    # 最後にTL0をもう一度クリアする
-    ret = wings.util.send_cmd_and_confirm(
-        ope,
-        c2a_enum.Cmd_CODE_TLCD_CLEAR_ALL_TIMELINE,
-        (0, ),
-        c2a_enum.Tlm_CODE_HK,
-    )
-    assert ret == "SUC"
-
-    # epochをデフォルトに戻す
-    ret = wings.util.send_cmd_and_confirm(
+    # epoch をデフォルトに戻す
+    assert "SUC" == wings.util.send_cmd_and_confirm(
         ope, c2a_enum.Cmd_CODE_TMGR_SET_UTL_UNIXTIME_EPOCH, (TMGR_DEFAULT_UNIXTIME_EPOCH_FOR_UTL,), c2a_enum.Tlm_CODE_HK
     )
-    assert ret == "SUC"
 
     tlm_MOBC = wings.util.generate_and_receive_tlm(
         ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_MOBC
@@ -199,8 +98,146 @@ def test_tmgr_set_utl_unixtime_epoch():
     assert tlm_MOBC["MOBC.TM_UTL_UNIXTIME_EPOCH"] == TMGR_DEFAULT_UNIXTIME_EPOCH_FOR_UTL
 
 
+@pytest.mark.sils
+@pytest.mark.real
+def test_tmgr_utl_cmd():
+
+    # unixtime_at_ti0 > epoch の場合（正常時）
+    unixtime_at_ti0 = time.time()
+    assert "SUC" == wings.util.send_cmd_and_confirm(
+        ope,
+        c2a_enum.Cmd_CODE_TMGR_SET_UNIXTIME,
+        (unixtime_at_ti0, 0, 0),
+        c2a_enum.Tlm_CODE_HK,
+    )
+
+    _test_utl_cmd(unixtime_at_ti0, TMGR_DEFAULT_UNIXTIME_EPOCH_FOR_UTL)
+
+    # unixtime_at_ti0 < epoch の場合（意図した TI で UTL が打てない）
+    unixtime_at_ti0 = TMGR_DEFAULT_UNIXTIME_EPOCH_FOR_UTL - 100
+    assert "SUC" == wings.util.send_cmd_and_confirm(
+        ope,
+        c2a_enum.Cmd_CODE_TMGR_SET_UNIXTIME,
+        (unixtime_at_ti0, 0, 0),
+        c2a_enum.Tlm_CODE_HK,
+    )
+
+    _test_utl_cmd(unixtime_at_ti0, TMGR_DEFAULT_UNIXTIME_EPOCH_FOR_UTL)
+
+    # epoch が変わった場合
+    new_epoch = time.time()
+    assert "SUC" == wings.util.send_cmd_and_confirm(
+        ope, c2a_enum.Cmd_CODE_TMGR_SET_UTL_UNIXTIME_EPOCH, (new_epoch,), c2a_enum.Tlm_CODE_HK
+    )
+
+    unixtime_at_ti0 = time.time() + 100
+    assert "SUC" == wings.util.send_cmd_and_confirm(
+        ope,
+        c2a_enum.Cmd_CODE_TMGR_SET_UNIXTIME,
+        (unixtime_at_ti0, 0, 0),
+        c2a_enum.Tlm_CODE_HK,
+    )
+
+    _test_utl_cmd(unixtime_at_ti0, new_epoch)
+
+
+def _test_utl_cmd(unixtime_at_ti0, utl_unixtime_epoch):
+    # 最初にTL0をクリアしておく
+    assert "SUC" == wings.util.send_cmd_and_confirm(
+        ope,
+        c2a_enum.Cmd_CODE_TLCD_CLEAR_ALL_TIMELINE,
+        (0, ),
+        c2a_enum.Tlm_CODE_HK,
+    )
+
+    tlm_HK = wings.util.generate_and_receive_tlm(
+        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_HK
+    )
+
+    # NOP を10個, 未来のランダムな unixtime で登録する
+    ti_of_cmds = generate_random_tis(tlm_HK["HK.SH.TI"], 10)
+    send_utl_nops(ti_of_cmds, unixtime_at_ti0)
+
+    # 重複を削除して時刻順に並べ替え
+    ti_of_cmds = list(set(ti_of_cmds))
+    ti_of_cmds.sort()
+
+
+    # TL0 に正しく登録されているか確認
+    tlm_TL = wings.util.generate_and_receive_tlm(
+        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_TL
+    )
+    assert tlm_TL["TL.LINE_NO"] == 0
+
+    for i, ti in enumerate(ti_of_cmds):
+        tlm_name = "TL.CMD" + str(i) + "_TI"
+        ti = reflect_epoch_gap(ti, utl_unixtime_epoch, unixtime_at_ti0)
+
+        # TODO: wingsが改修されたら誤差範囲を狭くする
+        assert tlm_TL[tlm_name] <= ti
+        assert tlm_TL[tlm_name] >  ti - OBCT_CYCLES_PER_SEC
+
+    # 最後にTL0をもう一度クリアする
+    assert "SUC" == wings.util.send_cmd_and_confirm(
+        ope,
+        c2a_enum.Cmd_CODE_TLCD_CLEAR_ALL_TIMELINE,
+        (0, ),
+        c2a_enum.Tlm_CODE_HK,
+    )
+
+
+@pytest.mark.sils
+@pytest.mark.real
+def test_tmgr_final_check():
+    # unixtime_at_ti0 を初期化する
+    unixtime_at_ti0 = 0.0
+    assert "SUC" == wings.util.send_cmd_and_confirm(
+        ope,
+        c2a_enum.Cmd_CODE_TMGR_SET_UNIXTIME,
+        (unixtime_at_ti0, 0, 0),
+        c2a_enum.Tlm_CODE_HK,
+    )
+
+    # epochをデフォルトに戻す
+    assert "SUC" == wings.util.send_cmd_and_confirm(
+        ope, c2a_enum.Cmd_CODE_TMGR_SET_UTL_UNIXTIME_EPOCH, (TMGR_DEFAULT_UNIXTIME_EPOCH_FOR_UTL,), c2a_enum.Tlm_CODE_HK
+    )
+
+
+# 未来のランダムな時刻の TI を n 個生成する
+# TODO: wingsがutl_cmdの時刻引数を0.1秒刻みで受け付けるように改修されたら, TIの10の倍数縛りをなくす
+def generate_random_tis(ti_now, n):
+    ti_future = (ti_now // OBCT_CYCLES_PER_SEC) * OBCT_CYCLES_PER_SEC + 10000
+
+    return [ti_future + random.randrange(100) * OBCT_CYCLES_PER_SEC for i in range(n)]
+
+
+def send_utl_nops(ti_of_cmds, unixtime_at_ti0):
+    unixtime_at_ti0 = (int)(unixtime_at_ti0)  # TODO: wingsが改修されたら整数縛りをなくす
+
+    for ti in ti_of_cmds:
+        # utl_cmd のwings側の時刻引数は一般の unixtime であることに注意
+        wings.util.send_utl_cmd(
+            ope, unixtime_at_ti0 + ti // OBCT_CYCLES_PER_SEC, c2a_enum.Cmd_CODE_NOP, (),
+        )
+
+
+def reflect_epoch_gap(ti, epoch, unixtime_at_ti0):
+    # utl_unixtime_epoch をデフォルトから変更した場合, wings側とずれが生じる
+    # epoch が増えた分だけ, C2A 上では unixtime_at_ti0 が小さく見積もられ, 実行時刻 TI は大きくなる
+    ret = ti + (epoch - TMGR_DEFAULT_UNIXTIME_EPOCH_FOR_UTL) * OBCT_CYCLES_PER_SEC
+
+    if unixtime_at_ti0 >= epoch:
+        return ret
+    else: # unixtime_at_ti0 < epoch
+        # utl_unixtime_at_ti0 = unixtime_at_ti0 - epoch が負の値にならないように,
+        # utl_unixtime_at_ti0 = 0 として例外処理され大きい値が返り, 実行時刻 TI は小さく見積もられる
+        return ret - (epoch - unixtime_at_ti0) * OBCT_CYCLES_PER_SEC
+
+
 if __name__ == "__main__":
     # test_tmgr_set_time()
     # test_tmgr_set_unixtime()
     # test_tmgr_set_utl_unixtime_epoch()
+    # test_tmgr_utl_cmd()
     pass

--- a/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/TimeManager/test_time_manager.py
+++ b/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/TimeManager/test_time_manager.py
@@ -4,6 +4,7 @@
 import os
 import sys
 import time
+import random
 
 import isslwings as wings
 import pytest
@@ -51,8 +52,8 @@ def test_tmgr_set_time():
 @pytest.mark.real
 def test_tmgr_set_unixtime():
 
+    #=====unixtime_at_ti0 が正しく更新できるか確認=====
     current_unixtime = time.time()
-
     ti = 1000
     step = 60
     ret = wings.util.send_cmd_and_confirm(
@@ -63,13 +64,55 @@ def test_tmgr_set_unixtime():
     )
     assert ret == "SUC"
 
-    # 0.05秒の精度でunixtimeが正確に登録されているか確認
     tlm_HK = wings.util.generate_and_receive_tlm(
         ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_HK
     )
     unixtime_at_ti0 = current_unixtime - (ti / 10) - (step / 1000)
-    assert tlm_HK["HK.OBC_TM_UNIXTIME_AT_TI0"] > unixtime_at_ti0 - 0.05
-    assert tlm_HK["HK.OBC_TM_UNIXTIME_AT_TI0"] < unixtime_at_ti0 + 0.05
+    assert tlm_HK["HK.OBC_TM_UNIXTIME_AT_TI0"] ==  unixtime_at_ti0
+
+
+    #=====UTL_cmd が正しく打てるか確認=====
+    # 最初にTL0をクリアしておく
+    ret = wings.util.send_cmd_and_confirm(
+        ope,
+        c2a_enum.Cmd_CODE_TLCD_CLEAR_ALL_TIMELINE,
+        (0, ),
+        c2a_enum.Tlm_CODE_HK,
+    )
+    assert ret == "SUC"
+
+    # NOP を10個, 未来のランダムな時刻で登録する
+    # TODO: wingsがutl_cmdの時刻引数を0.1秒刻みで受け付けるように改修されたら, tiの10の倍数縛りをなくす
+    ti_60_sec_after = (tlm_HK["HK.SH.TI"] // 10) * 10 + 600
+    ti_of_cmds = [ti_60_sec_after + random.randrange(100) * 10 for i in range(10)]
+    unixtime_at_ti0 = (int)(unixtime_at_ti0)
+    for ti in ti_of_cmds:
+        ret = wings.util.send_utl_cmd(
+            ope, unixtime_at_ti0 + ti//10, c2a_enum.Cmd_CODE_NOP, (),
+        )
+    # 重複を削除して時刻順に並べ替え
+    ti_of_cmds = list(set(ti_of_cmds))
+    ti_of_cmds.sort()
+    time.sleep(2)
+
+    # TL0 に正しく登録されているか確認
+    tlm_TL = wings.util.generate_and_receive_tlm(
+        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_TL
+    )
+    assert tlm_TL["TL.LINE_NO"] == 0
+    for i, ti in enumerate(ti_of_cmds):
+        tlm_name = "TL.CMD" + str(i) + "_TI"
+        assert tlm_TL[tlm_name] <= ti # FIXME: 0.1秒刻みになったら修正する
+        assert tlm_TL[tlm_name] > ti - 10
+
+    # 最後にTL0をもう一度クリアする
+    ret = wings.util.send_cmd_and_confirm(
+        ope,
+        c2a_enum.Cmd_CODE_TLCD_CLEAR_ALL_TIMELINE,
+        (0, ),
+        c2a_enum.Tlm_CODE_HK,
+    )
+    assert ret == "SUC"
 
 
 @pytest.mark.sils
@@ -102,6 +145,6 @@ def test_tmgr_set_utl_unixtime_epoch():
 
 if __name__ == "__main__":
     # test_tmgr_set_time()
-    # test_tmgr_set_unixtime()
+    test_tmgr_set_unixtime()
     # test_tmgr_set_utl_unixtime_epoch()
     pass

--- a/System/TimeManager/time_manager.c
+++ b/System/TimeManager/time_manager.c
@@ -156,6 +156,10 @@ cycle_t TMGR_get_utl_unixtime_from_unixtime(const double unixtime)
 cycle_t TMGR_get_ti_from_utl_unixtime(const cycle_t utl_unixtime)
 {
   cycle_t utl_unixtime_at_ti0 = TMGR_get_utl_unixtime_from_unixtime(time_manager_.unixtime_info_.unixtime_at_ti0);
+
+  // unixtime_at_ti0 より小さい実行引数は無効なのでゼロを返す
+  if (utl_unixtime < utl_unixtime_at_ti0) return 0;
+
   return utl_unixtime - utl_unixtime_at_ti0;
 }
 

--- a/System/TimeManager/time_manager.c
+++ b/System/TimeManager/time_manager.c
@@ -157,7 +157,10 @@ cycle_t TMGR_get_ti_from_utl_unixtime(const cycle_t utl_unixtime)
 {
   cycle_t utl_unixtime_at_ti0 = TMGR_get_utl_unixtime_from_unixtime(time_manager_.unixtime_info_.unixtime_at_ti0);
 
-  // unixtime_at_ti0 より小さい実行引数は無効なのでゼロを返す
+  // unixtime_at_ti0 <= epoch となるのはおかしいのでゼロを返す
+  if (utl_unixtime_at_ti0 == 0) return 0;
+
+  // unixtime_at_ti0 より小さい実行時刻は無効なのでゼロを返す
   if (utl_unixtime < utl_unixtime_at_ti0) return 0;
 
   return utl_unixtime - utl_unixtime_at_ti0;

--- a/System/TimeManager/time_manager.h
+++ b/System/TimeManager/time_manager.h
@@ -154,7 +154,7 @@ cycle_t TMGR_get_utl_unixtime_from_unixtime(const double unixtime);
  * @brief 引数で指定された utl_unixtime に対応する TI を返す
  * @note UTL_cmd で実行時刻情報を TI に変換する際に用いる
  * @param[in] utl_unixtime
- * @retval 0 : 引数の unixtime が unixtime_at_ti0 より小さい場合
+ * @retval 0 : "unixtime_at_ti0 <= utl_unixtime_epoch" or "utl_unixtime < utl_unixtime_at_ti0" の場合
  * @retval TI (total_cycleのこと) : それ以外の場合
  */
 cycle_t TMGR_get_ti_from_utl_unixtime(const cycle_t utl_unixtime);

--- a/System/TimeManager/time_manager.h
+++ b/System/TimeManager/time_manager.h
@@ -154,7 +154,8 @@ cycle_t TMGR_get_utl_unixtime_from_unixtime(const double unixtime);
  * @brief 引数で指定された utl_unixtime に対応する TI を返す
  * @note UTL_cmd で実行時刻情報を TI に変換する際に用いる
  * @param[in] utl_unixtime
- * @return TI (total_cycleのこと)
+ * @retval 0 : 引数の unixtime が unixtime_at_ti0 より小さい場合
+ * @retval TI (total_cycleのこと) : それ以外の場合
  */
 cycle_t TMGR_get_ti_from_utl_unixtime(const cycle_t utl_unixtime);
 

--- a/c2a_core_main.h
+++ b/c2a_core_main.h
@@ -10,6 +10,6 @@ void C2A_core_main(void);
 #define C2A_CORE_VER_MAJOR (3)
 #define C2A_CORE_VER_MINOR (5)
 #define C2A_CORE_VER_PATCH (0)
-#define C2A_CORE_VER_PRE   ("beta.0")
+#define C2A_CORE_VER_PRE   ("beta.1")
 
 #endif


### PR DESCRIPTION
## 概要
UTL_cmd のpytestを追加した

## Issue
- https://github.com/ut-issl/c2a-core/issues/175

## 詳細
TMGR のテストに UTL_cmd が正しく打てるかどうかの確認を追加した。

## 検証結果
作成したpytestが通った

## 影響範囲
小

## 補足
python-wings-if側のPRの検証にもなっている
- https://github.com/ut-issl/python-wings-interface/pull/6