### PR TITLE
文字コードがUTF-8になったことによる， `#pragma section` スクリプトの修正

### DIFF
--- a/Examples/minimum_user_for_s2e/src/src_user/Script/AddSection/AddSection.pl
+++ b/Examples/minimum_user_for_s2e/src/src_user/Script/AddSection/AddSection.pl
@@ -105,7 +105,7 @@ sub ProcFile {
 sub ReadHeadLine {
 	my $file = $_[0];
 	# open (FH, "<:encoding(cp932)", $file) || die "can't open $file: $!";
-	open (FH, "<:encoding(sjis)", $file) or die "can't open $file: $!";
+	open (FH, "<:encoding(".$SETTING{'FILE_ENCODING'}.")", $file) or die "can't open $file: $!";
 	my $line = <FH>;
 	# $line =~ s/ /_/g;
 	# seek FH, 0, 0; # go back to the start of the file
@@ -118,7 +118,7 @@ sub ReadHeadLine {
 sub ReadLastLine {
 	my $file = $_[0];
 	# print $_[0], "\n";
-	open (FH, "<:encoding(sjis)", $file) or die "can't open $file: $!";
+	open (FH, "<:encoding(".$SETTING{'FILE_ENCODING'}.")", $file) or die "can't open $file: $!";
 	my $line;
 	while (<FH>) {
 		eof $_ and $line = $_;
@@ -130,7 +130,7 @@ sub ReadLastLine {
 
 sub EraseHeadLine {
 	my $file = $_[0];
-	open (FH, "+<:encoding(sjis)", $file) or die "can't open $file: $!";
+	open (FH, "+<:encoding(".$SETTING{'FILE_ENCODING'}.")", $file) or die "can't open $file: $!";
 	my @lines=<FH>;
 	shift(@lines);
 	seek(FH, 0, 0);
@@ -141,7 +141,7 @@ sub EraseHeadLine {
 
 sub EraseLastLine {
 	my $file = $_[0];
-	open (FH, "+<:encoding(sjis)", $file) or die "can't update $file: $!";
+	open (FH, "+<:encoding(".$SETTING{'FILE_ENCODING'}.")", $file) or die "can't update $file: $!";
 	my $addr;
 	while (<FH>) {
 		$addr = tell(FH) unless eof(FH);
@@ -153,7 +153,7 @@ sub EraseLastLine {
 sub AddHeadLine {
 	my $str  = $_[0];
 	my $file = $_[1];
-	open (FH, "+<:encoding(sjis)", $file) or die "can't update $file: $!";
+	open (FH, "+<:encoding(".$SETTING{'FILE_ENCODING'}.")", $file) or die "can't update $file: $!";
 
 	my @orig = <FH>;
 	seek(FH, 0, 0);
@@ -165,7 +165,7 @@ sub AddHeadLine {
 sub AddLastLine {
 	my $str  = $_[0];
 	my $file = $_[1];
-	open (FH, ">>:encoding(sjis)", $file) or die "can't update $file: $!";
+	open (FH, ">>:encoding(".$SETTING{'FILE_ENCODING'}.")", $file) or die "can't update $file: $!";
 	print FH $str;
 	close FH;
 }

--- a/Examples/minimum_user_for_s2e/src/src_user/Script/AddSection/settings.pl
+++ b/Examples/minimum_user_for_s2e/src/src_user/Script/AddSection/settings.pl
@@ -13,6 +13,7 @@ sub GetSetting {
 	$SETTING{'FOOTER'} = '#pragma section';
 
 	$SETTING{'ROOT_PATH'} = '../../';
+	$SETTING{'FILE_ENCODING'} = 'utf8';
 	$SETTING{'LOG_FILE'}  = './log.log';
 	$SETTING{'SEARCH_PATH'} = [
 		'Applications',

--- a/Script/AddSection/AddSection.pl
+++ b/Script/AddSection/AddSection.pl
@@ -105,7 +105,7 @@ sub ProcFile {
 sub ReadHeadLine {
 	my $file = $_[0];
 	# open (FH, "<:encoding(cp932)", $file) || die "can't open $file: $!";
-	open (FH, "<:encoding(sjis)", $file) or die "can't open $file: $!";
+	open (FH, "<:encoding(".$SETTING{'FILE_ENCODING'}.")", $file) or die "can't open $file: $!";
 	my $line = <FH>;
 	# $line =~ s/ /_/g;
 	# seek FH, 0, 0; # go back to the start of the file
@@ -118,7 +118,7 @@ sub ReadHeadLine {
 sub ReadLastLine {
 	my $file = $_[0];
 	# print $_[0], "\n";
-	open (FH, "<:encoding(sjis)", $file) or die "can't open $file: $!";
+	open (FH, "<:encoding(".$SETTING{'FILE_ENCODING'}.")", $file) or die "can't open $file: $!";
 	my $line;
 	while (<FH>) {
 		eof $_ and $line = $_;
@@ -130,7 +130,7 @@ sub ReadLastLine {
 
 sub EraseHeadLine {
 	my $file = $_[0];
-	open (FH, "+<:encoding(sjis)", $file) or die "can't open $file: $!";
+	open (FH, "+<:encoding(".$SETTING{'FILE_ENCODING'}.")", $file) or die "can't open $file: $!";
 	my @lines=<FH>;
 	shift(@lines);
 	seek(FH, 0, 0);
@@ -141,7 +141,7 @@ sub EraseHeadLine {
 
 sub EraseLastLine {
 	my $file = $_[0];
-	open (FH, "+<:encoding(sjis)", $file) or die "can't update $file: $!";
+	open (FH, "+<:encoding(".$SETTING{'FILE_ENCODING'}.")", $file) or die "can't update $file: $!";
 	my $addr;
 	while (<FH>) {
 		$addr = tell(FH) unless eof(FH);
@@ -153,7 +153,7 @@ sub EraseLastLine {
 sub AddHeadLine {
 	my $str  = $_[0];
 	my $file = $_[1];
-	open (FH, "+<:encoding(sjis)", $file) or die "can't update $file: $!";
+	open (FH, "+<:encoding(".$SETTING{'FILE_ENCODING'}.")", $file) or die "can't update $file: $!";
 
 	my @orig = <FH>;
 	seek(FH, 0, 0);
@@ -165,7 +165,7 @@ sub AddHeadLine {
 sub AddLastLine {
 	my $str  = $_[0];
 	my $file = $_[1];
-	open (FH, ">>:encoding(sjis)", $file) or die "can't update $file: $!";
+	open (FH, ">>:encoding(".$SETTING{'FILE_ENCODING'}.")", $file) or die "can't update $file: $!";
 	print FH $str;
 	close FH;
 }

--- a/Script/AddSection/settings.pl
+++ b/Script/AddSection/settings.pl
@@ -13,6 +13,7 @@ sub GetSetting {
 	$SETTING{'FOOTER'} = '#pragma section';
 
 	$SETTING{'ROOT_PATH'} = '../../';
+	$SETTING{'FILE_ENCODING'} = 'utf8';
 	$SETTING{'LOG_FILE'}  = './log.log';
 	$SETTING{'SEARCH_PATH'} = [
 		'Applications',


### PR DESCRIPTION
## 概要
文字コードがUTF-8になったことによる， `#pragma section` スクリプトの修正

## Issue
- https://github.com/ut-issl/c2a-core/issues/21

## 詳細
- https://github.com/ut-issl/c2a-core/pull/185 に漏れがあったので，追加

## 検証結果
無事にスクリプトが動くことを確認

