### PR TITLE
UART_Configにファイルシステム向けの設定を追加

### DIFF
--- a/IfWrapper/uart.h
+++ b/IfWrapper/uart.h
@@ -80,6 +80,7 @@ typedef enum
 typedef struct
 {
   uint8_t          ch;              //!< 継承先の機器がつながっているポート番号
+  char*            dev_file_name;   //!< 継承先の機器がつながっているファイル名(ファイルシステム環境向け)
   uint32_t         baudrate;        //!< 継承先の機器のボーレート値
   PARITY_SETTINGS  parity_settings; //!< パリティ設定
   UART_DATA_LENGTH data_length;     //!< データ長

--- a/IfWrapper/uart.h
+++ b/IfWrapper/uart.h
@@ -80,7 +80,7 @@ typedef enum
 typedef struct
 {
   uint8_t          ch;              //!< 継承先の機器がつながっているポート番号
-  char*            dev_file_name;   //!< 継承先の機器がつながっているファイル名(ファイルシステム環境向け)
+  char*            device_file_name;  //!< 継承先の機器がつながっているファイル名 (Linuxなどのデバイスファイル環境向け)
   uint32_t         baudrate;        //!< 継承先の機器のボーレート値
   PARITY_SETTINGS  parity_settings; //!< パリティ設定
   UART_DATA_LENGTH data_length;     //!< データ長

--- a/IfWrapper/uart.h
+++ b/IfWrapper/uart.h
@@ -79,12 +79,12 @@ typedef enum
  */
 typedef struct
 {
-  uint8_t          ch;              //!< 継承先の機器がつながっているポート番号
+  uint8_t          ch;                //!< 継承先の機器がつながっているポート番号
   char*            device_file_name;  //!< 継承先の機器がつながっているファイル名 (Linuxなどのデバイスファイル環境向け)
-  uint32_t         baudrate;        //!< 継承先の機器のボーレート値
-  PARITY_SETTINGS  parity_settings; //!< パリティ設定
-  UART_DATA_LENGTH data_length;     //!< データ長
-  UART_STOP_BIT    stop_bit;        //!< ストップビット
+  uint32_t         baudrate;          //!< 継承先の機器のボーレート値
+  PARITY_SETTINGS  parity_settings;   //!< パリティ設定
+  UART_DATA_LENGTH data_length;       //!< データ長
+  UART_STOP_BIT    stop_bit;          //!< ストップビット
 } UART_Config;
 
 /**


### PR DESCRIPTION
## 概要
Linuxなど用に、UARTをデバイスファイル名として設定できるようにした

## Issue
NA

## 検証結果
Linux環境で確認済み
