### PR TITLE
pythonのフォーマットチェックCIとリンタCIをいれる

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,2 @@
 [flake8]
-max-line-length = 120
+max-line-length = 100

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120

--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,3 @@
 [flake8]
 max-line-length = 100
+ignore = E203

--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
 max-line-length = 100
-ignore = E203,W503,W504
+ignore = E203,E402,W503,W504

--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,9 @@
 [flake8]
 max-line-length = 100
-ignore = E203,E402,W503,W504
+ignore =
+    # black と競合するので
+    E203,
+    W503,
+    W504,
+    # https://github.com/ut-issl/c2a-core/issues/195
+    E402

--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
 max-line-length = 100
-ignore = E203
+ignore = E203,W503,W504

--- a/.github/workflows/python_check_format.yml
+++ b/.github/workflows/python_check_format.yml
@@ -1,4 +1,4 @@
-name: python format check
+name: reviewdog / python format check
 
 on:
   push:
@@ -13,5 +13,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: check python format with black
-        uses: psf/black@stable
+      # - name: check python format with black
+      #   uses: psf/black@stable
+
+      - uses: reviewdog/action-black@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-review
+          filter_mode: nofilter
+          fail_on_error: true
+          level: warning
+

--- a/.github/workflows/python_check_format.yml
+++ b/.github/workflows/python_check_format.yml
@@ -1,0 +1,17 @@
+name: python format check
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+
+jobs:
+  python-format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: check python format with black
+        uses: psf/black@stable

--- a/.github/workflows/python_check_format.yml
+++ b/.github/workflows/python_check_format.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 jobs:
-  python-format:
+  black_format:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -19,8 +19,8 @@ jobs:
       - uses: reviewdog/action-black@v2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          reporter: github-pr-review
+          # reporter: github-pr-review    # TODO: いい感じになったら直す
+          reporter: github-pr-check
           filter_mode: nofilter
           fail_on_error: true
           level: warning
-

--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 jobs:
-  flake8-lint:
+  flake8_lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -25,3 +25,4 @@ jobs:
           reporter: github-pr-review
           filter_mode: nofilter
           fail_on_error: true
+          level: warning

--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -1,0 +1,27 @@
+name: reviewdog / lint python
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+
+jobs:
+  flake8-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up python environment
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+
+      - name: flake8 Lint
+        uses: reviewdog/action-flake8@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-review
+          filter_mode: nofilter
+          fail_on_error: true

--- a/Examples/minimum_user_for_s2e/src/src_user/Test/README.md
+++ b/Examples/minimum_user_for_s2e/src/src_user/Test/README.md
@@ -42,7 +42,7 @@ pytest -m sils -v ./test/  # SILSの場合
 ```
 pytest -m real -v ./test/src_user/Applications/UserDefined/test_tlm_mem_dump.py
 
-or 
+or
 
 cd ./test/src_user/Applications/UserDefined/
 pytest -m real -v test_tlm_mem_dump.py
@@ -51,10 +51,10 @@ pytest -m real -v test_tlm_mem_dump.py
 ## 認証情報について
 wings と通信するにあたりに対して認証情報を渡す必要がある. `authorization.json.temp` と同じ key を持つ正しい `authorization.json` を誰かからもらうか，又はそれぞれの key に対応する環境変数を埋めること. 対応を下表に示す.
 
-| `authorization.json` の key | 環境変数             | 
-| :-------------------------- | :------------------ | 
-| client_id                   | WINGS_CLIENT_ID     | 
-| client_secret               | WINGS_CLIENT_SECRET | 
-| grant_type                  | WINGS_GRANT_TYPE    | 
-| username                    | WINGS_USERNAME      | 
-| password                    | WINGS_PASSWORD      | 
+| `authorization.json` の key | 環境変数            |
+| :-------------------------- | :------------------ |
+| client_id                   | WINGS_CLIENT_ID     |
+| client_secret               | WINGS_CLIENT_SECRET |
+| grant_type                  | WINGS_GRANT_TYPE    |
+| username                    | WINGS_USERNAME      |
+| password                    | WINGS_PASSWORD      |

--- a/Examples/minimum_user_for_s2e/src/src_user/Test/test/conftest.py
+++ b/Examples/minimum_user_for_s2e/src/src_user/Test/test/conftest.py
@@ -4,8 +4,6 @@
 import os
 import sys
 import time
-import json
-import isslwings as wings
 import pytest
 
 ROOT_PATH = "../"

--- a/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/CmdTlm/test_command_analyze.py
+++ b/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/CmdTlm/test_command_analyze.py
@@ -3,7 +3,6 @@
 
 import os
 import sys
-import time
 
 import isslwings as wings
 import pytest

--- a/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/CmdTlm/test_command_analyze.py
+++ b/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/CmdTlm/test_command_analyze.py
@@ -17,13 +17,14 @@ c2a_enum = c2a_enum_utils.get_c2a_enum()
 ope = wings_utils.get_wings_operation()
 
 # コードと整合をとる
-CA_TLM_PAGE_SIZE     = 32
-CA_TLM_PAGE_MAX      = 48
-CA_MAX_CMDS          = CA_TLM_PAGE_SIZE * CA_TLM_PAGE_MAX
+CA_TLM_PAGE_SIZE = 32
+CA_TLM_PAGE_MAX = 48
+CA_MAX_CMDS = CA_TLM_PAGE_SIZE * CA_TLM_PAGE_MAX
 CA_MAX_CMD_PARAM_NUM = 6
 
 # 既存のコマンドIDと被らないように！！
 TEST_CMD_ID = CA_MAX_CMDS - CA_TLM_PAGE_SIZE
+
 
 @pytest.mark.real
 @pytest.mark.sils
@@ -45,6 +46,7 @@ def test_command_analyze_set_page():
         ope, c2a_enum.Cmd_CODE_CA_SET_PAGE_FOR_TLM, (CA_TLM_PAGE_MAX,), c2a_enum.Tlm_CODE_HK
     )
 
+
 @pytest.mark.real
 @pytest.mark.sils
 def test_command_analyze_add_cmd():
@@ -60,7 +62,10 @@ def test_command_analyze_add_cmd():
 
     test_cmd_adr = "0x12345678"
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_CA_REGISTER_CMD, (TEST_CMD_ID, test_cmd_adr, "0x1234f0"), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_CA_REGISTER_CMD,
+        (TEST_CMD_ID, test_cmd_adr, "0x1234f0"),
+        c2a_enum.Tlm_CODE_HK,
     )
 
     tlm_CA = wings.util.generate_and_receive_tlm(
@@ -77,7 +82,10 @@ def test_command_analyze_add_cmd():
     # 危ないので戻す
     test_cmd_adr = "0x00000000"
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_CA_REGISTER_CMD, (TEST_CMD_ID, test_cmd_adr, "0x000000"), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_CA_REGISTER_CMD,
+        (TEST_CMD_ID, test_cmd_adr, "0x000000"),
+        c2a_enum.Tlm_CODE_HK,
     )
 
     tlm_CA = wings.util.generate_and_receive_tlm(
@@ -92,10 +100,16 @@ def test_command_analyze_add_cmd():
     assert tlm_CA["CA.CMD0.PARAM5_SIZE"] == "NONE"
 
     assert "LEN" == wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_CA_REGISTER_CMD, (TEST_CMD_ID, test_cmd_adr, "0x0000"), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_CA_REGISTER_CMD,
+        (TEST_CMD_ID, test_cmd_adr, "0x0000"),
+        c2a_enum.Tlm_CODE_HK,
     )
     assert "LEN" == wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_CA_REGISTER_CMD, (TEST_CMD_ID, test_cmd_adr, "0x00000000"), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_CA_REGISTER_CMD,
+        (TEST_CMD_ID, test_cmd_adr, "0x00000000"),
+        c2a_enum.Tlm_CODE_HK,
     )
 
 

--- a/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/AnomalyLogger/test_anomaly_logger.py
+++ b/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/AnomalyLogger/test_anomaly_logger.py
@@ -3,10 +3,11 @@
 
 import os
 import sys
-import time
 
-import isslwings as wings
-import pytest
+# import time
+
+# import isslwings as wings
+# import pytest
 
 ROOT_PATH = "../../../../"
 sys.path.append(os.path.dirname(__file__) + "/" + ROOT_PATH + "utils")

--- a/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/AnomalyLogger/test_anomaly_logger.py
+++ b/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/AnomalyLogger/test_anomaly_logger.py
@@ -7,7 +7,7 @@ import sys
 # import time
 
 # import isslwings as wings
-# import pytest
+import pytest
 
 ROOT_PATH = "../../../../"
 sys.path.append(os.path.dirname(__file__) + "/" + ROOT_PATH + "utils")
@@ -19,6 +19,14 @@ ope = wings_utils.get_wings_operation()
 
 
 # 現在 AL は deprecated (後継は EL) なので，一旦コメントアウト
+
+
+# 他をコメントアウトしてると， pytest がコケるので
+@pytest.mark.sils
+@pytest.mark.real
+def test_al_nop():
+    pass
+
 
 # @pytest.mark.sils
 # @pytest.mark.real

--- a/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/EventManager/test_event_handler.py
+++ b/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/EventManager/test_event_handler.py
@@ -65,7 +65,7 @@ EH_REGISTER_ACK_ILLEGAL_BCT_ID = 10
 EH_REGISTER_ACK_ILLEGAL_ACTIVE_FLAG = 11
 EH_REGISTER_ACK_UNKNOWN_ERR = 12
 
-conv_to_err_level = {0: "HIGH", 1: "MIDDLE", 2: "LOW", 1: "EL"}
+conv_to_err_level = {0: "HIGH", 1: "MIDDLE", 2: "LOW", 3: "EL", 4: "EH"}
 conv_to_match_flag = {0: "NO", 1: "YES"}
 conv_to_active = {0: "INACTIVE", 1: "ACTIVE"}
 conv_to_condition_type = {0: "SINGLE", 1: "CONTINUOUS", 2: "CUMULATIVE"}
@@ -192,14 +192,14 @@ def test_event_handler_delete_rule():
 
     init_el_and_eh()
 
-    tlm_EH_INDEX = download_eh_index_tlm()
+    download_eh_index_tlm()  # 目視チェック用
 
     # ルールを消す
     print("Cmd_EH_DELETE_RULE")
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
         ope, c2a_enum.Cmd_CODE_EH_DELETE_RULE, (EH_RULE_TEST2,), c2a_enum.Tlm_CODE_HK
     )
-    tlm_EH_INDEX = download_eh_index_tlm()
+    download_eh_index_tlm()  # 目視チェック用
     # FIXME: 自動化したい
     print("!!!!! 目視チェック：EH_RULE_TEST2 が EH_INDEX から消されつつ，ソートされているか確認 !!!!!")
     check_rule(

--- a/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/EventManager/test_event_handler.py
+++ b/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/EventManager/test_event_handler.py
@@ -68,7 +68,7 @@ EH_REGISTER_ACK_UNKNOWN_ERR = 12
 conv_to_err_level = {0: "HIGH", 1: "MIDDLE", 2: "LOW", 1: "EL"}
 conv_to_match_flag = {0: "NO", 1: "YES"}
 conv_to_active = {0: "INACTIVE", 1: "ACTIVE"}
-conv_to_condition_type = {0: "SINGLE", 1: "CONTINUOUS", 2:"CUMULATIVE"}
+conv_to_condition_type = {0: "SINGLE", 1: "CONTINUOUS", 2: "CUMULATIVE"}
 
 # TODO: カウンタのクリアを入れたら足す
 # TODO: EH対応EL発行を入れたら，色々変えないとダメ
@@ -197,16 +197,18 @@ def test_event_handler_delete_rule():
     # ルールを消す
     print("Cmd_EH_DELETE_RULE")
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EH_DELETE_RULE, (EH_RULE_TEST2, ), c2a_enum.Tlm_CODE_HK
+        ope, c2a_enum.Cmd_CODE_EH_DELETE_RULE, (EH_RULE_TEST2,), c2a_enum.Tlm_CODE_HK
     )
     tlm_EH_INDEX = download_eh_index_tlm()
     # FIXME: 自動化したい
     print("!!!!! 目視チェック：EH_RULE_TEST2 が EH_INDEX から消されつつ，ソートされているか確認 !!!!!")
-    check_rule("EH_RULE_TEST2 cleared", EH_RULE_TEST2, {'group': 0, 'local': 0, 'is_active': "INACTIVE"})
+    check_rule(
+        "EH_RULE_TEST2 cleared", EH_RULE_TEST2, {"group": 0, "local": 0, "is_active": "INACTIVE"}
+    )
 
     # 同じルールを消してエラー
     assert "CNT" == wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EH_DELETE_RULE, (EH_RULE_TEST2, ), c2a_enum.Tlm_CODE_HK
+        ope, c2a_enum.Cmd_CODE_EH_DELETE_RULE, (EH_RULE_TEST2,), c2a_enum.Tlm_CODE_HK
     )
 
 
@@ -226,20 +228,16 @@ def test_event_handler_register_rule():
 
     # テンプレ
     settings = {
-                    'event': {
-                        'group': EL_GROUP_TEST_EH,
-                        'local': 0,
-                        'err_level': EL_ERROR_LEVEL_LOW
-                    },
-                    'condition': {
-                        'type': EH_RESPONSE_CONDITION_SINGLE,
-                        'count_threshold': 0,
-                        'time_threshold_ms': 0
-                    },
-                    'should_match_err_level': 1,
-                    'deploy_bct_id': BC_TEST_EH_RESPOND,
-                    'is_active': 1,
-                }
+        "event": {"group": EL_GROUP_TEST_EH, "local": 0, "err_level": EL_ERROR_LEVEL_LOW},
+        "condition": {
+            "type": EH_RESPONSE_CONDITION_SINGLE,
+            "count_threshold": 0,
+            "time_threshold_ms": 0,
+        },
+        "should_match_err_level": 1,
+        "deploy_bct_id": BC_TEST_EH_RESPOND,
+        "is_active": 1,
+    }
 
     set_param_of_reg_from_cmd_eh_rule(EH_RULE_TEST0, settings)
     check_reg_from_cmd_eh_rule_param(EH_RULE_TEST0, settings)
@@ -254,7 +252,7 @@ def test_event_handler_register_rule():
 
     # 不正な group
     settings_invalid = copy.deepcopy(settings)
-    settings_invalid['event']['group'] = 0xffffffff
+    settings_invalid["event"]["group"] = 0xFFFFFFFF
     set_param_of_reg_from_cmd_eh_rule(EH_RULE_TEST1, settings_invalid)
     (cmd_ret, reg_ack) = register_rule()
     assert cmd_ret == "PRM"
@@ -262,7 +260,7 @@ def test_event_handler_register_rule():
 
     # 不正な type
     settings_invalid = copy.deepcopy(settings)
-    settings_invalid['condition']['type'] = 0xff
+    settings_invalid["condition"]["type"] = 0xFF
     set_param_of_reg_from_cmd_eh_rule(EH_RULE_TEST1, settings_invalid)
     (cmd_ret, reg_ack) = register_rule()
     assert cmd_ret == "PRM"
@@ -297,9 +295,13 @@ def test_event_handler_register_rule():
 
     # 最大重複数チェック（後ろに登録なしあるバージョン）
     settings_later_group = copy.deepcopy(settings)
-    settings_later_group['event']['group'] = EL_GROUP_TEST_EH + 1
-    set_param_of_reg_from_cmd_eh_rule(EH_RULE_TEST0 + EH_MAX_RULE_NUM_OF_EL_ID_DUPLICATES + 1, settings_later_group)
-    check_reg_from_cmd_eh_rule_param(EH_RULE_TEST0 + EH_MAX_RULE_NUM_OF_EL_ID_DUPLICATES + 1, settings_later_group)
+    settings_later_group["event"]["group"] = EL_GROUP_TEST_EH + 1
+    set_param_of_reg_from_cmd_eh_rule(
+        EH_RULE_TEST0 + EH_MAX_RULE_NUM_OF_EL_ID_DUPLICATES + 1, settings_later_group
+    )
+    check_reg_from_cmd_eh_rule_param(
+        EH_RULE_TEST0 + EH_MAX_RULE_NUM_OF_EL_ID_DUPLICATES + 1, settings_later_group
+    )
     (cmd_ret, reg_ack) = register_rule()
     assert reg_ack == EH_REGISTER_ACK_OK
     assert cmd_ret == "SUC"
@@ -337,20 +339,16 @@ def test_event_handler_check_index():
 
     # テンプレ
     settings = {
-                    'event': {
-                        'group': EL_GROUP_TEST_EH,
-                        'local': 0,
-                        'err_level': EL_ERROR_LEVEL_LOW
-                    },
-                    'condition': {
-                        'type': EH_RESPONSE_CONDITION_SINGLE,
-                        'count_threshold': 0,
-                        'time_threshold_ms': 0
-                    },
-                    'should_match_err_level': 1,
-                    'deploy_bct_id': BC_TEST_EH_RESPOND,
-                    'is_active': 1,
-                }
+        "event": {"group": EL_GROUP_TEST_EH, "local": 0, "err_level": EL_ERROR_LEVEL_LOW},
+        "condition": {
+            "type": EH_RESPONSE_CONDITION_SINGLE,
+            "count_threshold": 0,
+            "time_threshold_ms": 0,
+        },
+        "should_match_err_level": 1,
+        "deploy_bct_id": BC_TEST_EH_RESPOND,
+        "is_active": 1,
+    }
 
     # 次の順番のindexを作れるか？
     # group, local, duplicate_id, rule_id
@@ -366,143 +364,325 @@ def test_event_handler_check_index():
 
     # 順番はわざとバラバラ
     settings_tmp = copy.deepcopy(settings)
-    settings_tmp['event']['group'] = EL_GROUP_TEST_EH
-    settings_tmp['event']['local'] = 1
+    settings_tmp["event"]["group"] = EL_GROUP_TEST_EH
+    settings_tmp["event"]["local"] = 1
     set_param_of_reg_from_cmd_eh_rule(EH_RULE_TEST1, settings_tmp)
     (cmd_ret, reg_ack) = register_rule()
     assert cmd_ret == "SUC"
 
     settings_tmp = copy.deepcopy(settings)
-    settings_tmp['event']['group'] = EL_GROUP_TEST_EH1
-    settings_tmp['event']['local'] = 0
+    settings_tmp["event"]["group"] = EL_GROUP_TEST_EH1
+    settings_tmp["event"]["local"] = 0
     set_param_of_reg_from_cmd_eh_rule(EH_RULE_TEST5, settings_tmp)
     (cmd_ret, reg_ack) = register_rule()
     assert cmd_ret == "SUC"
 
     settings_tmp = copy.deepcopy(settings)
-    settings_tmp['event']['group'] = EL_GROUP_TEST_EH
-    settings_tmp['event']['local'] = 1
+    settings_tmp["event"]["group"] = EL_GROUP_TEST_EH
+    settings_tmp["event"]["local"] = 1
     set_param_of_reg_from_cmd_eh_rule(EH_RULE_TEST2, settings_tmp)
     (cmd_ret, reg_ack) = register_rule()
     assert cmd_ret == "SUC"
 
     settings_tmp = copy.deepcopy(settings)
-    settings_tmp['event']['group'] = EL_GROUP_TEST_EH
-    settings_tmp['event']['local'] = 0
+    settings_tmp["event"]["group"] = EL_GROUP_TEST_EH
+    settings_tmp["event"]["local"] = 0
     set_param_of_reg_from_cmd_eh_rule(EH_RULE_TEST0, settings_tmp)
     (cmd_ret, reg_ack) = register_rule()
     assert cmd_ret == "SUC"
 
     settings_tmp = copy.deepcopy(settings)
-    settings_tmp['event']['group'] = EL_GROUP_TEST_EH
-    settings_tmp['event']['local'] = 2
+    settings_tmp["event"]["group"] = EL_GROUP_TEST_EH
+    settings_tmp["event"]["local"] = 2
     set_param_of_reg_from_cmd_eh_rule(EH_RULE_TEST4, settings_tmp)
     (cmd_ret, reg_ack) = register_rule()
     assert cmd_ret == "SUC"
 
     settings_tmp = copy.deepcopy(settings)
-    settings_tmp['event']['group'] = EL_GROUP_TEST_EH1
-    settings_tmp['event']['local'] = 1
+    settings_tmp["event"]["group"] = EL_GROUP_TEST_EH1
+    settings_tmp["event"]["local"] = 1
     set_param_of_reg_from_cmd_eh_rule(EH_RULE_TEST7, settings_tmp)
     (cmd_ret, reg_ack) = register_rule()
     assert cmd_ret == "SUC"
 
     settings_tmp = copy.deepcopy(settings)
-    settings_tmp['event']['group'] = EL_GROUP_TEST_EH
-    settings_tmp['event']['local'] = 1
+    settings_tmp["event"]["group"] = EL_GROUP_TEST_EH
+    settings_tmp["event"]["local"] = 1
     set_param_of_reg_from_cmd_eh_rule(EH_RULE_TEST3, settings_tmp)
     (cmd_ret, reg_ack) = register_rule()
     assert cmd_ret == "SUC"
 
     settings_tmp = copy.deepcopy(settings)
-    settings_tmp['event']['group'] = EL_GROUP_TEST_EH1
-    settings_tmp['event']['local'] = 0
+    settings_tmp["event"]["group"] = EL_GROUP_TEST_EH1
+    settings_tmp["event"]["local"] = 0
     set_param_of_reg_from_cmd_eh_rule(EH_RULE_TEST6, settings_tmp)
     (cmd_ret, reg_ack) = register_rule()
     assert cmd_ret == "SUC"
 
     tlm_EH_INDEX = download_eh_index_tlm()
-    check_rule_index("TEST0", 0, {'group': EL_GROUP_TEST_EH,  'local': 0, 'duplicate_id': 0, 'rule_id': EH_RULE_TEST0}, tlm_EH_INDEX)
-    check_rule_index("TEST1", 1, {'group': EL_GROUP_TEST_EH,  'local': 1, 'duplicate_id': 0, 'rule_id': EH_RULE_TEST1}, tlm_EH_INDEX)
-    check_rule_index("TEST2", 2, {'group': EL_GROUP_TEST_EH,  'local': 1, 'duplicate_id': 1, 'rule_id': EH_RULE_TEST2}, tlm_EH_INDEX)
-    check_rule_index("TEST3", 3, {'group': EL_GROUP_TEST_EH,  'local': 1, 'duplicate_id': 2, 'rule_id': EH_RULE_TEST3}, tlm_EH_INDEX)
-    check_rule_index("TEST4", 4, {'group': EL_GROUP_TEST_EH,  'local': 2, 'duplicate_id': 0, 'rule_id': EH_RULE_TEST4}, tlm_EH_INDEX)
-    check_rule_index("TEST5", 5, {'group': EL_GROUP_TEST_EH1, 'local': 0, 'duplicate_id': 0, 'rule_id': EH_RULE_TEST5}, tlm_EH_INDEX)
-    check_rule_index("TEST6", 6, {'group': EL_GROUP_TEST_EH1, 'local': 0, 'duplicate_id': 1, 'rule_id': EH_RULE_TEST6}, tlm_EH_INDEX)
-    check_rule_index("TEST7", 7, {'group': EL_GROUP_TEST_EH1, 'local': 1, 'duplicate_id': 0, 'rule_id': EH_RULE_TEST7}, tlm_EH_INDEX)
+    check_rule_index(
+        "TEST0",
+        0,
+        {"group": EL_GROUP_TEST_EH, "local": 0, "duplicate_id": 0, "rule_id": EH_RULE_TEST0},
+        tlm_EH_INDEX,
+    )
+    check_rule_index(
+        "TEST1",
+        1,
+        {"group": EL_GROUP_TEST_EH, "local": 1, "duplicate_id": 0, "rule_id": EH_RULE_TEST1},
+        tlm_EH_INDEX,
+    )
+    check_rule_index(
+        "TEST2",
+        2,
+        {"group": EL_GROUP_TEST_EH, "local": 1, "duplicate_id": 1, "rule_id": EH_RULE_TEST2},
+        tlm_EH_INDEX,
+    )
+    check_rule_index(
+        "TEST3",
+        3,
+        {"group": EL_GROUP_TEST_EH, "local": 1, "duplicate_id": 2, "rule_id": EH_RULE_TEST3},
+        tlm_EH_INDEX,
+    )
+    check_rule_index(
+        "TEST4",
+        4,
+        {"group": EL_GROUP_TEST_EH, "local": 2, "duplicate_id": 0, "rule_id": EH_RULE_TEST4},
+        tlm_EH_INDEX,
+    )
+    check_rule_index(
+        "TEST5",
+        5,
+        {"group": EL_GROUP_TEST_EH1, "local": 0, "duplicate_id": 0, "rule_id": EH_RULE_TEST5},
+        tlm_EH_INDEX,
+    )
+    check_rule_index(
+        "TEST6",
+        6,
+        {"group": EL_GROUP_TEST_EH1, "local": 0, "duplicate_id": 1, "rule_id": EH_RULE_TEST6},
+        tlm_EH_INDEX,
+    )
+    check_rule_index(
+        "TEST7",
+        7,
+        {"group": EL_GROUP_TEST_EH1, "local": 1, "duplicate_id": 0, "rule_id": EH_RULE_TEST7},
+        tlm_EH_INDEX,
+    )
 
     # いい感じに消していく
     # 重複真ん中
     print("Cmd_EH_DELETE_RULE")
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EH_DELETE_RULE, (EH_RULE_TEST2, ), c2a_enum.Tlm_CODE_HK
+        ope, c2a_enum.Cmd_CODE_EH_DELETE_RULE, (EH_RULE_TEST2,), c2a_enum.Tlm_CODE_HK
     )
     tlm_EH_INDEX = download_eh_index_tlm()
-    check_rule_index("TEST0", 0, {'group': EL_GROUP_TEST_EH,  'local': 0, 'duplicate_id': 0, 'rule_id': EH_RULE_TEST0}, tlm_EH_INDEX)
-    check_rule_index("TEST1", 1, {'group': EL_GROUP_TEST_EH,  'local': 1, 'duplicate_id': 0, 'rule_id': EH_RULE_TEST1}, tlm_EH_INDEX)
-    check_rule_index("TEST3", 2, {'group': EL_GROUP_TEST_EH,  'local': 1, 'duplicate_id': 1, 'rule_id': EH_RULE_TEST3}, tlm_EH_INDEX)
-    check_rule_index("TEST4", 3, {'group': EL_GROUP_TEST_EH,  'local': 2, 'duplicate_id': 0, 'rule_id': EH_RULE_TEST4}, tlm_EH_INDEX)
-    check_rule_index("TEST5", 4, {'group': EL_GROUP_TEST_EH1, 'local': 0, 'duplicate_id': 0, 'rule_id': EH_RULE_TEST5}, tlm_EH_INDEX)
-    check_rule_index("TEST6", 5, {'group': EL_GROUP_TEST_EH1, 'local': 0, 'duplicate_id': 1, 'rule_id': EH_RULE_TEST6}, tlm_EH_INDEX)
-    check_rule_index("TEST7", 6, {'group': EL_GROUP_TEST_EH1, 'local': 1, 'duplicate_id': 0, 'rule_id': EH_RULE_TEST7}, tlm_EH_INDEX)
+    check_rule_index(
+        "TEST0",
+        0,
+        {"group": EL_GROUP_TEST_EH, "local": 0, "duplicate_id": 0, "rule_id": EH_RULE_TEST0},
+        tlm_EH_INDEX,
+    )
+    check_rule_index(
+        "TEST1",
+        1,
+        {"group": EL_GROUP_TEST_EH, "local": 1, "duplicate_id": 0, "rule_id": EH_RULE_TEST1},
+        tlm_EH_INDEX,
+    )
+    check_rule_index(
+        "TEST3",
+        2,
+        {"group": EL_GROUP_TEST_EH, "local": 1, "duplicate_id": 1, "rule_id": EH_RULE_TEST3},
+        tlm_EH_INDEX,
+    )
+    check_rule_index(
+        "TEST4",
+        3,
+        {"group": EL_GROUP_TEST_EH, "local": 2, "duplicate_id": 0, "rule_id": EH_RULE_TEST4},
+        tlm_EH_INDEX,
+    )
+    check_rule_index(
+        "TEST5",
+        4,
+        {"group": EL_GROUP_TEST_EH1, "local": 0, "duplicate_id": 0, "rule_id": EH_RULE_TEST5},
+        tlm_EH_INDEX,
+    )
+    check_rule_index(
+        "TEST6",
+        5,
+        {"group": EL_GROUP_TEST_EH1, "local": 0, "duplicate_id": 1, "rule_id": EH_RULE_TEST6},
+        tlm_EH_INDEX,
+    )
+    check_rule_index(
+        "TEST7",
+        6,
+        {"group": EL_GROUP_TEST_EH1, "local": 1, "duplicate_id": 0, "rule_id": EH_RULE_TEST7},
+        tlm_EH_INDEX,
+    )
 
     # 重複先頭
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EH_DELETE_RULE, (EH_RULE_TEST1, ), c2a_enum.Tlm_CODE_HK
+        ope, c2a_enum.Cmd_CODE_EH_DELETE_RULE, (EH_RULE_TEST1,), c2a_enum.Tlm_CODE_HK
     )
     tlm_EH_INDEX = download_eh_index_tlm()
-    check_rule_index("TEST0", 0, {'group': EL_GROUP_TEST_EH,  'local': 0, 'duplicate_id': 0, 'rule_id': EH_RULE_TEST0}, tlm_EH_INDEX)
-    check_rule_index("TEST3", 1, {'group': EL_GROUP_TEST_EH,  'local': 1, 'duplicate_id': 0, 'rule_id': EH_RULE_TEST3}, tlm_EH_INDEX)
-    check_rule_index("TEST4", 2, {'group': EL_GROUP_TEST_EH,  'local': 2, 'duplicate_id': 0, 'rule_id': EH_RULE_TEST4}, tlm_EH_INDEX)
-    check_rule_index("TEST5", 3, {'group': EL_GROUP_TEST_EH1, 'local': 0, 'duplicate_id': 0, 'rule_id': EH_RULE_TEST5}, tlm_EH_INDEX)
-    check_rule_index("TEST6", 4, {'group': EL_GROUP_TEST_EH1, 'local': 0, 'duplicate_id': 1, 'rule_id': EH_RULE_TEST6}, tlm_EH_INDEX)
-    check_rule_index("TEST7", 5, {'group': EL_GROUP_TEST_EH1, 'local': 1, 'duplicate_id': 0, 'rule_id': EH_RULE_TEST7}, tlm_EH_INDEX)
+    check_rule_index(
+        "TEST0",
+        0,
+        {"group": EL_GROUP_TEST_EH, "local": 0, "duplicate_id": 0, "rule_id": EH_RULE_TEST0},
+        tlm_EH_INDEX,
+    )
+    check_rule_index(
+        "TEST3",
+        1,
+        {"group": EL_GROUP_TEST_EH, "local": 1, "duplicate_id": 0, "rule_id": EH_RULE_TEST3},
+        tlm_EH_INDEX,
+    )
+    check_rule_index(
+        "TEST4",
+        2,
+        {"group": EL_GROUP_TEST_EH, "local": 2, "duplicate_id": 0, "rule_id": EH_RULE_TEST4},
+        tlm_EH_INDEX,
+    )
+    check_rule_index(
+        "TEST5",
+        3,
+        {"group": EL_GROUP_TEST_EH1, "local": 0, "duplicate_id": 0, "rule_id": EH_RULE_TEST5},
+        tlm_EH_INDEX,
+    )
+    check_rule_index(
+        "TEST6",
+        4,
+        {"group": EL_GROUP_TEST_EH1, "local": 0, "duplicate_id": 1, "rule_id": EH_RULE_TEST6},
+        tlm_EH_INDEX,
+    )
+    check_rule_index(
+        "TEST7",
+        5,
+        {"group": EL_GROUP_TEST_EH1, "local": 1, "duplicate_id": 0, "rule_id": EH_RULE_TEST7},
+        tlm_EH_INDEX,
+    )
 
     # 重複後ろ
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EH_DELETE_RULE, (EH_RULE_TEST6, ), c2a_enum.Tlm_CODE_HK
+        ope, c2a_enum.Cmd_CODE_EH_DELETE_RULE, (EH_RULE_TEST6,), c2a_enum.Tlm_CODE_HK
     )
     tlm_EH_INDEX = download_eh_index_tlm()
-    check_rule_index("TEST0", 0, {'group': EL_GROUP_TEST_EH,  'local': 0, 'duplicate_id': 0, 'rule_id': EH_RULE_TEST0}, tlm_EH_INDEX)
-    check_rule_index("TEST3", 1, {'group': EL_GROUP_TEST_EH,  'local': 1, 'duplicate_id': 0, 'rule_id': EH_RULE_TEST3}, tlm_EH_INDEX)
-    check_rule_index("TEST4", 2, {'group': EL_GROUP_TEST_EH,  'local': 2, 'duplicate_id': 0, 'rule_id': EH_RULE_TEST4}, tlm_EH_INDEX)
-    check_rule_index("TEST5", 3, {'group': EL_GROUP_TEST_EH1, 'local': 0, 'duplicate_id': 0, 'rule_id': EH_RULE_TEST5}, tlm_EH_INDEX)
-    check_rule_index("TEST7", 4, {'group': EL_GROUP_TEST_EH1, 'local': 1, 'duplicate_id': 0, 'rule_id': EH_RULE_TEST7}, tlm_EH_INDEX)
+    check_rule_index(
+        "TEST0",
+        0,
+        {"group": EL_GROUP_TEST_EH, "local": 0, "duplicate_id": 0, "rule_id": EH_RULE_TEST0},
+        tlm_EH_INDEX,
+    )
+    check_rule_index(
+        "TEST3",
+        1,
+        {"group": EL_GROUP_TEST_EH, "local": 1, "duplicate_id": 0, "rule_id": EH_RULE_TEST3},
+        tlm_EH_INDEX,
+    )
+    check_rule_index(
+        "TEST4",
+        2,
+        {"group": EL_GROUP_TEST_EH, "local": 2, "duplicate_id": 0, "rule_id": EH_RULE_TEST4},
+        tlm_EH_INDEX,
+    )
+    check_rule_index(
+        "TEST5",
+        3,
+        {"group": EL_GROUP_TEST_EH1, "local": 0, "duplicate_id": 0, "rule_id": EH_RULE_TEST5},
+        tlm_EH_INDEX,
+    )
+    check_rule_index(
+        "TEST7",
+        4,
+        {"group": EL_GROUP_TEST_EH1, "local": 1, "duplicate_id": 0, "rule_id": EH_RULE_TEST7},
+        tlm_EH_INDEX,
+    )
 
     # 先頭
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EH_DELETE_RULE, (EH_RULE_TEST0, ), c2a_enum.Tlm_CODE_HK
+        ope, c2a_enum.Cmd_CODE_EH_DELETE_RULE, (EH_RULE_TEST0,), c2a_enum.Tlm_CODE_HK
     )
     tlm_EH_INDEX = download_eh_index_tlm()
-    check_rule_index("TEST3", 0, {'group': EL_GROUP_TEST_EH,  'local': 1, 'duplicate_id': 0, 'rule_id': EH_RULE_TEST3}, tlm_EH_INDEX)
-    check_rule_index("TEST4", 1, {'group': EL_GROUP_TEST_EH,  'local': 2, 'duplicate_id': 0, 'rule_id': EH_RULE_TEST4}, tlm_EH_INDEX)
-    check_rule_index("TEST5", 2, {'group': EL_GROUP_TEST_EH1, 'local': 0, 'duplicate_id': 0, 'rule_id': EH_RULE_TEST5}, tlm_EH_INDEX)
-    check_rule_index("TEST7", 3, {'group': EL_GROUP_TEST_EH1, 'local': 1, 'duplicate_id': 0, 'rule_id': EH_RULE_TEST7}, tlm_EH_INDEX)
+    check_rule_index(
+        "TEST3",
+        0,
+        {"group": EL_GROUP_TEST_EH, "local": 1, "duplicate_id": 0, "rule_id": EH_RULE_TEST3},
+        tlm_EH_INDEX,
+    )
+    check_rule_index(
+        "TEST4",
+        1,
+        {"group": EL_GROUP_TEST_EH, "local": 2, "duplicate_id": 0, "rule_id": EH_RULE_TEST4},
+        tlm_EH_INDEX,
+    )
+    check_rule_index(
+        "TEST5",
+        2,
+        {"group": EL_GROUP_TEST_EH1, "local": 0, "duplicate_id": 0, "rule_id": EH_RULE_TEST5},
+        tlm_EH_INDEX,
+    )
+    check_rule_index(
+        "TEST7",
+        3,
+        {"group": EL_GROUP_TEST_EH1, "local": 1, "duplicate_id": 0, "rule_id": EH_RULE_TEST7},
+        tlm_EH_INDEX,
+    )
+
+    a
 
     # 後ろ
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EH_DELETE_RULE, (EH_RULE_TEST7, ), c2a_enum.Tlm_CODE_HK
+        ope, c2a_enum.Cmd_CODE_EH_DELETE_RULE, (EH_RULE_TEST7,), c2a_enum.Tlm_CODE_HK
     )
     tlm_EH_INDEX = download_eh_index_tlm()
-    check_rule_index("TEST3", 0, {'group': EL_GROUP_TEST_EH,  'local': 1, 'duplicate_id': 0, 'rule_id': EH_RULE_TEST3}, tlm_EH_INDEX)
-    check_rule_index("TEST4", 1, {'group': EL_GROUP_TEST_EH,  'local': 2, 'duplicate_id': 0, 'rule_id': EH_RULE_TEST4}, tlm_EH_INDEX)
-    check_rule_index("TEST5", 2, {'group': EL_GROUP_TEST_EH1, 'local': 0, 'duplicate_id': 0, 'rule_id': EH_RULE_TEST5}, tlm_EH_INDEX)
+    check_rule_index(
+        "TEST3",
+        0,
+        {"group": EL_GROUP_TEST_EH, "local": 1, "duplicate_id": 0, "rule_id": EH_RULE_TEST3},
+        tlm_EH_INDEX,
+    )
+    check_rule_index(
+        "TEST4",
+        1,
+        {"group": EL_GROUP_TEST_EH, "local": 2, "duplicate_id": 0, "rule_id": EH_RULE_TEST4},
+        tlm_EH_INDEX,
+    )
+    check_rule_index(
+        "TEST5",
+        2,
+        {"group": EL_GROUP_TEST_EH1, "local": 0, "duplicate_id": 0, "rule_id": EH_RULE_TEST5},
+        tlm_EH_INDEX,
+    )
 
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EH_DELETE_RULE, (EH_RULE_TEST4, ), c2a_enum.Tlm_CODE_HK
+        ope, c2a_enum.Cmd_CODE_EH_DELETE_RULE, (EH_RULE_TEST4,), c2a_enum.Tlm_CODE_HK
     )
     tlm_EH_INDEX = download_eh_index_tlm()
-    check_rule_index("TEST3", 0, {'group': EL_GROUP_TEST_EH,  'local': 1, 'duplicate_id': 0, 'rule_id': EH_RULE_TEST3}, tlm_EH_INDEX)
-    check_rule_index("TEST5", 1, {'group': EL_GROUP_TEST_EH1, 'local': 0, 'duplicate_id': 0, 'rule_id': EH_RULE_TEST5}, tlm_EH_INDEX)
+    check_rule_index(
+        "TEST3",
+        0,
+        {"group": EL_GROUP_TEST_EH, "local": 1, "duplicate_id": 0, "rule_id": EH_RULE_TEST3},
+        tlm_EH_INDEX,
+    )
+    check_rule_index(
+        "TEST5",
+        1,
+        {"group": EL_GROUP_TEST_EH1, "local": 0, "duplicate_id": 0, "rule_id": EH_RULE_TEST5},
+        tlm_EH_INDEX,
+    )
 
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EH_DELETE_RULE, (EH_RULE_TEST3, ), c2a_enum.Tlm_CODE_HK
+        ope, c2a_enum.Cmd_CODE_EH_DELETE_RULE, (EH_RULE_TEST3,), c2a_enum.Tlm_CODE_HK
     )
     tlm_EH_INDEX = download_eh_index_tlm()
-    check_rule_index("TEST5", 0, {'group': EL_GROUP_TEST_EH1, 'local': 0, 'duplicate_id': 0, 'rule_id': EH_RULE_TEST5}, tlm_EH_INDEX)
+    check_rule_index(
+        "TEST5",
+        0,
+        {"group": EL_GROUP_TEST_EH1, "local": 0, "duplicate_id": 0, "rule_id": EH_RULE_TEST5},
+        tlm_EH_INDEX,
+    )
 
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EH_DELETE_RULE, (EH_RULE_TEST5, ), c2a_enum.Tlm_CODE_HK
+        ope, c2a_enum.Cmd_CODE_EH_DELETE_RULE, (EH_RULE_TEST5,), c2a_enum.Tlm_CODE_HK
     )
     tlm_EH_INDEX = download_eh_index_tlm()
     check_rule_indexes_cleared()
@@ -519,7 +699,10 @@ def test_event_handler_check_counter():
 
     # テレメ設定
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EH_SET_TARGET_ID_OF_RULE_TABLE_FOR_TLM, (EH_RULE_TEST0,), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EH_SET_TARGET_ID_OF_RULE_TABLE_FOR_TLM,
+        (EH_RULE_TEST0,),
+        c2a_enum.Tlm_CODE_HK,
     )
 
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
@@ -553,15 +736,24 @@ def test_event_handler_clear_counter_by_event():
 
     # テレメ設定
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EH_SET_TARGET_ID_OF_RULE_TABLE_FOR_TLM, (EH_RULE_TEST3,), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EH_SET_TARGET_ID_OF_RULE_TABLE_FOR_TLM,
+        (EH_RULE_TEST3,),
+        c2a_enum.Tlm_CODE_HK,
     )
 
     # +2
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_RECORD_EVENT, (EL_GROUP_TEST_EH, 3, EL_ERROR_LEVEL_LOW, 0), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EL_RECORD_EVENT,
+        (EL_GROUP_TEST_EH, 3, EL_ERROR_LEVEL_LOW, 0),
+        c2a_enum.Tlm_CODE_HK,
     )
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_RECORD_EVENT, (EL_GROUP_TEST_EH, 3, EL_ERROR_LEVEL_LOW, 0), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EL_RECORD_EVENT,
+        (EL_GROUP_TEST_EH, 3, EL_ERROR_LEVEL_LOW, 0),
+        c2a_enum.Tlm_CODE_HK,
     )
 
     tlm_EH = download_eh_tlm()
@@ -570,7 +762,10 @@ def test_event_handler_clear_counter_by_event():
     # エラーレベル違い
     print("Cmd_EH_CLEAR_RULE_COUNTER_BY_EVENT")
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EH_CLEAR_RULE_COUNTER_BY_EVENT, (EL_GROUP_TEST_EH, 3, EL_ERROR_LEVEL_HIGH), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EH_CLEAR_RULE_COUNTER_BY_EVENT,
+        (EL_GROUP_TEST_EH, 3, EL_ERROR_LEVEL_HIGH),
+        c2a_enum.Tlm_CODE_HK,
     )
 
     tlm_EH = download_eh_tlm()
@@ -579,7 +774,10 @@ def test_event_handler_clear_counter_by_event():
     # クリアされるはず
     print("Cmd_EH_CLEAR_RULE_COUNTER_BY_EVENT")
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EH_CLEAR_RULE_COUNTER_BY_EVENT, (EL_GROUP_TEST_EH, 3, EL_ERROR_LEVEL_LOW), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EH_CLEAR_RULE_COUNTER_BY_EVENT,
+        (EL_GROUP_TEST_EH, 3, EL_ERROR_LEVEL_LOW),
+        c2a_enum.Tlm_CODE_HK,
     )
 
     tlm_EH = download_eh_tlm()
@@ -597,42 +795,61 @@ def test_event_handler_respond_single():
 
     # should_match_err_level == 1 の
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_RECORD_EVENT, (EL_GROUP_TEST_EH, 0, EL_ERROR_LEVEL_HIGH, 0), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EL_RECORD_EVENT,
+        (EL_GROUP_TEST_EH, 0, EL_ERROR_LEVEL_HIGH, 0),
+        c2a_enum.Tlm_CODE_HK,
     )
     exec_eh()
     assert check_respend_eh() == "not_responded"
 
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_RECORD_EVENT, (EL_GROUP_TEST_EH, 0, EL_ERROR_LEVEL_LOW, 0), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EL_RECORD_EVENT,
+        (EL_GROUP_TEST_EH, 0, EL_ERROR_LEVEL_LOW, 0),
+        c2a_enum.Tlm_CODE_HK,
     )
     exec_eh()
     assert check_respend_eh() == "responded"
 
     # inactivateされてしまうので動かないはず
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_RECORD_EVENT, (EL_GROUP_TEST_EH, 0, EL_ERROR_LEVEL_LOW, 0), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EL_RECORD_EVENT,
+        (EL_GROUP_TEST_EH, 0, EL_ERROR_LEVEL_LOW, 0),
+        c2a_enum.Tlm_CODE_HK,
     )
     exec_eh()
     assert check_respend_eh() == "not_responded"
 
     # activate
-    check_rule("TEST0", EH_RULE_TEST0, {'group': EL_GROUP_TEST_EH, 'local': 0, 'is_active': "INACTIVE"})
+    check_rule(
+        "TEST0", EH_RULE_TEST0, {"group": EL_GROUP_TEST_EH, "local": 0, "is_active": "INACTIVE"}
+    )
     print("Cmd_EH_ACTIVATE_RULE")
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
         ope, c2a_enum.Cmd_CODE_EH_ACTIVATE_RULE, (EH_RULE_TEST0,), c2a_enum.Tlm_CODE_HK
     )
-    check_rule("TEST0", EH_RULE_TEST0, {'group': EL_GROUP_TEST_EH, 'local': 0, 'is_active': "ACTIVE"})
+    check_rule(
+        "TEST0", EH_RULE_TEST0, {"group": EL_GROUP_TEST_EH, "local": 0, "is_active": "ACTIVE"}
+    )
 
     # これで再度動く
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_RECORD_EVENT, (EL_GROUP_TEST_EH, 0, EL_ERROR_LEVEL_LOW, 0), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EL_RECORD_EVENT,
+        (EL_GROUP_TEST_EH, 0, EL_ERROR_LEVEL_LOW, 0),
+        c2a_enum.Tlm_CODE_HK,
     )
     exec_eh()
     assert check_respend_eh() == "responded"
 
     # should_match_err_level == 0 の
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_RECORD_EVENT, (EL_GROUP_TEST_EH, 1, EL_ERROR_LEVEL_LOW, 0), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EL_RECORD_EVENT,
+        (EL_GROUP_TEST_EH, 1, EL_ERROR_LEVEL_LOW, 0),
+        c2a_enum.Tlm_CODE_HK,
     )
     exec_eh()
     assert check_respend_eh() == "responded"
@@ -641,7 +858,10 @@ def test_event_handler_respond_single():
         ope, c2a_enum.Cmd_CODE_EH_ACTIVATE_RULE, (EH_RULE_TEST1,), c2a_enum.Tlm_CODE_HK
     )
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_RECORD_EVENT, (EL_GROUP_TEST_EH, 1, EL_ERROR_LEVEL_HIGH, 0), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EL_RECORD_EVENT,
+        (EL_GROUP_TEST_EH, 1, EL_ERROR_LEVEL_HIGH, 0),
+        c2a_enum.Tlm_CODE_HK,
     )
     exec_eh()
     assert check_respend_eh() == "responded"
@@ -650,15 +870,22 @@ def test_event_handler_respond_single():
     )
 
     # inactivate
-    check_rule("TEST1", EH_RULE_TEST1, {'group': EL_GROUP_TEST_EH, 'local': 1, 'is_active': "ACTIVE"})
+    check_rule(
+        "TEST1", EH_RULE_TEST1, {"group": EL_GROUP_TEST_EH, "local": 1, "is_active": "ACTIVE"}
+    )
     print("Cmd_EH_INACTIVATE_RULE")
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
         ope, c2a_enum.Cmd_CODE_EH_INACTIVATE_RULE, (EH_RULE_TEST1,), c2a_enum.Tlm_CODE_HK
     )
-    check_rule("TEST1", EH_RULE_TEST1, {'group': EL_GROUP_TEST_EH, 'local': 1, 'is_active': "INACTIVE"})
+    check_rule(
+        "TEST1", EH_RULE_TEST1, {"group": EL_GROUP_TEST_EH, "local": 1, "is_active": "INACTIVE"}
+    )
 
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_RECORD_EVENT, (EL_GROUP_TEST_EH, 1, EL_ERROR_LEVEL_LOW, 0), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EL_RECORD_EVENT,
+        (EL_GROUP_TEST_EH, 1, EL_ERROR_LEVEL_LOW, 0),
+        c2a_enum.Tlm_CODE_HK,
     )
     exec_eh()
     assert check_respend_eh() == "not_responded"
@@ -681,14 +908,19 @@ def test_event_handler_respond_single_multiple():
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
         ope, c2a_enum.Cmd_CODE_EH_ACTIVATE_RULE, (EH_RULE_TEST4,), c2a_enum.Tlm_CODE_HK
     )
-    check_rule("TEST4", EH_RULE_TEST4, {'group': EL_GROUP_TEST_EH, 'local': 0, 'is_active': "ACTIVE"})
+    check_rule(
+        "TEST4", EH_RULE_TEST4, {"group": EL_GROUP_TEST_EH, "local": 0, "is_active": "ACTIVE"}
+    )
 
     # 発火
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_RECORD_EVENT, (EL_GROUP_TEST_EH, 0, EL_ERROR_LEVEL_LOW, 0), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EL_RECORD_EVENT,
+        (EL_GROUP_TEST_EH, 0, EL_ERROR_LEVEL_LOW, 0),
+        c2a_enum.Tlm_CODE_HK,
     )
     exec_eh()
-    assert check_respend_eh() == "responded"       # 少なくとも１つは動いた
+    assert check_respend_eh() == "responded"  # 少なくとも１つは動いた
 
     # カウンタの増加が +2 であることを確認
     tlm_EH = download_eh_tlm()
@@ -712,7 +944,10 @@ def test_event_handler_respond_continuous():
 
     # EL テレメで見れるように
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EH_SET_TARGET_ID_OF_RULE_TABLE_FOR_TLM, (EH_RULE_TEST2, ), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EH_SET_TARGET_ID_OF_RULE_TABLE_FOR_TLM,
+        (EH_RULE_TEST2,),
+        c2a_enum.Tlm_CODE_HK,
     )
 
     download_eh_log_tlm()
@@ -720,7 +955,10 @@ def test_event_handler_respond_continuous():
     for i in range(3):
         assert check_respend_eh() == "not_responded"
         assert "SUC" == wings.util.send_rt_cmd_and_confirm(
-            ope, c2a_enum.Cmd_CODE_EL_RECORD_EVENT, (EL_GROUP_TEST_EH, 2, EL_ERROR_LEVEL_LOW, 0), c2a_enum.Tlm_CODE_HK
+            ope,
+            c2a_enum.Cmd_CODE_EL_RECORD_EVENT,
+            (EL_GROUP_TEST_EH, 2, EL_ERROR_LEVEL_LOW, 0),
+            c2a_enum.Tlm_CODE_HK,
         )
         time.sleep(28)
     assert check_respend_eh() == "not_responded"
@@ -729,7 +967,10 @@ def test_event_handler_respond_continuous():
     for i in range(3):
         assert check_respend_eh() == "not_responded"
         assert "SUC" == wings.util.send_rt_cmd_and_confirm(
-            ope, c2a_enum.Cmd_CODE_EL_RECORD_EVENT, (EL_GROUP_TEST_EH, 2, EL_ERROR_LEVEL_LOW, 0), c2a_enum.Tlm_CODE_HK
+            ope,
+            c2a_enum.Cmd_CODE_EL_RECORD_EVENT,
+            (EL_GROUP_TEST_EH, 2, EL_ERROR_LEVEL_LOW, 0),
+            c2a_enum.Tlm_CODE_HK,
         )
     assert check_respend_eh() == "responded"
     download_eh_log_tlm()
@@ -749,13 +990,19 @@ def test_event_handler_respond_cumulative():
 
     # EL テレメで見れるように
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EH_SET_TARGET_ID_OF_RULE_TABLE_FOR_TLM, (EH_RULE_TEST3, ), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EH_SET_TARGET_ID_OF_RULE_TABLE_FOR_TLM,
+        (EH_RULE_TEST3,),
+        c2a_enum.Tlm_CODE_HK,
     )
 
     for i in range(3):
         assert check_respend_eh() == "not_responded"
         assert "SUC" == wings.util.send_rt_cmd_and_confirm(
-            ope, c2a_enum.Cmd_CODE_EL_RECORD_EVENT, (EL_GROUP_TEST_EH, 3, EL_ERROR_LEVEL_LOW, 0), c2a_enum.Tlm_CODE_HK
+            ope,
+            c2a_enum.Cmd_CODE_EL_RECORD_EVENT,
+            (EL_GROUP_TEST_EH, 3, EL_ERROR_LEVEL_LOW, 0),
+            c2a_enum.Tlm_CODE_HK,
         )
     assert check_respend_eh() == "responded"
 
@@ -775,35 +1022,114 @@ def test_event_handler_activate_and_inactivate_rule_for_multi_level():
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
         ope, c2a_enum.Cmd_CODE_EH_ACTIVATE_RULE, (EH_RULE_TEST5,), c2a_enum.Tlm_CODE_HK
     )
-    check_rule("TEST5", EH_RULE_TEST5, {'group': c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE, 'local': EH_RULE_TEST0, 'is_active': "ACTIVE"})
+    check_rule(
+        "TEST5",
+        EH_RULE_TEST5,
+        {
+            "group": c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE,
+            "local": EH_RULE_TEST0,
+            "is_active": "ACTIVE",
+        },
+    )
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
         ope, c2a_enum.Cmd_CODE_EH_ACTIVATE_RULE, (EH_RULE_TEST6,), c2a_enum.Tlm_CODE_HK
     )
-    check_rule("TEST6", EH_RULE_TEST6, {'group': c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE, 'local': EH_RULE_TEST5, 'is_active': "ACTIVE"})
+    check_rule(
+        "TEST6",
+        EH_RULE_TEST6,
+        {
+            "group": c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE,
+            "local": EH_RULE_TEST5,
+            "is_active": "ACTIVE",
+        },
+    )
 
     # inactivate Lv.1 to Lv.3
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EH_INACTIVATE_RULE_FOR_MULTI_LEVEL, (EH_RULE_TEST6,), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EH_INACTIVATE_RULE_FOR_MULTI_LEVEL,
+        (EH_RULE_TEST6,),
+        c2a_enum.Tlm_CODE_HK,
     )
-    check_rule("TEST6", EH_RULE_TEST6, {'group': c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE, 'local': EH_RULE_TEST5, 'is_active': "INACTIVE"})
-    check_rule("TEST6", EH_RULE_TEST5, {'group': c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE, 'local': EH_RULE_TEST0, 'is_active': "INACTIVE"})
-    check_rule("TEST0", EH_RULE_TEST0, {'group': EL_GROUP_TEST_EH, 'local': 0, 'is_active': "INACTIVE"})
+    check_rule(
+        "TEST6",
+        EH_RULE_TEST6,
+        {
+            "group": c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE,
+            "local": EH_RULE_TEST5,
+            "is_active": "INACTIVE",
+        },
+    )
+    check_rule(
+        "TEST6",
+        EH_RULE_TEST5,
+        {
+            "group": c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE,
+            "local": EH_RULE_TEST0,
+            "is_active": "INACTIVE",
+        },
+    )
+    check_rule(
+        "TEST0", EH_RULE_TEST0, {"group": EL_GROUP_TEST_EH, "local": 0, "is_active": "INACTIVE"}
+    )
 
     # activate Lv.1 to Lv.3
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EH_ACTIVATE_RULE_FOR_MULTI_LEVEL, (EH_RULE_TEST6,), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EH_ACTIVATE_RULE_FOR_MULTI_LEVEL,
+        (EH_RULE_TEST6,),
+        c2a_enum.Tlm_CODE_HK,
     )
-    check_rule("TEST6", EH_RULE_TEST6, {'group': c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE, 'local': EH_RULE_TEST5, 'is_active': "ACTIVE"})
-    check_rule("TEST6", EH_RULE_TEST5, {'group': c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE, 'local': EH_RULE_TEST0, 'is_active': "ACTIVE"})
-    check_rule("TEST0", EH_RULE_TEST0, {'group': EL_GROUP_TEST_EH, 'local': 0, 'is_active': "ACTIVE"})
+    check_rule(
+        "TEST6",
+        EH_RULE_TEST6,
+        {
+            "group": c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE,
+            "local": EH_RULE_TEST5,
+            "is_active": "ACTIVE",
+        },
+    )
+    check_rule(
+        "TEST6",
+        EH_RULE_TEST5,
+        {
+            "group": c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE,
+            "local": EH_RULE_TEST0,
+            "is_active": "ACTIVE",
+        },
+    )
+    check_rule(
+        "TEST0", EH_RULE_TEST0, {"group": EL_GROUP_TEST_EH, "local": 0, "is_active": "ACTIVE"}
+    )
 
     # inactivate Lv.1 to Lv.2
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EH_INACTIVATE_RULE_FOR_MULTI_LEVEL, (EH_RULE_TEST5,), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EH_INACTIVATE_RULE_FOR_MULTI_LEVEL,
+        (EH_RULE_TEST5,),
+        c2a_enum.Tlm_CODE_HK,
     )
-    check_rule("TEST6", EH_RULE_TEST6, {'group': c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE, 'local': EH_RULE_TEST5, 'is_active': "ACTIVE"})
-    check_rule("TEST6", EH_RULE_TEST5, {'group': c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE, 'local': EH_RULE_TEST0, 'is_active': "INACTIVE"})
-    check_rule("TEST0", EH_RULE_TEST0, {'group': EL_GROUP_TEST_EH, 'local': 0, 'is_active': "INACTIVE"})
+    check_rule(
+        "TEST6",
+        EH_RULE_TEST6,
+        {
+            "group": c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE,
+            "local": EH_RULE_TEST5,
+            "is_active": "ACTIVE",
+        },
+    )
+    check_rule(
+        "TEST6",
+        EH_RULE_TEST5,
+        {
+            "group": c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE,
+            "local": EH_RULE_TEST0,
+            "is_active": "INACTIVE",
+        },
+    )
+    check_rule(
+        "TEST0", EH_RULE_TEST0, {"group": EL_GROUP_TEST_EH, "local": 0, "is_active": "INACTIVE"}
+    )
 
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
         ope, c2a_enum.Cmd_CODE_EH_INACTIVATE_RULE, (EH_RULE_TEST6,), c2a_enum.Tlm_CODE_HK
@@ -811,11 +1137,32 @@ def test_event_handler_activate_and_inactivate_rule_for_multi_level():
 
     # activate Lv.1 to Lv.2
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EH_ACTIVATE_RULE_FOR_MULTI_LEVEL, (EH_RULE_TEST5,), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EH_ACTIVATE_RULE_FOR_MULTI_LEVEL,
+        (EH_RULE_TEST5,),
+        c2a_enum.Tlm_CODE_HK,
     )
-    check_rule("TEST6", EH_RULE_TEST6, {'group': c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE, 'local': EH_RULE_TEST5, 'is_active': "INACTIVE"})
-    check_rule("TEST6", EH_RULE_TEST5, {'group': c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE, 'local': EH_RULE_TEST0, 'is_active': "ACTIVE"})
-    check_rule("TEST0", EH_RULE_TEST0, {'group': EL_GROUP_TEST_EH, 'local': 0, 'is_active': "ACTIVE"})
+    check_rule(
+        "TEST6",
+        EH_RULE_TEST6,
+        {
+            "group": c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE,
+            "local": EH_RULE_TEST5,
+            "is_active": "INACTIVE",
+        },
+    )
+    check_rule(
+        "TEST6",
+        EH_RULE_TEST5,
+        {
+            "group": c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE,
+            "local": EH_RULE_TEST0,
+            "is_active": "ACTIVE",
+        },
+    )
+    check_rule(
+        "TEST0", EH_RULE_TEST0, {"group": EL_GROUP_TEST_EH, "local": 0, "is_active": "ACTIVE"}
+    )
 
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
         ope, c2a_enum.Cmd_CODE_EH_ACTIVATE_RULE, (EH_RULE_TEST6,), c2a_enum.Tlm_CODE_HK
@@ -823,11 +1170,32 @@ def test_event_handler_activate_and_inactivate_rule_for_multi_level():
 
     # inactivate only Lv.1
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EH_INACTIVATE_RULE_FOR_MULTI_LEVEL, (EH_RULE_TEST0,), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EH_INACTIVATE_RULE_FOR_MULTI_LEVEL,
+        (EH_RULE_TEST0,),
+        c2a_enum.Tlm_CODE_HK,
     )
-    check_rule("TEST6", EH_RULE_TEST6, {'group': c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE, 'local': EH_RULE_TEST5, 'is_active': "ACTIVE"})
-    check_rule("TEST6", EH_RULE_TEST5, {'group': c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE, 'local': EH_RULE_TEST0, 'is_active': "ACTIVE"})
-    check_rule("TEST0", EH_RULE_TEST0, {'group': EL_GROUP_TEST_EH, 'local': 0, 'is_active': "INACTIVE"})
+    check_rule(
+        "TEST6",
+        EH_RULE_TEST6,
+        {
+            "group": c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE,
+            "local": EH_RULE_TEST5,
+            "is_active": "ACTIVE",
+        },
+    )
+    check_rule(
+        "TEST6",
+        EH_RULE_TEST5,
+        {
+            "group": c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE,
+            "local": EH_RULE_TEST0,
+            "is_active": "ACTIVE",
+        },
+    )
+    check_rule(
+        "TEST0", EH_RULE_TEST0, {"group": EL_GROUP_TEST_EH, "local": 0, "is_active": "INACTIVE"}
+    )
 
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
         ope, c2a_enum.Cmd_CODE_EH_INACTIVATE_RULE, (EH_RULE_TEST6,), c2a_enum.Tlm_CODE_HK
@@ -838,11 +1206,32 @@ def test_event_handler_activate_and_inactivate_rule_for_multi_level():
 
     # activate only Lv.1
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EH_ACTIVATE_RULE_FOR_MULTI_LEVEL, (EH_RULE_TEST0,), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EH_ACTIVATE_RULE_FOR_MULTI_LEVEL,
+        (EH_RULE_TEST0,),
+        c2a_enum.Tlm_CODE_HK,
     )
-    check_rule("TEST6", EH_RULE_TEST6, {'group': c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE, 'local': EH_RULE_TEST5, 'is_active': "INACTIVE"})
-    check_rule("TEST6", EH_RULE_TEST5, {'group': c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE, 'local': EH_RULE_TEST0, 'is_active': "INACTIVE"})
-    check_rule("TEST0", EH_RULE_TEST0, {'group': EL_GROUP_TEST_EH, 'local': 0, 'is_active': "ACTIVE"})
+    check_rule(
+        "TEST6",
+        EH_RULE_TEST6,
+        {
+            "group": c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE,
+            "local": EH_RULE_TEST5,
+            "is_active": "INACTIVE",
+        },
+    )
+    check_rule(
+        "TEST6",
+        EH_RULE_TEST5,
+        {
+            "group": c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE,
+            "local": EH_RULE_TEST0,
+            "is_active": "INACTIVE",
+        },
+    )
+    check_rule(
+        "TEST0", EH_RULE_TEST0, {"group": EL_GROUP_TEST_EH, "local": 0, "is_active": "ACTIVE"}
+    )
 
 
 @pytest.mark.real
@@ -858,16 +1247,35 @@ def test_event_handler_respond_multi_level():
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
         ope, c2a_enum.Cmd_CODE_EH_ACTIVATE_RULE, (EH_RULE_TEST5,), c2a_enum.Tlm_CODE_HK
     )
-    check_rule("TEST5", EH_RULE_TEST5, {'group': c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE, 'local': EH_RULE_TEST0, 'is_active': "ACTIVE"})
+    check_rule(
+        "TEST5",
+        EH_RULE_TEST5,
+        {
+            "group": c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE,
+            "local": EH_RULE_TEST0,
+            "is_active": "ACTIVE",
+        },
+    )
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
         ope, c2a_enum.Cmd_CODE_EH_ACTIVATE_RULE, (EH_RULE_TEST6,), c2a_enum.Tlm_CODE_HK
     )
-    check_rule("TEST6", EH_RULE_TEST6, {'group': c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE, 'local': EH_RULE_TEST5, 'is_active': "ACTIVE"})
+    check_rule(
+        "TEST6",
+        EH_RULE_TEST6,
+        {
+            "group": c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE,
+            "local": EH_RULE_TEST5,
+            "is_active": "ACTIVE",
+        },
+    )
 
     # Lv.1 発火
     print("### Lv.1 ###")
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_RECORD_EVENT, (EL_GROUP_TEST_EH, 0, EL_ERROR_LEVEL_LOW, 0), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EL_RECORD_EVENT,
+        (EL_GROUP_TEST_EH, 0, EL_ERROR_LEVEL_LOW, 0),
+        c2a_enum.Tlm_CODE_HK,
     )
     exec_eh()
     assert check_respend_eh() == "responded"
@@ -879,7 +1287,9 @@ def test_event_handler_respond_multi_level():
     assert tlm_EL["EL.TLOGS.EH.EVENTS0.GROUP"] == c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE
     assert tlm_EL["EL.TLOGS.EH.EVENTS0.LOCAL"] == EH_RULE_TEST0
 
-    check_rule("TEST0", EH_RULE_TEST0, {'group': EL_GROUP_TEST_EH, 'local': 0, 'is_active': "INACTIVE"})
+    check_rule(
+        "TEST0", EH_RULE_TEST0, {"group": EL_GROUP_TEST_EH, "local": 0, "is_active": "INACTIVE"}
+    )
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
         ope, c2a_enum.Cmd_CODE_EH_ACTIVATE_RULE, (EH_RULE_TEST0,), c2a_enum.Tlm_CODE_HK
     )
@@ -887,7 +1297,10 @@ def test_event_handler_respond_multi_level():
     # Lv.2 発火 (Lv.1 はキャンセル)
     print("### Lv.2 ###")
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_RECORD_EVENT, (EL_GROUP_TEST_EH, 0, EL_ERROR_LEVEL_LOW, 0), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EL_RECORD_EVENT,
+        (EL_GROUP_TEST_EH, 0, EL_ERROR_LEVEL_LOW, 0),
+        c2a_enum.Tlm_CODE_HK,
     )
     exec_eh()
     assert check_respend_eh() == "responded"
@@ -897,7 +1310,10 @@ def test_event_handler_respond_multi_level():
     check_log(0, EH_RULE_TEST5, tlm_EH_LOG)
     check_log(1, EH_RULE_TEST0, tlm_EH_LOG)
     tlm_EL = download_el_tlm()
-    assert tlm_EL["EL.TLOGS.EH.EVENTS0.GROUP"] == c2a_enum.EL_CORE_GROUP_EH_RESPOND_WITH_HIGHER_LEVEL_RULE
+    assert (
+        tlm_EL["EL.TLOGS.EH.EVENTS0.GROUP"]
+        == c2a_enum.EL_CORE_GROUP_EH_RESPOND_WITH_HIGHER_LEVEL_RULE
+    )
     assert tlm_EL["EL.TLOGS.EH.EVENTS0.LOCAL"] == EH_RULE_TEST0
     assert tlm_EL["EL.TLOGS.EH.EVENTS1.GROUP"] == c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE
     assert tlm_EL["EL.TLOGS.EH.EVENTS1.LOCAL"] == EH_RULE_TEST5
@@ -906,16 +1322,32 @@ def test_event_handler_respond_multi_level():
     assert tlm_EL["EL.TLOGS.EH.EVENTS3.GROUP"] == c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE
     assert tlm_EL["EL.TLOGS.EH.EVENTS3.LOCAL"] == EH_RULE_TEST0
 
-    check_rule("TEST0", EH_RULE_TEST0, {'group': EL_GROUP_TEST_EH, 'local': 0, 'is_active': "INACTIVE"})
-    check_rule("TEST0", EH_RULE_TEST5, {'group': c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE, 'local': EH_RULE_TEST0, 'is_active': "INACTIVE"})
+    check_rule(
+        "TEST0", EH_RULE_TEST0, {"group": EL_GROUP_TEST_EH, "local": 0, "is_active": "INACTIVE"}
+    )
+    check_rule(
+        "TEST0",
+        EH_RULE_TEST5,
+        {
+            "group": c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE,
+            "local": EH_RULE_TEST0,
+            "is_active": "INACTIVE",
+        },
+    )
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EH_ACTIVATE_RULE_FOR_MULTI_LEVEL, (EH_RULE_TEST5,), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EH_ACTIVATE_RULE_FOR_MULTI_LEVEL,
+        (EH_RULE_TEST5,),
+        c2a_enum.Tlm_CODE_HK,
     )
 
     # Lv.1 発火
     print("### Lv.1 ###")
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_RECORD_EVENT, (EL_GROUP_TEST_EH, 0, EL_ERROR_LEVEL_LOW, 0), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EL_RECORD_EVENT,
+        (EL_GROUP_TEST_EH, 0, EL_ERROR_LEVEL_LOW, 0),
+        c2a_enum.Tlm_CODE_HK,
     )
     exec_eh()
     assert check_respend_eh() == "responded"
@@ -928,14 +1360,19 @@ def test_event_handler_respond_multi_level():
     tlm_EL = download_el_tlm()
     assert tlm_EL["EL.TLOGS.EH.EVENTS0.GROUP"] == c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE
     assert tlm_EL["EL.TLOGS.EH.EVENTS0.LOCAL"] == EH_RULE_TEST0
-    assert tlm_EL["EL.TLOGS.EH.EVENTS1.GROUP"] == c2a_enum.EL_CORE_GROUP_EH_RESPOND_WITH_HIGHER_LEVEL_RULE
+    assert (
+        tlm_EL["EL.TLOGS.EH.EVENTS1.GROUP"]
+        == c2a_enum.EL_CORE_GROUP_EH_RESPOND_WITH_HIGHER_LEVEL_RULE
+    )
     assert tlm_EL["EL.TLOGS.EH.EVENTS1.LOCAL"] == EH_RULE_TEST0
     assert tlm_EL["EL.TLOGS.EH.EVENTS2.GROUP"] == c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE
     assert tlm_EL["EL.TLOGS.EH.EVENTS2.LOCAL"] == EH_RULE_TEST5
     assert tlm_EL["EL.TLOGS.EH.EVENTS3.GROUP"] == c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE
     assert tlm_EL["EL.TLOGS.EH.EVENTS3.LOCAL"] == EH_RULE_TEST0
 
-    check_rule("TEST0", EH_RULE_TEST0, {'group': EL_GROUP_TEST_EH, 'local': 0, 'is_active': "INACTIVE"})
+    check_rule(
+        "TEST0", EH_RULE_TEST0, {"group": EL_GROUP_TEST_EH, "local": 0, "is_active": "INACTIVE"}
+    )
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
         ope, c2a_enum.Cmd_CODE_EH_ACTIVATE_RULE, (EH_RULE_TEST0,), c2a_enum.Tlm_CODE_HK
     )
@@ -943,7 +1380,10 @@ def test_event_handler_respond_multi_level():
     # Lv.3 発火 (Lv.1,2 はキャンセル)
     print("### Lv.3 ###")
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_RECORD_EVENT, (EL_GROUP_TEST_EH, 0, EL_ERROR_LEVEL_LOW, 0), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EL_RECORD_EVENT,
+        (EL_GROUP_TEST_EH, 0, EL_ERROR_LEVEL_LOW, 0),
+        c2a_enum.Tlm_CODE_HK,
     )
     exec_eh()
     assert check_respend_eh() == "responded"
@@ -955,18 +1395,42 @@ def test_event_handler_respond_multi_level():
     check_log(2, EH_RULE_TEST5, tlm_EH_LOG)
     check_log(3, EH_RULE_TEST0, tlm_EH_LOG)
     tlm_EL = download_el_tlm()
-    assert tlm_EL["EL.TLOGS.EH.EVENTS0.GROUP"] == c2a_enum.EL_CORE_GROUP_EH_RESPOND_WITH_HIGHER_LEVEL_RULE
+    assert (
+        tlm_EL["EL.TLOGS.EH.EVENTS0.GROUP"]
+        == c2a_enum.EL_CORE_GROUP_EH_RESPOND_WITH_HIGHER_LEVEL_RULE
+    )
     assert tlm_EL["EL.TLOGS.EH.EVENTS0.LOCAL"] == EH_RULE_TEST0
-    assert tlm_EL["EL.TLOGS.EH.EVENTS1.GROUP"] == c2a_enum.EL_CORE_GROUP_EH_RESPOND_WITH_HIGHER_LEVEL_RULE
+    assert (
+        tlm_EL["EL.TLOGS.EH.EVENTS1.GROUP"]
+        == c2a_enum.EL_CORE_GROUP_EH_RESPOND_WITH_HIGHER_LEVEL_RULE
+    )
     assert tlm_EL["EL.TLOGS.EH.EVENTS1.LOCAL"] == EH_RULE_TEST5
     assert tlm_EL["EL.TLOGS.EH.EVENTS2.GROUP"] == c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE
     assert tlm_EL["EL.TLOGS.EH.EVENTS2.LOCAL"] == EH_RULE_TEST6
     assert tlm_EL["EL.TLOGS.EH.EVENTS3.GROUP"] == c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE
     assert tlm_EL["EL.TLOGS.EH.EVENTS3.LOCAL"] == EH_RULE_TEST5
 
-    check_rule("TEST0", EH_RULE_TEST0, {'group': EL_GROUP_TEST_EH, 'local': 0, 'is_active': "INACTIVE"})
-    check_rule("TEST0", EH_RULE_TEST5, {'group': c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE, 'local': EH_RULE_TEST0, 'is_active': "INACTIVE"})
-    check_rule("TEST0", EH_RULE_TEST6, {'group': c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE, 'local': EH_RULE_TEST5, 'is_active': "INACTIVE"})
+    check_rule(
+        "TEST0", EH_RULE_TEST0, {"group": EL_GROUP_TEST_EH, "local": 0, "is_active": "INACTIVE"}
+    )
+    check_rule(
+        "TEST0",
+        EH_RULE_TEST5,
+        {
+            "group": c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE,
+            "local": EH_RULE_TEST0,
+            "is_active": "INACTIVE",
+        },
+    )
+    check_rule(
+        "TEST0",
+        EH_RULE_TEST6,
+        {
+            "group": c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE,
+            "local": EH_RULE_TEST5,
+            "is_active": "INACTIVE",
+        },
+    )
 
 
 @pytest.mark.real
@@ -985,7 +1449,10 @@ def test_event_handler_responded_log():
     check_log(2, EH_RULE_MAX, tlm_EH_LOG)
 
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_RECORD_EVENT, (EL_GROUP_TEST_EH, 0, EL_ERROR_LEVEL_LOW, 0), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EL_RECORD_EVENT,
+        (EL_GROUP_TEST_EH, 0, EL_ERROR_LEVEL_LOW, 0),
+        c2a_enum.Tlm_CODE_HK,
     )
     exec_eh()
     assert check_respend_eh() == "responded"
@@ -999,7 +1466,10 @@ def test_event_handler_responded_log():
     check_log(2, EH_RULE_MAX, tlm_EH_LOG)
 
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_RECORD_EVENT, (EL_GROUP_TEST_EH, 1, EL_ERROR_LEVEL_LOW, 0), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EL_RECORD_EVENT,
+        (EL_GROUP_TEST_EH, 1, EL_ERROR_LEVEL_LOW, 0),
+        c2a_enum.Tlm_CODE_HK,
     )
     exec_eh()
     assert check_respend_eh() == "responded"
@@ -1084,13 +1554,16 @@ def download_el_tlm():
 def check_rule(name, rule_id, settings):
     print("check_rule: " + name)
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EH_SET_TARGET_ID_OF_RULE_TABLE_FOR_TLM, (rule_id, ), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EH_SET_TARGET_ID_OF_RULE_TABLE_FOR_TLM,
+        (rule_id,),
+        c2a_enum.Tlm_CODE_HK,
     )
     tlm_EH = download_eh_tlm()
     assert tlm_EH["EH.TLM_INFO.RULE.TARGET_RULE_ID"] == rule_id
-    assert tlm_EH["EH.TARTGET_RULE.SETTINGS.EVENT.GROUP"] == settings['group']
-    assert tlm_EH["EH.TARTGET_RULE.SETTINGS.EVENT.LOCAL"] == settings['local']
-    assert tlm_EH["EH.TARTGET_RULE.SETTINGS.IS_ACTIVE"] == settings['is_active']
+    assert tlm_EH["EH.TARTGET_RULE.SETTINGS.EVENT.GROUP"] == settings["group"]
+    assert tlm_EH["EH.TARTGET_RULE.SETTINGS.EVENT.LOCAL"] == settings["local"]
+    assert tlm_EH["EH.TARTGET_RULE.SETTINGS.IS_ACTIVE"] == settings["is_active"]
 
 
 def check_log(index, id, tlm_EH_LOG):
@@ -1100,33 +1573,59 @@ def check_log(index, id, tlm_EH_LOG):
 
 def check_rule_index(name, id, settings, tlm_EH_INDEX):
     print("check_rule_index: " + name + ", id: " + str(id))
-    assert tlm_EH_INDEX["EH_INDEX.IDX" + str(id) + ".GROUP"] == settings['group']
-    assert tlm_EH_INDEX["EH_INDEX.IDX" + str(id) + ".LOCAL"] == settings['local']
-    assert tlm_EH_INDEX["EH_INDEX.IDX" + str(id) + ".DUPLICATE_ID"] == settings['duplicate_id']
-    assert tlm_EH_INDEX["EH_INDEX.IDX" + str(id) + ".RULE_ID"] == settings['rule_id']
+    assert tlm_EH_INDEX["EH_INDEX.IDX" + str(id) + ".GROUP"] == settings["group"]
+    assert tlm_EH_INDEX["EH_INDEX.IDX" + str(id) + ".LOCAL"] == settings["local"]
+    assert tlm_EH_INDEX["EH_INDEX.IDX" + str(id) + ".DUPLICATE_ID"] == settings["duplicate_id"]
+    assert tlm_EH_INDEX["EH_INDEX.IDX" + str(id) + ".RULE_ID"] == settings["rule_id"]
 
 
 def check_default_rules():
     print("check_default_rules")
-    check_rule("TEST0", EH_RULE_TEST0, {'group': EL_GROUP_TEST_EH, 'local': 0, 'is_active': "ACTIVE"})
-    check_rule("TEST1", EH_RULE_TEST1, {'group': EL_GROUP_TEST_EH, 'local': 1, 'is_active': "ACTIVE"})
-    check_rule("TEST2", EH_RULE_TEST2, {'group': EL_GROUP_TEST_EH, 'local': 2, 'is_active': "ACTIVE"})
-    check_rule("TEST3", EH_RULE_TEST3, {'group': EL_GROUP_TEST_EH, 'local': 3, 'is_active': "ACTIVE"})
-    check_rule("TEST4", EH_RULE_TEST4, {'group': EL_GROUP_TEST_EH, 'local': 0, 'is_active': "INACTIVE"})
-    check_rule("TEST5", EH_RULE_TEST5, {'group': c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE, 'local': EH_RULE_TEST0, 'is_active': "INACTIVE"})
-    check_rule("TEST6", EH_RULE_TEST6, {'group': c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE, 'local': EH_RULE_TEST5, 'is_active': "INACTIVE"})
+    check_rule(
+        "TEST0", EH_RULE_TEST0, {"group": EL_GROUP_TEST_EH, "local": 0, "is_active": "ACTIVE"}
+    )
+    check_rule(
+        "TEST1", EH_RULE_TEST1, {"group": EL_GROUP_TEST_EH, "local": 1, "is_active": "ACTIVE"}
+    )
+    check_rule(
+        "TEST2", EH_RULE_TEST2, {"group": EL_GROUP_TEST_EH, "local": 2, "is_active": "ACTIVE"}
+    )
+    check_rule(
+        "TEST3", EH_RULE_TEST3, {"group": EL_GROUP_TEST_EH, "local": 3, "is_active": "ACTIVE"}
+    )
+    check_rule(
+        "TEST4", EH_RULE_TEST4, {"group": EL_GROUP_TEST_EH, "local": 0, "is_active": "INACTIVE"}
+    )
+    check_rule(
+        "TEST5",
+        EH_RULE_TEST5,
+        {
+            "group": c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE,
+            "local": EH_RULE_TEST0,
+            "is_active": "INACTIVE",
+        },
+    )
+    check_rule(
+        "TEST6",
+        EH_RULE_TEST6,
+        {
+            "group": c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE,
+            "local": EH_RULE_TEST5,
+            "is_active": "INACTIVE",
+        },
+    )
 
 
 def check_rules_cleared():
     print("check_default_rule_cleared")
-    check_rule("TEST0", EH_RULE_TEST0, {'group': 0, 'local': 0, 'is_active': "INACTIVE"})
-    check_rule("TEST1", EH_RULE_TEST1, {'group': 0, 'local': 0, 'is_active': "INACTIVE"})
-    check_rule("TEST2", EH_RULE_TEST2, {'group': 0, 'local': 0, 'is_active': "INACTIVE"})
-    check_rule("TEST3", EH_RULE_TEST3, {'group': 0, 'local': 0, 'is_active': "INACTIVE"})
-    check_rule("TEST4", EH_RULE_TEST3, {'group': 0, 'local': 0, 'is_active': "INACTIVE"})
-    check_rule("TEST5", EH_RULE_TEST3, {'group': 0, 'local': 0, 'is_active': "INACTIVE"})
-    check_rule("TEST6", EH_RULE_TEST3, {'group': 0, 'local': 0, 'is_active': "INACTIVE"})
-    check_rule("TEST7", EH_RULE_TEST3, {'group': 0, 'local': 0, 'is_active': "INACTIVE"})
+    check_rule("TEST0", EH_RULE_TEST0, {"group": 0, "local": 0, "is_active": "INACTIVE"})
+    check_rule("TEST1", EH_RULE_TEST1, {"group": 0, "local": 0, "is_active": "INACTIVE"})
+    check_rule("TEST2", EH_RULE_TEST2, {"group": 0, "local": 0, "is_active": "INACTIVE"})
+    check_rule("TEST3", EH_RULE_TEST3, {"group": 0, "local": 0, "is_active": "INACTIVE"})
+    check_rule("TEST4", EH_RULE_TEST3, {"group": 0, "local": 0, "is_active": "INACTIVE"})
+    check_rule("TEST5", EH_RULE_TEST3, {"group": 0, "local": 0, "is_active": "INACTIVE"})
+    check_rule("TEST6", EH_RULE_TEST3, {"group": 0, "local": 0, "is_active": "INACTIVE"})
+    check_rule("TEST7", EH_RULE_TEST3, {"group": 0, "local": 0, "is_active": "INACTIVE"})
 
 
 def check_default_rule_indexes():
@@ -1135,16 +1634,61 @@ def check_default_rule_indexes():
 
     print("Cmd_EH_SET_PAGE_OF_RULE_SORTED_IDX_FOR_TLM")
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EH_SET_PAGE_OF_RULE_SORTED_IDX_FOR_TLM, (0, ), c2a_enum.Tlm_CODE_HK
+        ope, c2a_enum.Cmd_CODE_EH_SET_PAGE_OF_RULE_SORTED_IDX_FOR_TLM, (0,), c2a_enum.Tlm_CODE_HK
     )
     tlm_EH_INDEX = download_eh_index_tlm()
-    check_rule_index("TEST0", 2, {'group': EL_GROUP_TEST_EH, 'local': 0, 'duplicate_id': 0, 'rule_id': EH_RULE_TEST0}, tlm_EH_INDEX)
-    check_rule_index("TEST1", 4, {'group': EL_GROUP_TEST_EH, 'local': 1, 'duplicate_id': 0, 'rule_id': EH_RULE_TEST1}, tlm_EH_INDEX)
-    check_rule_index("TEST2", 5, {'group': EL_GROUP_TEST_EH, 'local': 2, 'duplicate_id': 0, 'rule_id': EH_RULE_TEST2}, tlm_EH_INDEX)
-    check_rule_index("TEST3", 6, {'group': EL_GROUP_TEST_EH, 'local': 3, 'duplicate_id': 0, 'rule_id': EH_RULE_TEST3}, tlm_EH_INDEX)
-    check_rule_index("TEST4", 3, {'group': EL_GROUP_TEST_EH, 'local': 0, 'duplicate_id': 1, 'rule_id': EH_RULE_TEST4}, tlm_EH_INDEX)
-    check_rule_index("TEST5", 0, {'group': c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE, 'local': EH_RULE_TEST0, 'duplicate_id': 0, 'rule_id': EH_RULE_TEST5}, tlm_EH_INDEX)
-    check_rule_index("TEST6", 1, {'group': c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE, 'local': EH_RULE_TEST5, 'duplicate_id': 0, 'rule_id': EH_RULE_TEST6}, tlm_EH_INDEX)
+    check_rule_index(
+        "TEST0",
+        2,
+        {"group": EL_GROUP_TEST_EH, "local": 0, "duplicate_id": 0, "rule_id": EH_RULE_TEST0},
+        tlm_EH_INDEX,
+    )
+    check_rule_index(
+        "TEST1",
+        4,
+        {"group": EL_GROUP_TEST_EH, "local": 1, "duplicate_id": 0, "rule_id": EH_RULE_TEST1},
+        tlm_EH_INDEX,
+    )
+    check_rule_index(
+        "TEST2",
+        5,
+        {"group": EL_GROUP_TEST_EH, "local": 2, "duplicate_id": 0, "rule_id": EH_RULE_TEST2},
+        tlm_EH_INDEX,
+    )
+    check_rule_index(
+        "TEST3",
+        6,
+        {"group": EL_GROUP_TEST_EH, "local": 3, "duplicate_id": 0, "rule_id": EH_RULE_TEST3},
+        tlm_EH_INDEX,
+    )
+    check_rule_index(
+        "TEST4",
+        3,
+        {"group": EL_GROUP_TEST_EH, "local": 0, "duplicate_id": 1, "rule_id": EH_RULE_TEST4},
+        tlm_EH_INDEX,
+    )
+    check_rule_index(
+        "TEST5",
+        0,
+        {
+            "group": c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE,
+            "local": EH_RULE_TEST0,
+            "duplicate_id": 0,
+            "rule_id": EH_RULE_TEST5,
+        },
+        tlm_EH_INDEX,
+    )
+    check_rule_index(
+        "TEST6",
+        1,
+        {
+            "group": c2a_enum.EL_CORE_GROUP_EH_MATCH_RULE,
+            "local": EH_RULE_TEST5,
+            "duplicate_id": 0,
+            "rule_id": EH_RULE_TEST6,
+        },
+        tlm_EH_INDEX,
+    )
 
 
 def check_rule_indexes_cleared():
@@ -1152,17 +1696,33 @@ def check_rule_indexes_cleared():
 
     print("Cmd_EH_SET_PAGE_OF_RULE_SORTED_IDX_FOR_TLM")
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EH_SET_PAGE_OF_RULE_SORTED_IDX_FOR_TLM, (0, ), c2a_enum.Tlm_CODE_HK
+        ope, c2a_enum.Cmd_CODE_EH_SET_PAGE_OF_RULE_SORTED_IDX_FOR_TLM, (0,), c2a_enum.Tlm_CODE_HK
     )
     tlm_EH_INDEX = download_eh_index_tlm()
-    check_rule_index("0", 0, {'group': 0, 'local': 0, 'duplicate_id': 0, 'rule_id': EH_RULE_MAX}, tlm_EH_INDEX)
-    check_rule_index("1", 1, {'group': 0, 'local': 0, 'duplicate_id': 0, 'rule_id': EH_RULE_MAX}, tlm_EH_INDEX)
-    check_rule_index("2", 2, {'group': 0, 'local': 0, 'duplicate_id': 0, 'rule_id': EH_RULE_MAX}, tlm_EH_INDEX)
-    check_rule_index("3", 3, {'group': 0, 'local': 0, 'duplicate_id': 0, 'rule_id': EH_RULE_MAX}, tlm_EH_INDEX)
-    check_rule_index("4", 4, {'group': 0, 'local': 0, 'duplicate_id': 0, 'rule_id': EH_RULE_MAX}, tlm_EH_INDEX)
-    check_rule_index("5", 5, {'group': 0, 'local': 0, 'duplicate_id': 0, 'rule_id': EH_RULE_MAX}, tlm_EH_INDEX)
-    check_rule_index("6", 6, {'group': 0, 'local': 0, 'duplicate_id': 0, 'rule_id': EH_RULE_MAX}, tlm_EH_INDEX)
-    check_rule_index("7", 7, {'group': 0, 'local': 0, 'duplicate_id': 0, 'rule_id': EH_RULE_MAX}, tlm_EH_INDEX)
+    check_rule_index(
+        "0", 0, {"group": 0, "local": 0, "duplicate_id": 0, "rule_id": EH_RULE_MAX}, tlm_EH_INDEX
+    )
+    check_rule_index(
+        "1", 1, {"group": 0, "local": 0, "duplicate_id": 0, "rule_id": EH_RULE_MAX}, tlm_EH_INDEX
+    )
+    check_rule_index(
+        "2", 2, {"group": 0, "local": 0, "duplicate_id": 0, "rule_id": EH_RULE_MAX}, tlm_EH_INDEX
+    )
+    check_rule_index(
+        "3", 3, {"group": 0, "local": 0, "duplicate_id": 0, "rule_id": EH_RULE_MAX}, tlm_EH_INDEX
+    )
+    check_rule_index(
+        "4", 4, {"group": 0, "local": 0, "duplicate_id": 0, "rule_id": EH_RULE_MAX}, tlm_EH_INDEX
+    )
+    check_rule_index(
+        "5", 5, {"group": 0, "local": 0, "duplicate_id": 0, "rule_id": EH_RULE_MAX}, tlm_EH_INDEX
+    )
+    check_rule_index(
+        "6", 6, {"group": 0, "local": 0, "duplicate_id": 0, "rule_id": EH_RULE_MAX}, tlm_EH_INDEX
+    )
+    check_rule_index(
+        "7", 7, {"group": 0, "local": 0, "duplicate_id": 0, "rule_id": EH_RULE_MAX}, tlm_EH_INDEX
+    )
 
 
 def set_param_of_reg_from_cmd_eh_rule(rule_id, settings):
@@ -1170,27 +1730,29 @@ def set_param_of_reg_from_cmd_eh_rule(rule_id, settings):
 
     print("Cmd_EH_SET_REGISTER_RULE_EVENT_PARAM")
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EH_SET_REGISTER_RULE_EVENT_PARAM,
+        ope,
+        c2a_enum.Cmd_CODE_EH_SET_REGISTER_RULE_EVENT_PARAM,
         (
             rule_id,
-            settings['event']['group'],
-            settings['event']['local'],
-            settings['event']['err_level'],
-            settings['should_match_err_level'],
-            settings['deploy_bct_id']
+            settings["event"]["group"],
+            settings["event"]["local"],
+            settings["event"]["err_level"],
+            settings["should_match_err_level"],
+            settings["deploy_bct_id"],
         ),
-        c2a_enum.Tlm_CODE_HK
+        c2a_enum.Tlm_CODE_HK,
     )
     print("Cmd_EH_SET_REGISTER_RULE_CONDITION_PARAM")
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EH_SET_REGISTER_RULE_CONDITION_PARAM,
+        ope,
+        c2a_enum.Cmd_CODE_EH_SET_REGISTER_RULE_CONDITION_PARAM,
         (
-            settings['condition']['type'],
-            settings['condition']['count_threshold'],
-            settings['condition']['time_threshold_ms'],
-            settings['is_active']
+            settings["condition"]["type"],
+            settings["condition"]["count_threshold"],
+            settings["condition"]["time_threshold_ms"],
+            settings["is_active"],
         ),
-        c2a_enum.Tlm_CODE_HK
+        c2a_enum.Tlm_CODE_HK,
     )
 
 
@@ -1200,15 +1762,30 @@ def check_reg_from_cmd_eh_rule_param(rule_id, settings):
     tlm_EH = download_eh_tlm()
 
     assert tlm_EH["EH.REG_FROM_CMD.RULE_ID"] == rule_id
-    assert tlm_EH["EH.REG_FROM_CMD.SETTINGS.EVENT.GROUP"] == settings['event']['group']
-    assert tlm_EH["EH.REG_FROM_CMD.SETTINGS.EVENT.LOCAL"] == settings['event']['local']
-    assert tlm_EH["EH.REG_FROM_CMD.SETTINGS.EVENT.ERR_LEVEL"] == conv_to_err_level[settings['event']['err_level']]
-    assert tlm_EH["EH.REG_FROM_CMD.SETTINGS.SHOULD_MATCH_ERR_LEVEL"] == conv_to_match_flag[settings['should_match_err_level']]
-    assert tlm_EH["EH.REG_FROM_CMD.SETTINGS.IS_ACTIVE"] == conv_to_active[settings['is_active']]
-    assert tlm_EH["EH.REG_FROM_CMD.SETTINGS.CONDITION.TYPE"] == conv_to_condition_type[settings['condition']['type']]
-    assert tlm_EH["EH.REG_FROM_CMD.SETTINGS.CONDITION.COUNT_THRESHOLD"] == settings['condition']['count_threshold']
-    assert tlm_EH["EH.REG_FROM_CMD.SETTINGS.CONDITION.TIME_THRESHOLD_MS"] == settings['condition']['time_threshold_ms']
-    assert tlm_EH["EH.REG_FROM_CMD.SETTINGS.DEPLOY_BCT_ID"] == settings['deploy_bct_id']
+    assert tlm_EH["EH.REG_FROM_CMD.SETTINGS.EVENT.GROUP"] == settings["event"]["group"]
+    assert tlm_EH["EH.REG_FROM_CMD.SETTINGS.EVENT.LOCAL"] == settings["event"]["local"]
+    assert (
+        tlm_EH["EH.REG_FROM_CMD.SETTINGS.EVENT.ERR_LEVEL"]
+        == conv_to_err_level[settings["event"]["err_level"]]
+    )
+    assert (
+        tlm_EH["EH.REG_FROM_CMD.SETTINGS.SHOULD_MATCH_ERR_LEVEL"]
+        == conv_to_match_flag[settings["should_match_err_level"]]
+    )
+    assert tlm_EH["EH.REG_FROM_CMD.SETTINGS.IS_ACTIVE"] == conv_to_active[settings["is_active"]]
+    assert (
+        tlm_EH["EH.REG_FROM_CMD.SETTINGS.CONDITION.TYPE"]
+        == conv_to_condition_type[settings["condition"]["type"]]
+    )
+    assert (
+        tlm_EH["EH.REG_FROM_CMD.SETTINGS.CONDITION.COUNT_THRESHOLD"]
+        == settings["condition"]["count_threshold"]
+    )
+    assert (
+        tlm_EH["EH.REG_FROM_CMD.SETTINGS.CONDITION.TIME_THRESHOLD_MS"]
+        == settings["condition"]["time_threshold_ms"]
+    )
+    assert tlm_EH["EH.REG_FROM_CMD.SETTINGS.DEPLOY_BCT_ID"] == settings["deploy_bct_id"]
 
 
 def register_rule():
@@ -1232,7 +1809,7 @@ def check_respend_eh():
     # download_eh_tlm()
 
     (group, local, err_level) = get_latest_event()
-    if (group == EL_GROUP_TEST_EH_RESPOND and local == 0 and err_level == "LOW"):
+    if group == EL_GROUP_TEST_EH_RESPOND and local == 0 and err_level == "LOW":
         return "responded"
     else:
         return "not_responded"
@@ -1244,7 +1821,11 @@ def get_latest_event():
     tlm_EL = wings.util.generate_and_receive_tlm(
         ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_EL
     )
-    return (tlm_EL["EL.LATEST_EVENT.GROUP"], tlm_EL["EL.LATEST_EVENT.LOCAL"], tlm_EL["EL.LATEST_EVENT.ERR_LEVEL"])
+    return (
+        tlm_EL["EL.LATEST_EVENT.GROUP"],
+        tlm_EL["EL.LATEST_EVENT.LOCAL"],
+        tlm_EL["EL.LATEST_EVENT.ERR_LEVEL"],
+    )
 
 
 def exec_eh():

--- a/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/EventManager/test_event_handler.py
+++ b/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/EventManager/test_event_handler.py
@@ -627,8 +627,6 @@ def test_event_handler_check_index():
         tlm_EH_INDEX,
     )
 
-    a
-
     # 後ろ
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
         ope, c2a_enum.Cmd_CODE_EH_DELETE_RULE, (EH_RULE_TEST7,), c2a_enum.Tlm_CODE_HK

--- a/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/EventManager/test_event_handler.py
+++ b/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/EventManager/test_event_handler.py
@@ -73,6 +73,7 @@ conv_to_condition_type = {0: "SINGLE", 1: "CONTINUOUS", 2: "CUMULATIVE"}
 # TODO: カウンタのクリアを入れたら足す
 # TODO: EH対応EL発行を入れたら，色々変えないとダメ
 
+
 # 各種設定の確認など
 @pytest.mark.real
 @pytest.mark.sils

--- a/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/EventManager/test_event_logger.py
+++ b/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/EventManager/test_event_logger.py
@@ -97,7 +97,7 @@ g_clog_capacity_pre = g_clog_capacity
 def test_event_logger_init_check():
     update_all_tlm()
 
-    ### 初期化
+    # ### 初期化
     ret = wings.util.send_rt_cmd_and_confirm(
         ope, c2a_enum.Cmd_CODE_EL_INIT, (), c2a_enum.Tlm_CODE_HK
     )
@@ -147,7 +147,7 @@ def test_event_logger_set_params():
 @pytest.mark.real
 @pytest.mark.sils
 def test_event_logger_record_event():
-    ### 初期化
+    # ### 初期化
     ret = wings.util.send_rt_cmd_and_confirm(
         ope, c2a_enum.Cmd_CODE_EL_INIT, (), c2a_enum.Tlm_CODE_HK
     )
@@ -156,7 +156,7 @@ def test_event_logger_record_event():
     change_clog_tlm_page(0, EL_ERROR_LEVEL_HIGH)
     update_all_tlm()
 
-    ### Cmd_EL_RECORD_EVENT のアサーション
+    # ### Cmd_EL_RECORD_EVENT のアサーション
     local0 = 1
     local1 = 5
     note0 = 2
@@ -190,7 +190,7 @@ def test_event_logger_record_event():
     for err_level in range(EL_ERROR_LEVEL_MAX):
         assert g_counts_pre[err_level] == g_counts[err_level]
 
-    ### Cmd_EL_RECORD_EVENT での登録
+    # ### Cmd_EL_RECORD_EVENT での登録
     ret = wings.util.send_rt_cmd_and_confirm(
         ope,
         c2a_enum.Cmd_CODE_EL_RECORD_EVENT,
@@ -241,7 +241,7 @@ def test_event_logger_record_event():
     assert g_clog_em_tlm["EL_CLOG.CLOGS.LOG0.DELTA_RECORD_TIME.TOTAL_CYCLE"] == diff_cycle
     assert g_clog_em_tlm["EL_CLOG.CLOGS.LOG0.DELTA_RECORD_TIME.STEP"] == diff_step
 
-    ### CLog のずらし
+    # ### CLog のずらし
     # 違うイベント
     ret = wings.util.send_rt_cmd_and_confirm(
         ope,
@@ -276,7 +276,7 @@ def test_event_logger_record_event():
 @pytest.mark.real
 @pytest.mark.sils
 def test_event_logger_clear_log():
-    ### 初期化
+    # ### 初期化
     ret = wings.util.send_rt_cmd_and_confirm(
         ope, c2a_enum.Cmd_CODE_EL_INIT, (), c2a_enum.Tlm_CODE_HK
     )
@@ -286,7 +286,7 @@ def test_event_logger_clear_log():
     note0 = 2
     note1 = 3
 
-    ### Cmd_EL_RECORD_EVENT での登録
+    # ### Cmd_EL_RECORD_EVENT での登録
     ret = wings.util.send_rt_cmd_and_confirm(
         ope,
         c2a_enum.Cmd_CODE_EL_RECORD_EVENT,
@@ -311,7 +311,7 @@ def test_event_logger_clear_log():
     assert assert_clog(EL_GROUP_TEST, local0, EL_ERROR_LEVEL_HIGH, note0, 0) == 1
     assert assert_clog(EL_GROUP_TEST, local1, EL_ERROR_LEVEL_LOW, note1, 0) == 1
 
-    ### 全消去
+    # ### 全消去
     ret = wings.util.send_rt_cmd_and_confirm(
         ope, c2a_enum.Cmd_CODE_EL_CLEAR_LOG_ALL, (), c2a_enum.Tlm_CODE_HK
     )
@@ -328,7 +328,7 @@ def test_event_logger_clear_log():
     assert assert_clog(EL_CORE_GROUP_NULL, 0, EL_ERROR_LEVEL_HIGH, 0, 0) == 0
     assert assert_clog(EL_CORE_GROUP_NULL, 0, EL_ERROR_LEVEL_LOW, 0, 0) == 0
 
-    ### Cmd_EL_RECORD_EVENT での登録
+    # ### Cmd_EL_RECORD_EVENT での登録
     ret = wings.util.send_rt_cmd_and_confirm(
         ope,
         c2a_enum.Cmd_CODE_EL_RECORD_EVENT,
@@ -345,7 +345,7 @@ def test_event_logger_clear_log():
     )
     assert_latest_log(EL_GROUP_TEST, local1, EL_ERROR_LEVEL_LOW, note1)
 
-    ### エラーレベル消去
+    # ### エラーレベル消去
     ret = wings.util.send_rt_cmd_and_confirm(
         ope,
         c2a_enum.Cmd_CODE_EL_CLEAR_LOG_BY_ERR_LEVEL,
@@ -389,7 +389,7 @@ def test_event_logger_clear_log():
 
     # 本当はTLogを消したらCLogも消えてないことを書くにするとかやりたいが，面倒なので．．．
 
-    ### 統計情報削除
+    # ### 統計情報削除
     ret = wings.util.send_rt_cmd_and_confirm(
         ope, c2a_enum.Cmd_CODE_EL_CLEAR_STATISTICS, (), c2a_enum.Tlm_CODE_HK
     )
@@ -405,12 +405,12 @@ def test_event_logger_clear_log():
 @pytest.mark.real
 @pytest.mark.sils
 def test_event_logger_tlog_overflow():
-    ### 初期化
+    # ### 初期化
     ret = wings.util.send_rt_cmd_and_confirm(
         ope, c2a_enum.Cmd_CODE_EL_INIT, (), c2a_enum.Tlm_CODE_HK
     )
 
-    ### 設定コマンドのアサーション確認
+    # ### 設定コマンドのアサーション確認
     change_tlog_tlm_page(0, EL_ERROR_LEVEL_HIGH)
 
     ret = wings.util.send_rt_cmd_and_confirm(
@@ -461,7 +461,7 @@ def test_event_logger_tlog_overflow():
     update_el_tlog_tlm()
     assert g_tlog_is_enable_overwrite == 1
 
-    ### 上書き不可にする
+    # ### 上書き不可にする
     ret = wings.util.send_rt_cmd_and_confirm(
         ope,
         c2a_enum.Cmd_CODE_EL_DISABLE_TLOG_OVERWRITE,
@@ -471,11 +471,11 @@ def test_event_logger_tlog_overflow():
     update_el_tlog_tlm()
     assert g_tlog_is_enable_overwrite == 0
 
-    ### 半分埋める
+    # ### 半分埋める
     local0 = 1
-    local1 = 5
+    # local1 = 5
     note0 = 2
-    note1 = 3
+    # note1 = 3
 
     change_tlog_tlm_page(0, EL_ERROR_LEVEL_HIGH)
     update_el_tlog_tlm()
@@ -493,7 +493,7 @@ def test_event_logger_tlog_overflow():
     assert g_counts[EL_ERROR_LEVEL_HIGH] == g_tlog_capacity // 2 - 1
     assert g_tlog_wp == g_tlog_capacity // 2 - 1
 
-    ### 半分まで来た EL インベント確認
+    # ### 半分まで来た EL インベント確認
     ret = wings.util.send_rt_cmd_and_confirm(
         ope,
         c2a_enum.Cmd_CODE_EL_RECORD_EVENT,
@@ -520,7 +520,7 @@ def test_event_logger_tlog_overflow():
 
     assert g_tlog_is_overflow == 0
 
-    ### 残１まで埋める
+    # ### 残１まで埋める
     change_tlog_tlm_page(0, EL_ERROR_LEVEL_HIGH)
     update_el_tlog_tlm()
     for i in range(g_tlog_wp, g_tlog_capacity - 1):
@@ -536,7 +536,7 @@ def test_event_logger_tlog_overflow():
     assert g_tlog_wp == g_tlog_capacity - 1
     assert g_tlog_is_overflow == 0
 
-    ### 溢れチェック
+    # ### 溢れチェック
     # ラスト１
     change_tlog_tlm_page(0, EL_ERROR_LEVEL_HIGH)
     ret = wings.util.send_rt_cmd_and_confirm(
@@ -565,7 +565,7 @@ def test_event_logger_tlog_overflow():
         == 1
     )
 
-    ### 溢れた場合のwpの位置など
+    # ### 溢れた場合のwpの位置など
     change_tlog_tlm_page(0, EL_ERROR_LEVEL_HIGH)
     update_el_tlm()
     update_el_tlog_tlm()
@@ -598,7 +598,7 @@ def test_event_logger_tlog_overflow():
     assert g_counts_pre[EL_ERROR_LEVEL_HIGH] + 1 == g_counts[EL_ERROR_LEVEL_HIGH]
     assert g_tlog_wp == 0
 
-    ### 追記OKに
+    # ### 追記OKに
     change_tlog_tlm_page(0, EL_ERROR_LEVEL_HIGH)
     ret = wings.util.send_rt_cmd_and_confirm(
         ope,
@@ -630,19 +630,17 @@ def test_event_logger_tlog_overflow():
 @pytest.mark.real
 @pytest.mark.sils
 def test_event_logger_clog_overflow():
-    ### 初期化
-    ret = wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_INIT, (), c2a_enum.Tlm_CODE_HK
-    )
+    # ### 初期化
+    wings.util.send_rt_cmd_and_confirm(ope, c2a_enum.Cmd_CODE_EL_INIT, (), c2a_enum.Tlm_CODE_HK)
 
     update_el_tlm()
     update_el_clog_tlm()
 
-    ### すべて埋める
+    # ### すべて埋める
     local0 = 1
-    local1 = 5
+    # local1 = 5
     note0 = 2
-    note1 = 3
+    # note1 = 3
 
     change_clog_tlm_page(0, EL_ERROR_LEVEL_HIGH)
     update_el_clog_tlm()
@@ -659,8 +657,8 @@ def test_event_logger_clog_overflow():
     # assert g_counts[EL_ERROR_LEVEL_EL] == 0           # TLog の Full event があるかもしれないので．
     assert g_count_total == g_counts[EL_ERROR_LEVEL_HIGH] + g_counts[EL_ERROR_LEVEL_EL]
 
-    ### 溢れチェック
-    ret = wings.util.send_rt_cmd_and_confirm(
+    # ### 溢れチェック
+    wings.util.send_rt_cmd_and_confirm(
         ope,
         c2a_enum.Cmd_CODE_EL_RECORD_EVENT,
         (EL_GROUP_TEST1, local0, EL_ERROR_LEVEL_HIGH, note0),
@@ -684,12 +682,12 @@ def test_event_logger_clog_overflow():
 @pytest.mark.real
 @pytest.mark.sils
 def test_event_logger_logging_setting():
-    ### 初期化
+    # ### 初期化
     ret = wings.util.send_rt_cmd_and_confirm(
         ope, c2a_enum.Cmd_CODE_EL_INIT, (), c2a_enum.Tlm_CODE_HK
     )
 
-    ### 切り替え
+    # ### 切り替え
     ret = wings.util.send_rt_cmd_and_confirm(
         ope, c2a_enum.Cmd_CODE_EL_DISABLE_LOGGING_ALL, (), c2a_enum.Tlm_CODE_HK
     )
@@ -730,7 +728,7 @@ def test_event_logger_logging_setting():
     assert g_el_tlm["EL.IS_LOGGING_ENABLE" + str(EL_GROUP_TEST)] == 1
     assert g_el_tlm["EL.IS_LOGGING_ENABLE" + str(EL_GROUP_TEST1)] == 1
 
-    ### 無効化されたイベント記録
+    # ### 無効化されたイベント記録
     ret = wings.util.send_rt_cmd_and_confirm(
         ope, c2a_enum.Cmd_CODE_EL_DISABLE_LOGGING, (EL_GROUP_TEST,), c2a_enum.Tlm_CODE_HK
     )
@@ -746,7 +744,7 @@ def test_event_logger_logging_setting():
     assert g_count_total_pre == g_count_total
     assert g_counts_pre[EL_ERROR_LEVEL_HIGH] == g_counts[EL_ERROR_LEVEL_HIGH]
 
-    ### リセット
+    # ### リセット
     ret = wings.util.send_rt_cmd_and_confirm(
         ope, c2a_enum.Cmd_CODE_EL_INIT_LOGGING_SETTINGS, (), c2a_enum.Tlm_CODE_HK
     )
@@ -762,7 +760,7 @@ def test_event_logger_logging_setting():
 def test_event_logger_final_check():
     update_all_tlm()
 
-    ### 初期化
+    # ### 初期化
     ret = wings.util.send_rt_cmd_and_confirm(
         ope, c2a_enum.Cmd_CODE_EL_INIT, (), c2a_enum.Tlm_CODE_HK
     )
@@ -915,8 +913,12 @@ def update_el_tlm():
 
 
 def update_el_tlog_tlm():
-    global g_tlog_em_tlm, g_tlog_count_total, g_tlog_count, g_tlog_tlm_info, g_tlog_capacity, g_tlog_wp, g_tlog_is_enable_overwrite, g_tlog_is_overflow
-    global g_tlog_em_tlm_pre, g_tlog_count_total_pre, g_tlog_count_pre, g_tlog_tlm_info_pre, g_tlog_capacity_pre, g_tlog_wp_pre, g_tlog_is_enable_overwrite_pre, g_tlog_is_overflow_pre
+    global g_tlog_em_tlm, g_tlog_count_total, g_tlog_count, g_tlog_tlm_info
+    global g_tlog_capacity, g_tlog_wp
+    global g_tlog_is_enable_overwrite, g_tlog_is_overflow
+    global g_tlog_em_tlm_pre, g_tlog_count_total_pre, g_tlog_count_pre, g_tlog_tlm_info_pre
+    global g_tlog_capacity_pre, g_tlog_wp_pre
+    global g_tlog_is_enable_overwrite_pre, g_tlog_is_overflow_pre
 
     (
         g_tlog_em_tlm_pre,
@@ -956,8 +958,10 @@ def update_el_tlog_tlm():
 
 
 def update_el_clog_tlm():
-    global g_clog_em_tlm, g_clog_count_total, g_clog_count, g_clog_tlm_info, g_clog_capacity
-    global g_clog_em_tlm_pre, g_clog_count_total_pre, g_clog_count_pre, g_clog_tlm_info_pre, g_clog_capacity_pre
+    global g_clog_em_tlm, g_clog_count_total, g_clog_count
+    global g_clog_tlm_info, g_clog_capacity
+    global g_clog_em_tlm_pre, g_clog_count_total_pre, g_clog_count_pre
+    global g_clog_tlm_info_pre, g_clog_capacity_pre
 
     (
         g_clog_em_tlm_pre,

--- a/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/EventManager/test_event_logger.py
+++ b/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/EventManager/test_event_logger.py
@@ -672,8 +672,12 @@ def test_event_logger_clog_overflow():
     assert g_counts_pre[EL_ERROR_LEVEL_EL] + 2 == g_counts[EL_ERROR_LEVEL_EL]
     assert g_count_total == g_counts[EL_ERROR_LEVEL_HIGH] + g_counts[EL_ERROR_LEVEL_EL]
 
-    # assert_tlog(EL_CORE_GROUP_EL_DROP_CLOG1, EL_GROUP_TEST, EL_ERROR_LEVEL_EL, 0, 0)      # TLog の Full event があるかもしれないので．
-    # assert_tlog(EL_CORE_GROUP_EL_DROP_CLOG2, 0, EL_ERROR_LEVEL_EL, 1, 1)      # TLog の Full event があるかもしれないので．
+    # assert_tlog(
+    #     EL_CORE_GROUP_EL_DROP_CLOG1, EL_GROUP_TEST, EL_ERROR_LEVEL_EL, 0, 0
+    # )  # TLog の Full event があるかもしれないので．
+    # assert_tlog(
+    #     EL_CORE_GROUP_EL_DROP_CLOG2, 0, EL_ERROR_LEVEL_EL, 1, 1
+    # )  # TLog の Full event があるかもしれないので．
     assert assert_clog(EL_CORE_GROUP_EL_DROP_CLOG1, EL_GROUP_TEST, EL_ERROR_LEVEL_EL, 0, 1) == 1
     assert assert_clog(EL_CORE_GROUP_EL_DROP_CLOG2, 0, EL_ERROR_LEVEL_EL, 1, 0) == 1
 

--- a/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/EventManager/test_event_logger.py
+++ b/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/EventManager/test_event_logger.py
@@ -18,36 +18,36 @@ ope = wings_utils.get_wings_operation()
 
 
 # コードと整合をとる
-EL_TLOG_TLM_PAGE_SIZE        = 36
-EL_TLOG_TLM_PAGE_MAX_HIGH    = 4
-EL_TLOG_TLM_PAGE_MAX_MIDDLE  = 4
-EL_TLOG_TLM_PAGE_MAX_LOW     = 4
-EL_CLOG_TLM_PAGE_SIZE        = 22
-EL_CLOG_TLM_PAGE_MAX_HIGH    = 4
-EL_CLOG_TLM_PAGE_MAX_MIDDLE  = 4
-EL_CLOG_TLM_PAGE_MAX_LOW     = 4
+EL_TLOG_TLM_PAGE_SIZE = 36
+EL_TLOG_TLM_PAGE_MAX_HIGH = 4
+EL_TLOG_TLM_PAGE_MAX_MIDDLE = 4
+EL_TLOG_TLM_PAGE_MAX_LOW = 4
+EL_CLOG_TLM_PAGE_SIZE = 22
+EL_CLOG_TLM_PAGE_MAX_HIGH = 4
+EL_CLOG_TLM_PAGE_MAX_MIDDLE = 4
+EL_CLOG_TLM_PAGE_MAX_LOW = 4
 
-EL_TLOG_LOG_SIZE_MAX_EL      = 16
-EL_CLOG_LOG_SIZE_MAX_EL      = 8
+EL_TLOG_LOG_SIZE_MAX_EL = 16
+EL_CLOG_LOG_SIZE_MAX_EL = 8
 
-EL_ERROR_LEVEL_HIGH    = 0
-EL_ERROR_LEVEL_MIDDLE  = 1
-EL_ERROR_LEVEL_LOW     = 2
-EL_ERROR_LEVEL_EL      = 3
-EL_ERROR_LEVEL_EH      = 4
-EL_ERROR_LEVEL_MAX     = 5
+EL_ERROR_LEVEL_HIGH = 0
+EL_ERROR_LEVEL_MIDDLE = 1
+EL_ERROR_LEVEL_LOW = 2
+EL_ERROR_LEVEL_EL = 3
+EL_ERROR_LEVEL_EH = 4
+EL_ERROR_LEVEL_MAX = 5
 EL_ERROR_LEVEL_TLM_DICT = ["HIGH", "MIDDLE", "LOW", "EL"]
 
-EL_CORE_GROUP_NULL          = c2a_enum.EL_CORE_GROUP_NULL
-EL_CORE_GROUP_EVENT_LOGGER  = c2a_enum.EL_CORE_GROUP_EVENT_LOGGER
+EL_CORE_GROUP_NULL = c2a_enum.EL_CORE_GROUP_NULL
+EL_CORE_GROUP_EVENT_LOGGER = c2a_enum.EL_CORE_GROUP_EVENT_LOGGER
 EL_CORE_GROUP_EL_DROP_CLOG1 = c2a_enum.EL_CORE_GROUP_EL_DROP_CLOG1
 EL_CORE_GROUP_EL_DROP_CLOG2 = c2a_enum.EL_CORE_GROUP_EL_DROP_CLOG2
-EL_GROUP_TEST  = c2a_enum.EL_GROUP_TEST
+EL_GROUP_TEST = c2a_enum.EL_GROUP_TEST
 EL_GROUP_TEST1 = c2a_enum.EL_GROUP_TEST1
-EL_GROUP_MAX   = c2a_enum.EL_GROUP_MAX
+EL_GROUP_MAX = c2a_enum.EL_GROUP_MAX
 
 EL_EVENT_LOCAL_TLOG_HIGH_HALF_FULL = 1
-EL_EVENT_LOCAL_TLOG_HIGH_FULL      = 2
+EL_EVENT_LOCAL_TLOG_HIGH_FULL = 2
 
 
 # 更新が頻繁にあるので，グローバルで
@@ -159,19 +159,28 @@ def test_event_logger_record_event():
     ### Cmd_EL_RECORD_EVENT のアサーション
     local0 = 1
     local1 = 5
-    note0  = 2
-    note1  = 3
+    note0 = 2
+    note1 = 3
 
     ret = wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_RECORD_EVENT, (EL_GROUP_TEST, local0, EL_ERROR_LEVEL_MAX, note0), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EL_RECORD_EVENT,
+        (EL_GROUP_TEST, local0, EL_ERROR_LEVEL_MAX, note0),
+        c2a_enum.Tlm_CODE_HK,
     )
     assert ret == "PRM"
     ret = wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_RECORD_EVENT, (EL_GROUP_TEST, local0, EL_ERROR_LEVEL_EL, note0), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EL_RECORD_EVENT,
+        (EL_GROUP_TEST, local0, EL_ERROR_LEVEL_EL, note0),
+        c2a_enum.Tlm_CODE_HK,
     )
     assert ret == "PRM"
     ret = wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_RECORD_EVENT, (EL_GROUP_MAX, local0, EL_ERROR_LEVEL_HIGH, note0), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EL_RECORD_EVENT,
+        (EL_GROUP_MAX, local0, EL_ERROR_LEVEL_HIGH, note0),
+        c2a_enum.Tlm_CODE_HK,
     )
     assert ret == "PRM"
 
@@ -183,7 +192,10 @@ def test_event_logger_record_event():
 
     ### Cmd_EL_RECORD_EVENT での登録
     ret = wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_RECORD_EVENT, (EL_GROUP_TEST, local0, EL_ERROR_LEVEL_HIGH, note0), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EL_RECORD_EVENT,
+        (EL_GROUP_TEST, local0, EL_ERROR_LEVEL_HIGH, note0),
+        c2a_enum.Tlm_CODE_HK,
     )
     assert ret == "SUC"
 
@@ -204,11 +216,14 @@ def test_event_logger_record_event():
     assert g_clog_em_tlm["EL_CLOG.CLOGS.LOG0.DELTA_RECORD_TIME.TOTAL_CYCLE"] == 0
     assert g_clog_em_tlm["EL_CLOG.CLOGS.LOG0.DELTA_RECORD_TIME.STEP"] == 0
     last_log_time_cycle = g_clog_em_tlm["EL_CLOG.CLOGS.LOG0.EVENT.TIME.TOTAL_CYCLE"]
-    last_log_time_step  = g_clog_em_tlm["EL_CLOG.CLOGS.LOG0.EVENT.TIME.STEP"]
+    last_log_time_step = g_clog_em_tlm["EL_CLOG.CLOGS.LOG0.EVENT.TIME.STEP"]
 
     # 同じイベント（note はわざと変えている）
     ret = wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_RECORD_EVENT, (EL_GROUP_TEST, local0, EL_ERROR_LEVEL_HIGH, note1), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EL_RECORD_EVENT,
+        (EL_GROUP_TEST, local0, EL_ERROR_LEVEL_HIGH, note1),
+        c2a_enum.Tlm_CODE_HK,
     )
 
     assert_latest_log(EL_GROUP_TEST, local0, EL_ERROR_LEVEL_HIGH, note1)
@@ -217,10 +232,10 @@ def test_event_logger_record_event():
     assert_tlog(EL_GROUP_TEST, local0, EL_ERROR_LEVEL_HIGH, note0, 0)
 
     diff_cycle = g_clog_em_tlm["EL_CLOG.CLOGS.LOG0.EVENT.TIME.TOTAL_CYCLE"] - last_log_time_cycle
-    diff_step  = g_clog_em_tlm["EL_CLOG.CLOGS.LOG0.EVENT.TIME.STEP"] - last_log_time_step
+    diff_step = g_clog_em_tlm["EL_CLOG.CLOGS.LOG0.EVENT.TIME.STEP"] - last_log_time_step
 
     if diff_step < 0:
-        diff_step  += 100
+        diff_step += 100
         diff_cycle -= 1
 
     assert g_clog_em_tlm["EL_CLOG.CLOGS.LOG0.DELTA_RECORD_TIME.TOTAL_CYCLE"] == diff_cycle
@@ -229,7 +244,10 @@ def test_event_logger_record_event():
     ### CLog のずらし
     # 違うイベント
     ret = wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_RECORD_EVENT, (EL_GROUP_TEST, local1, EL_ERROR_LEVEL_HIGH, note1), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EL_RECORD_EVENT,
+        (EL_GROUP_TEST, local1, EL_ERROR_LEVEL_HIGH, note1),
+        c2a_enum.Tlm_CODE_HK,
     )
 
     assert_latest_tlog(EL_GROUP_TEST, local1, EL_ERROR_LEVEL_HIGH, note1)
@@ -240,7 +258,10 @@ def test_event_logger_record_event():
 
     # 最初と同じイベント
     ret = wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_RECORD_EVENT, (EL_GROUP_TEST, local0, EL_ERROR_LEVEL_HIGH, note0), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EL_RECORD_EVENT,
+        (EL_GROUP_TEST, local0, EL_ERROR_LEVEL_HIGH, note0),
+        c2a_enum.Tlm_CODE_HK,
     )
 
     assert_tlog(EL_GROUP_TEST, local0, EL_ERROR_LEVEL_HIGH, note0, 0)
@@ -262,17 +283,23 @@ def test_event_logger_clear_log():
 
     local0 = 1
     local1 = 5
-    note0  = 2
-    note1  = 3
+    note0 = 2
+    note1 = 3
 
     ### Cmd_EL_RECORD_EVENT での登録
     ret = wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_RECORD_EVENT, (EL_GROUP_TEST, local0, EL_ERROR_LEVEL_HIGH, note0), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EL_RECORD_EVENT,
+        (EL_GROUP_TEST, local0, EL_ERROR_LEVEL_HIGH, note0),
+        c2a_enum.Tlm_CODE_HK,
     )
     assert_latest_log(EL_GROUP_TEST, local0, EL_ERROR_LEVEL_HIGH, note0)
 
     ret = wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_RECORD_EVENT, (EL_GROUP_TEST, local1, EL_ERROR_LEVEL_LOW, note1), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EL_RECORD_EVENT,
+        (EL_GROUP_TEST, local1, EL_ERROR_LEVEL_LOW, note1),
+        c2a_enum.Tlm_CODE_HK,
     )
     assert_latest_log(EL_GROUP_TEST, local1, EL_ERROR_LEVEL_LOW, note1)
 
@@ -301,33 +328,50 @@ def test_event_logger_clear_log():
     assert assert_clog(EL_CORE_GROUP_NULL, 0, EL_ERROR_LEVEL_HIGH, 0, 0) == 0
     assert assert_clog(EL_CORE_GROUP_NULL, 0, EL_ERROR_LEVEL_LOW, 0, 0) == 0
 
-
     ### Cmd_EL_RECORD_EVENT での登録
     ret = wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_RECORD_EVENT, (EL_GROUP_TEST, local0, EL_ERROR_LEVEL_HIGH, note0), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EL_RECORD_EVENT,
+        (EL_GROUP_TEST, local0, EL_ERROR_LEVEL_HIGH, note0),
+        c2a_enum.Tlm_CODE_HK,
     )
     assert_latest_log(EL_GROUP_TEST, local0, EL_ERROR_LEVEL_HIGH, note0)
 
     ret = wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_RECORD_EVENT, (EL_GROUP_TEST, local1, EL_ERROR_LEVEL_LOW, note1), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EL_RECORD_EVENT,
+        (EL_GROUP_TEST, local1, EL_ERROR_LEVEL_LOW, note1),
+        c2a_enum.Tlm_CODE_HK,
     )
     assert_latest_log(EL_GROUP_TEST, local1, EL_ERROR_LEVEL_LOW, note1)
 
     ### エラーレベル消去
     ret = wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_CLEAR_LOG_BY_ERR_LEVEL, (EL_ERROR_LEVEL_MAX,), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EL_CLEAR_LOG_BY_ERR_LEVEL,
+        (EL_ERROR_LEVEL_MAX,),
+        c2a_enum.Tlm_CODE_HK,
     )
     assert ret == "PRM"
     ret = wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_CLEAR_LOG_BY_ERR_LEVEL, (EL_ERROR_LEVEL_HIGH,), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EL_CLEAR_LOG_BY_ERR_LEVEL,
+        (EL_ERROR_LEVEL_HIGH,),
+        c2a_enum.Tlm_CODE_HK,
     )
     assert ret == "SUC"
     ret = wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_CLEAR_LOG_BY_ERR_LEVEL, (EL_ERROR_LEVEL_MAX,), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EL_CLEAR_LOG_BY_ERR_LEVEL,
+        (EL_ERROR_LEVEL_MAX,),
+        c2a_enum.Tlm_CODE_HK,
     )
     assert ret == "PRM"
     ret = wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_CLEAR_LOG_BY_ERR_LEVEL, (EL_ERROR_LEVEL_LOW,), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EL_CLEAR_LOG_BY_ERR_LEVEL,
+        (EL_ERROR_LEVEL_LOW,),
+        c2a_enum.Tlm_CODE_HK,
     )
     assert ret == "SUC"
 
@@ -337,7 +381,7 @@ def test_event_logger_clear_log():
     assert g_counts[EL_ERROR_LEVEL_HIGH] != 0
     assert g_counts[EL_ERROR_LEVEL_LOW] != 0
 
-    assert_latest_log(EL_GROUP_TEST, local1, EL_ERROR_LEVEL_LOW, note1)     # これは消えない
+    assert_latest_log(EL_GROUP_TEST, local1, EL_ERROR_LEVEL_LOW, note1)  # これは消えない
     assert_tlog(EL_CORE_GROUP_NULL, 0, EL_ERROR_LEVEL_HIGH, 0, 0)
     assert_tlog(EL_CORE_GROUP_NULL, 0, EL_ERROR_LEVEL_LOW, 0, 0)
     assert assert_clog(EL_CORE_GROUP_NULL, 0, EL_ERROR_LEVEL_HIGH, 0, 0) == 0
@@ -383,23 +427,35 @@ def test_event_logger_tlog_overflow():
     assert g_tlog_is_enable_overwrite == 1
 
     ret = wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_DISABLE_TLOG_OVERWRITE, (EL_ERROR_LEVEL_MAX,), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EL_DISABLE_TLOG_OVERWRITE,
+        (EL_ERROR_LEVEL_MAX,),
+        c2a_enum.Tlm_CODE_HK,
     )
     assert ret == "PRM"
     ret = wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_DISABLE_TLOG_OVERWRITE, (EL_ERROR_LEVEL_LOW,), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EL_DISABLE_TLOG_OVERWRITE,
+        (EL_ERROR_LEVEL_LOW,),
+        c2a_enum.Tlm_CODE_HK,
     )
     assert ret == "SUC"
     update_el_tlog_tlm()
     assert g_tlog_is_enable_overwrite == 1
     ret = wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_DISABLE_TLOG_OVERWRITE, (EL_ERROR_LEVEL_HIGH,), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EL_DISABLE_TLOG_OVERWRITE,
+        (EL_ERROR_LEVEL_HIGH,),
+        c2a_enum.Tlm_CODE_HK,
     )
     assert ret == "SUC"
     update_el_tlog_tlm()
     assert g_tlog_is_enable_overwrite == 0
     ret = wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_ENABLE_TLOG_OVERWRITE, (EL_ERROR_LEVEL_HIGH,), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EL_ENABLE_TLOG_OVERWRITE,
+        (EL_ERROR_LEVEL_HIGH,),
+        c2a_enum.Tlm_CODE_HK,
     )
     assert ret == "SUC"
     update_el_tlog_tlm()
@@ -407,7 +463,10 @@ def test_event_logger_tlog_overflow():
 
     ### 上書き不可にする
     ret = wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_DISABLE_TLOG_OVERWRITE, (EL_ERROR_LEVEL_HIGH,), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EL_DISABLE_TLOG_OVERWRITE,
+        (EL_ERROR_LEVEL_HIGH,),
+        c2a_enum.Tlm_CODE_HK,
     )
     update_el_tlog_tlm()
     assert g_tlog_is_enable_overwrite == 0
@@ -415,14 +474,16 @@ def test_event_logger_tlog_overflow():
     ### 半分埋める
     local0 = 1
     local1 = 5
-    note0  = 2
-    note1  = 3
+    note0 = 2
+    note1 = 3
 
     change_tlog_tlm_page(0, EL_ERROR_LEVEL_HIGH)
     update_el_tlog_tlm()
     assert g_tlog_wp == 0
     for i in range(g_tlog_wp, g_tlog_capacity // 2 - 1):
-        ope.send_rt_cmd(c2a_enum.Cmd_CODE_EL_RECORD_EVENT, (EL_GROUP_TEST, local0, EL_ERROR_LEVEL_HIGH, note0))
+        ope.send_rt_cmd(
+            c2a_enum.Cmd_CODE_EL_RECORD_EVENT, (EL_GROUP_TEST, local0, EL_ERROR_LEVEL_HIGH, note0)
+        )
         time.sleep(0.4)
 
     # 念の為チェック
@@ -434,7 +495,10 @@ def test_event_logger_tlog_overflow():
 
     ### 半分まで来た EL インベント確認
     ret = wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_RECORD_EVENT, (EL_GROUP_TEST, local0, EL_ERROR_LEVEL_HIGH, note0), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EL_RECORD_EVENT,
+        (EL_GROUP_TEST, local0, EL_ERROR_LEVEL_HIGH, note0),
+        c2a_enum.Tlm_CODE_HK,
     )
 
     update_el_tlm()
@@ -444,8 +508,15 @@ def test_event_logger_tlog_overflow():
     assert g_counts[EL_ERROR_LEVEL_EL] == 1
     assert g_count_total == g_counts[EL_ERROR_LEVEL_HIGH] + g_counts[EL_ERROR_LEVEL_EL]
 
-    assert_latest_tlog(EL_CORE_GROUP_EVENT_LOGGER, EL_EVENT_LOCAL_TLOG_HIGH_HALF_FULL, EL_ERROR_LEVEL_EL, 0)
-    assert assert_latest_clog(EL_CORE_GROUP_EVENT_LOGGER, EL_EVENT_LOCAL_TLOG_HIGH_HALF_FULL, EL_ERROR_LEVEL_EL, 0) == 1
+    assert_latest_tlog(
+        EL_CORE_GROUP_EVENT_LOGGER, EL_EVENT_LOCAL_TLOG_HIGH_HALF_FULL, EL_ERROR_LEVEL_EL, 0
+    )
+    assert (
+        assert_latest_clog(
+            EL_CORE_GROUP_EVENT_LOGGER, EL_EVENT_LOCAL_TLOG_HIGH_HALF_FULL, EL_ERROR_LEVEL_EL, 0
+        )
+        == 1
+    )
 
     assert g_tlog_is_overflow == 0
 
@@ -453,7 +524,9 @@ def test_event_logger_tlog_overflow():
     change_tlog_tlm_page(0, EL_ERROR_LEVEL_HIGH)
     update_el_tlog_tlm()
     for i in range(g_tlog_wp, g_tlog_capacity - 1):
-        ope.send_rt_cmd(c2a_enum.Cmd_CODE_EL_RECORD_EVENT, (EL_GROUP_TEST, local0, EL_ERROR_LEVEL_HIGH, note0))
+        ope.send_rt_cmd(
+            c2a_enum.Cmd_CODE_EL_RECORD_EVENT, (EL_GROUP_TEST, local0, EL_ERROR_LEVEL_HIGH, note0)
+        )
         time.sleep(0.4)
 
     # 念の為チェック
@@ -467,7 +540,10 @@ def test_event_logger_tlog_overflow():
     # ラスト１
     change_tlog_tlm_page(0, EL_ERROR_LEVEL_HIGH)
     ret = wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_RECORD_EVENT, (EL_GROUP_TEST, local0, EL_ERROR_LEVEL_HIGH, note0), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EL_RECORD_EVENT,
+        (EL_GROUP_TEST, local0, EL_ERROR_LEVEL_HIGH, note0),
+        c2a_enum.Tlm_CODE_HK,
     )
 
     update_el_tlm()
@@ -479,8 +555,15 @@ def test_event_logger_tlog_overflow():
     assert g_tlog_wp == 0
     assert g_tlog_is_overflow == 1
 
-    assert_latest_tlog(EL_CORE_GROUP_EVENT_LOGGER, EL_EVENT_LOCAL_TLOG_HIGH_FULL, EL_ERROR_LEVEL_EL, 0)
-    assert assert_latest_clog(EL_CORE_GROUP_EVENT_LOGGER, EL_EVENT_LOCAL_TLOG_HIGH_FULL, EL_ERROR_LEVEL_EL, 0) == 1
+    assert_latest_tlog(
+        EL_CORE_GROUP_EVENT_LOGGER, EL_EVENT_LOCAL_TLOG_HIGH_FULL, EL_ERROR_LEVEL_EL, 0
+    )
+    assert (
+        assert_latest_clog(
+            EL_CORE_GROUP_EVENT_LOGGER, EL_EVENT_LOCAL_TLOG_HIGH_FULL, EL_ERROR_LEVEL_EL, 0
+        )
+        == 1
+    )
 
     ### 溢れた場合のwpの位置など
     change_tlog_tlm_page(0, EL_ERROR_LEVEL_HIGH)
@@ -488,7 +571,10 @@ def test_event_logger_tlog_overflow():
     update_el_tlog_tlm()
 
     ret = wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_RECORD_EVENT, (EL_GROUP_TEST, local0, EL_ERROR_LEVEL_HIGH, note0), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EL_RECORD_EVENT,
+        (EL_GROUP_TEST, local0, EL_ERROR_LEVEL_HIGH, note0),
+        c2a_enum.Tlm_CODE_HK,
     )
 
     update_el_tlm()
@@ -499,7 +585,10 @@ def test_event_logger_tlog_overflow():
     assert g_tlog_wp == 0
 
     ret = wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_RECORD_EVENT, (EL_GROUP_TEST, local0, EL_ERROR_LEVEL_HIGH, note0), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EL_RECORD_EVENT,
+        (EL_GROUP_TEST, local0, EL_ERROR_LEVEL_HIGH, note0),
+        c2a_enum.Tlm_CODE_HK,
     )
 
     update_el_tlm()
@@ -512,7 +601,10 @@ def test_event_logger_tlog_overflow():
     ### 追記OKに
     change_tlog_tlm_page(0, EL_ERROR_LEVEL_HIGH)
     ret = wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_ENABLE_TLOG_OVERWRITE, (EL_ERROR_LEVEL_HIGH,), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EL_ENABLE_TLOG_OVERWRITE,
+        (EL_ERROR_LEVEL_HIGH,),
+        c2a_enum.Tlm_CODE_HK,
     )
 
     update_el_tlm()
@@ -520,7 +612,10 @@ def test_event_logger_tlog_overflow():
     assert g_tlog_is_enable_overwrite == 1
 
     ret = wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_RECORD_EVENT, (EL_GROUP_TEST, local0, EL_ERROR_LEVEL_HIGH, note0), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EL_RECORD_EVENT,
+        (EL_GROUP_TEST, local0, EL_ERROR_LEVEL_HIGH, note0),
+        c2a_enum.Tlm_CODE_HK,
     )
 
     update_el_tlm()
@@ -546,13 +641,15 @@ def test_event_logger_clog_overflow():
     ### すべて埋める
     local0 = 1
     local1 = 5
-    note0  = 2
-    note1  = 3
+    note0 = 2
+    note1 = 3
 
     change_clog_tlm_page(0, EL_ERROR_LEVEL_HIGH)
     update_el_clog_tlm()
     for i in range(0, g_clog_capacity):
-        ope.send_rt_cmd(c2a_enum.Cmd_CODE_EL_RECORD_EVENT, (EL_GROUP_TEST, i, EL_ERROR_LEVEL_HIGH, note0))
+        ope.send_rt_cmd(
+            c2a_enum.Cmd_CODE_EL_RECORD_EVENT, (EL_GROUP_TEST, i, EL_ERROR_LEVEL_HIGH, note0)
+        )
         time.sleep(0.4)
 
     update_el_tlm()
@@ -564,7 +661,10 @@ def test_event_logger_clog_overflow():
 
     ### 溢れチェック
     ret = wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_RECORD_EVENT, (EL_GROUP_TEST1, local0, EL_ERROR_LEVEL_HIGH, note0), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EL_RECORD_EVENT,
+        (EL_GROUP_TEST1, local0, EL_ERROR_LEVEL_HIGH, note0),
+        c2a_enum.Tlm_CODE_HK,
     )
 
     update_el_tlm()
@@ -637,7 +737,10 @@ def test_event_logger_logging_setting():
 
     update_el_tlm()
     ret = wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_RECORD_EVENT, (EL_GROUP_TEST, 0, EL_ERROR_LEVEL_HIGH, 0), c2a_enum.Tlm_CODE_HK
+        ope,
+        c2a_enum.Cmd_CODE_EL_RECORD_EVENT,
+        (EL_GROUP_TEST, 0, EL_ERROR_LEVEL_HIGH, 0),
+        c2a_enum.Tlm_CODE_HK,
     )
     assert ret == "CNT"
     assert g_count_total_pre == g_count_total
@@ -670,12 +773,12 @@ def test_event_logger_final_check():
 def assert_latest_log(group, local, err_level, note):
     update_el_tlm()
 
-    assert g_latest_event["group"      ] == group
-    assert g_latest_event["local"      ] == local
-    assert g_latest_event["err_level"  ] == EL_ERROR_LEVEL_TLM_DICT[err_level]
+    assert g_latest_event["group"] == group
+    assert g_latest_event["local"] == local
+    assert g_latest_event["err_level"] == EL_ERROR_LEVEL_TLM_DICT[err_level]
     # assert g_latest_event["total_cycle"] == total_cycle
     # assert g_latest_event["step"       ] == step
-    assert g_latest_event["note"       ] == note
+    assert g_latest_event["note"] == note
 
 
 def assert_latest_tlog(group, local, err_level, note):
@@ -703,7 +806,7 @@ def assert_tlog(group, local, err_level, note, idx):
     tlm_idx = idx % EL_TLOG_TLM_PAGE_SIZE
     assert g_tlog_em_tlm["EL_TLOG.TLOGS.EVENTS" + str(tlm_idx) + ".GROUP"] == group
     assert g_tlog_em_tlm["EL_TLOG.TLOGS.EVENTS" + str(tlm_idx) + ".LOCAL"] == local
-    assert g_tlog_em_tlm["EL_TLOG.TLOGS.EVENTS" + str(tlm_idx) + ".NOTE"]  == note
+    assert g_tlog_em_tlm["EL_TLOG.TLOGS.EVENTS" + str(tlm_idx) + ".NOTE"] == note
 
 
 def assert_latest_clog(group, local, err_level, note):
@@ -721,7 +824,7 @@ def assert_clog(group, local, err_level, note, idx):
 
     assert g_clog_em_tlm["EL_CLOG.CLOGS.LOG" + str(idx) + ".EVENT.GROUP"] == group
     assert g_clog_em_tlm["EL_CLOG.CLOGS.LOG" + str(idx) + ".EVENT.LOCAL"] == local
-    assert g_clog_em_tlm["EL_CLOG.CLOGS.LOG" + str(idx) + ".EVENT.NOTE"]  == note
+    assert g_clog_em_tlm["EL_CLOG.CLOGS.LOG" + str(idx) + ".EVENT.NOTE"] == note
 
     return g_clog_em_tlm["EL_CLOG.CLOGS.LOG" + str(idx) + ".COUNT"]
 
@@ -770,8 +873,13 @@ def update_el_tlm():
     global g_el_tlm, g_count_total, g_counts, g_tlm_info, g_latest_event
     global g_el_tlm_pre, g_count_total_pre, g_counts_pre, g_tlm_info_pre, g_latest_event_pre
 
-    g_el_tlm_pre, g_count_total_pre, g_counts_pre, g_tlm_info_pre, g_latest_event_pre = \
-                    g_el_tlm, g_count_total, g_counts, g_tlm_info, g_latest_event
+    g_el_tlm_pre, g_count_total_pre, g_counts_pre, g_tlm_info_pre, g_latest_event_pre = (
+        g_el_tlm,
+        g_count_total,
+        g_counts,
+        g_tlm_info,
+        g_latest_event,
+    )
 
     el_tlm = wings.util.generate_and_receive_tlm(
         ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_EL
@@ -779,64 +887,104 @@ def update_el_tlm():
 
     g_el_tlm = el_tlm
     g_count_total = el_tlm["EL.STATISTICS.RECORD_COUNTER_TOTAL"]
-    g_counts =  [
-                    el_tlm["EL.STATISTICS.RECORD_COUNTERS_HIGH"],
-                    el_tlm["EL.STATISTICS.RECORD_COUNTERS_MIDDLE"],
-                    el_tlm["EL.STATISTICS.RECORD_COUNTERS_LOW"],
-                    el_tlm["EL.STATISTICS.RECORD_COUNTERS_EL"],
-                    el_tlm["EL.STATISTICS.RECORD_COUNTERS_EH"]
-                ]
+    g_counts = [
+        el_tlm["EL.STATISTICS.RECORD_COUNTERS_HIGH"],
+        el_tlm["EL.STATISTICS.RECORD_COUNTERS_MIDDLE"],
+        el_tlm["EL.STATISTICS.RECORD_COUNTERS_LOW"],
+        el_tlm["EL.STATISTICS.RECORD_COUNTERS_EL"],
+        el_tlm["EL.STATISTICS.RECORD_COUNTERS_EH"],
+    ]
     g_tlm_info = {
-                    "tlog"  : {"page_no" : el_tlm["EL.TLM_INFO.TLOG.PAGE_NO"], "err_level" : el_tlm["EL.TLM_INFO.TLOG.ERR_LEVEL"]},
-                    "clog"  : {"page_no" : el_tlm["EL.TLM_INFO.CLOG.PAGE_NO"], "err_level" : el_tlm["EL.TLM_INFO.CLOG.ERR_LEVEL"]}
-                 }
+        "tlog": {
+            "page_no": el_tlm["EL.TLM_INFO.TLOG.PAGE_NO"],
+            "err_level": el_tlm["EL.TLM_INFO.TLOG.ERR_LEVEL"],
+        },
+        "clog": {
+            "page_no": el_tlm["EL.TLM_INFO.CLOG.PAGE_NO"],
+            "err_level": el_tlm["EL.TLM_INFO.CLOG.ERR_LEVEL"],
+        },
+    }
     g_latest_event = {
-                        "group"       : el_tlm["EL.LATEST_EVENT.GROUP"],
-                        "local"       : el_tlm["EL.LATEST_EVENT.LOCAL"],
-                        "err_level"   : el_tlm["EL.LATEST_EVENT.ERR_LEVEL"],
-                        "total_cycle" : el_tlm["EL.LATEST_EVENT.TIME.TOTAL_CYCLE"],
-                        "step"        : el_tlm["EL.LATEST_EVENT.TIME.STEP"],
-                        "note"        : el_tlm["EL.LATEST_EVENT.NOTE"],
-                     }
+        "group": el_tlm["EL.LATEST_EVENT.GROUP"],
+        "local": el_tlm["EL.LATEST_EVENT.LOCAL"],
+        "err_level": el_tlm["EL.LATEST_EVENT.ERR_LEVEL"],
+        "total_cycle": el_tlm["EL.LATEST_EVENT.TIME.TOTAL_CYCLE"],
+        "step": el_tlm["EL.LATEST_EVENT.TIME.STEP"],
+        "note": el_tlm["EL.LATEST_EVENT.NOTE"],
+    }
 
 
 def update_el_tlog_tlm():
     global g_tlog_em_tlm, g_tlog_count_total, g_tlog_count, g_tlog_tlm_info, g_tlog_capacity, g_tlog_wp, g_tlog_is_enable_overwrite, g_tlog_is_overflow
     global g_tlog_em_tlm_pre, g_tlog_count_total_pre, g_tlog_count_pre, g_tlog_tlm_info_pre, g_tlog_capacity_pre, g_tlog_wp_pre, g_tlog_is_enable_overwrite_pre, g_tlog_is_overflow_pre
 
-    g_tlog_em_tlm_pre, g_tlog_count_total_pre, g_tlog_count_pre, g_tlog_tlm_info_pre, g_tlog_capacity_pre, g_tlog_wp_pre, g_tlog_is_enable_overwrite_pre, g_tlog_is_overflow_pre = \
-                    g_tlog_em_tlm, g_tlog_count_total, g_tlog_count, g_tlog_tlm_info, g_tlog_capacity, g_tlog_wp, g_tlog_is_enable_overwrite, g_tlog_is_overflow
+    (
+        g_tlog_em_tlm_pre,
+        g_tlog_count_total_pre,
+        g_tlog_count_pre,
+        g_tlog_tlm_info_pre,
+        g_tlog_capacity_pre,
+        g_tlog_wp_pre,
+        g_tlog_is_enable_overwrite_pre,
+        g_tlog_is_overflow_pre,
+    ) = (
+        g_tlog_em_tlm,
+        g_tlog_count_total,
+        g_tlog_count,
+        g_tlog_tlm_info,
+        g_tlog_capacity,
+        g_tlog_wp,
+        g_tlog_is_enable_overwrite,
+        g_tlog_is_overflow,
+    )
 
     el_tlog_tlm = wings.util.generate_and_receive_tlm(
         ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_EL_TLOG
     )
 
-    g_tlog_em_tlm              = el_tlog_tlm
-    g_tlog_count_total         = el_tlog_tlm["EL_TLOG.STATISTICS.RECORD_COUNTER_TOTAL"]
-    g_tlog_count               = el_tlog_tlm["EL_TLOG.STATISTICS.RECORD_COUNTERS_ERR_LEVEL"]
-    g_tlog_tlm_info            = {"page_no" : el_tlog_tlm["EL_TLOG.TLM_INFO.TLOG.PAGE_NO"], "err_level" : el_tlog_tlm["EL_TLOG.TLM_INFO.TLOG.ERR_LEVEL"]}
-    g_tlog_capacity            = el_tlog_tlm["EL_TLOG.TLOGS.LOG_CAPACITY"]
-    g_tlog_wp                  = el_tlog_tlm["EL_TLOG.TLOGS.LOG_WP"]
+    g_tlog_em_tlm = el_tlog_tlm
+    g_tlog_count_total = el_tlog_tlm["EL_TLOG.STATISTICS.RECORD_COUNTER_TOTAL"]
+    g_tlog_count = el_tlog_tlm["EL_TLOG.STATISTICS.RECORD_COUNTERS_ERR_LEVEL"]
+    g_tlog_tlm_info = {
+        "page_no": el_tlog_tlm["EL_TLOG.TLM_INFO.TLOG.PAGE_NO"],
+        "err_level": el_tlog_tlm["EL_TLOG.TLM_INFO.TLOG.ERR_LEVEL"],
+    }
+    g_tlog_capacity = el_tlog_tlm["EL_TLOG.TLOGS.LOG_CAPACITY"]
+    g_tlog_wp = el_tlog_tlm["EL_TLOG.TLOGS.LOG_WP"]
     g_tlog_is_enable_overwrite = el_tlog_tlm["EL_TLOG.TLOGS.IS_ENABLE_OVERWRITE"]
-    g_tlog_is_overflow         = el_tlog_tlm["EL_TLOG.TLOGS.IS_TABLE_OVERFLOW"]
+    g_tlog_is_overflow = el_tlog_tlm["EL_TLOG.TLOGS.IS_TABLE_OVERFLOW"]
 
 
 def update_el_clog_tlm():
     global g_clog_em_tlm, g_clog_count_total, g_clog_count, g_clog_tlm_info, g_clog_capacity
     global g_clog_em_tlm_pre, g_clog_count_total_pre, g_clog_count_pre, g_clog_tlm_info_pre, g_clog_capacity_pre
 
-    g_clog_em_tlm_pre, g_clog_count_total_pre, g_clog_count_pre, g_clog_tlm_info_pre, g_clog_capacity_pre = \
-                    g_clog_em_tlm, g_clog_count_total, g_clog_count, g_clog_tlm_info, g_clog_capacity
+    (
+        g_clog_em_tlm_pre,
+        g_clog_count_total_pre,
+        g_clog_count_pre,
+        g_clog_tlm_info_pre,
+        g_clog_capacity_pre,
+    ) = (
+        g_clog_em_tlm,
+        g_clog_count_total,
+        g_clog_count,
+        g_clog_tlm_info,
+        g_clog_capacity,
+    )
 
     el_clog_tlm = wings.util.generate_and_receive_tlm(
         ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_EL_CLOG
     )
 
-    g_clog_em_tlm      = el_clog_tlm
+    g_clog_em_tlm = el_clog_tlm
     g_clog_count_total = el_clog_tlm["EL_CLOG.STATISTICS.RECORD_COUNTER_TOTAL"]
-    g_clog_count       = el_clog_tlm["EL_CLOG.STATISTICS.RECORD_COUNTERS_ERR_LEVEL"]
-    g_clog_tlm_info    = {"page_no" : el_clog_tlm["EL_CLOG.TLM_INFO.CLOG.PAGE_NO"], "err_level" : el_clog_tlm["EL_CLOG.TLM_INFO.CLOG.ERR_LEVEL"]}
-    g_clog_capacity    = el_clog_tlm["EL_CLOG.CLOGS.LOG_CAPACITY"]
+    g_clog_count = el_clog_tlm["EL_CLOG.STATISTICS.RECORD_COUNTERS_ERR_LEVEL"]
+    g_clog_tlm_info = {
+        "page_no": el_clog_tlm["EL_CLOG.TLM_INFO.CLOG.PAGE_NO"],
+        "err_level": el_clog_tlm["EL_CLOG.TLM_INFO.CLOG.ERR_LEVEL"],
+    }
+    g_clog_capacity = el_clog_tlm["EL_CLOG.CLOGS.LOG_CAPACITY"]
 
 
 if __name__ == "__main__":

--- a/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/ModeManager/test_mode_manager.py
+++ b/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/ModeManager/test_mode_manager.py
@@ -3,6 +3,7 @@
 
 import os
 import sys
+
 # import time
 
 # import isslwings as wings

--- a/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/ModeManager/test_mode_manager.py
+++ b/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/ModeManager/test_mode_manager.py
@@ -3,10 +3,10 @@
 
 import os
 import sys
-import time
+# import time
 
-import isslwings as wings
-import pytest
+# import isslwings as wings
+# import pytest
 
 ROOT_PATH = "../../../../"
 sys.path.append(os.path.dirname(__file__) + "/" + ROOT_PATH + "utils")

--- a/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/ModeManager/test_mode_manager.py
+++ b/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/ModeManager/test_mode_manager.py
@@ -7,7 +7,7 @@ import sys
 # import time
 
 # import isslwings as wings
-# import pytest
+import pytest
 
 ROOT_PATH = "../../../../"
 sys.path.append(os.path.dirname(__file__) + "/" + ROOT_PATH + "utils")
@@ -16,6 +16,13 @@ import wings_utils
 
 c2a_enum = c2a_enum_utils.get_c2a_enum()
 ope = wings_utils.get_wings_operation()
+
+
+# 他をコメントアウトしてると， pytest がコケるので
+@pytest.mark.sils
+@pytest.mark.real
+def test_mm_nop():
+    pass
 
 
 # @pytest.mark.sils

--- a/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/TaskManager/test_task_dispatcher.py
+++ b/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/TaskManager/test_task_dispatcher.py
@@ -3,10 +3,9 @@
 
 import os
 import sys
-import time
 
-import isslwings as wings
-import pytest
+# import isslwings as wings
+# import pytest
 
 ROOT_PATH = "../../../../"
 sys.path.append(os.path.dirname(__file__) + "/" + ROOT_PATH + "utils")

--- a/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/TaskManager/test_task_dispatcher.py
+++ b/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/TaskManager/test_task_dispatcher.py
@@ -5,7 +5,7 @@ import os
 import sys
 
 # import isslwings as wings
-# import pytest
+import pytest
 
 ROOT_PATH = "../../../../"
 sys.path.append(os.path.dirname(__file__) + "/" + ROOT_PATH + "utils")

--- a/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/TimeManager/test_obc_time.py
+++ b/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/TimeManager/test_obc_time.py
@@ -3,10 +3,9 @@
 
 import os
 import sys
-import time
 
-import isslwings as wings
-import pytest
+# import isslwings as wings
+# import pytest
 
 ROOT_PATH = "../../../../"
 sys.path.append(os.path.dirname(__file__) + "/" + ROOT_PATH + "utils")

--- a/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/TimeManager/test_obc_time.py
+++ b/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/TimeManager/test_obc_time.py
@@ -5,7 +5,7 @@ import os
 import sys
 
 # import isslwings as wings
-# import pytest
+import pytest
 
 ROOT_PATH = "../../../../"
 sys.path.append(os.path.dirname(__file__) + "/" + ROOT_PATH + "utils")
@@ -14,6 +14,13 @@ import wings_utils
 
 c2a_enum = c2a_enum_utils.get_c2a_enum()
 ope = wings_utils.get_wings_operation()
+
+
+# 他をコメントアウトしてると， pytest がコケるので
+@pytest.mark.sils
+@pytest.mark.real
+def test_obct_nop():
+    pass
 
 
 if __name__ == "__main__":

--- a/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/WatchdogTimer/test_watchdog_timer.py
+++ b/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/WatchdogTimer/test_watchdog_timer.py
@@ -3,7 +3,6 @@
 
 import os
 import sys
-import time
 
 import isslwings as wings
 import pytest

--- a/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/WatchdogTimer/test_watchdog_timer.py
+++ b/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/WatchdogTimer/test_watchdog_timer.py
@@ -25,27 +25,21 @@ def test_wdt_at_sils():
     assert tlm_HK["HK.WDT.IS_ENABLE"] == "ENA"
     assert tlm_HK["HK.WDT.IS_CLEAR_ENABLE"] == "ENA"
 
-    wings.util.send_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_WDT_DISABLE, (), c2a_enum.Tlm_CODE_HK
-    )
+    wings.util.send_cmd_and_confirm(ope, c2a_enum.Cmd_CODE_WDT_DISABLE, (), c2a_enum.Tlm_CODE_HK)
     tlm_HK = wings.util.generate_and_receive_tlm(
         ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_HK
     )
     assert tlm_HK["HK.WDT.IS_ENABLE"] == "DIS"
     assert tlm_HK["HK.WDT.IS_CLEAR_ENABLE"] == "ENA"
 
-    wings.util.send_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_WDT_ENABLE, (), c2a_enum.Tlm_CODE_HK
-    )
+    wings.util.send_cmd_and_confirm(ope, c2a_enum.Cmd_CODE_WDT_ENABLE, (), c2a_enum.Tlm_CODE_HK)
     tlm_HK = wings.util.generate_and_receive_tlm(
         ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_HK
     )
     assert tlm_HK["HK.WDT.IS_ENABLE"] == "ENA"
     assert tlm_HK["HK.WDT.IS_CLEAR_ENABLE"] == "ENA"
 
-    wings.util.send_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_WDT_STOP_CLEAR, (), c2a_enum.Tlm_CODE_HK
-    )
+    wings.util.send_cmd_and_confirm(ope, c2a_enum.Cmd_CODE_WDT_STOP_CLEAR, (), c2a_enum.Tlm_CODE_HK)
     tlm_HK = wings.util.generate_and_receive_tlm(
         ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_HK
     )

--- a/Examples/minimum_user_for_s2e/src/src_user/Test/utils/c2a_enum_utils.py
+++ b/Examples/minimum_user_for_s2e/src/src_user/Test/utils/c2a_enum_utils.py
@@ -4,19 +4,16 @@ import json
 import os
 import c2aenum as c2a
 
+
 def get_c2a_enum():
     c2a_src_abs_path = os.environ.get("C2A_SRC_ABS_PATH")
 
     # このifは環境変数が設定されているならsettings.jsonを無視したいという意図
     if c2a_src_abs_path == None:
-        with open(
-            os.path.dirname(__file__).replace("\\", "/") + "/../settings.json"
-        ) as f:
+        with open(os.path.dirname(__file__).replace("\\", "/") + "/../settings.json") as f:
             json_dict = json.load(f)
         c2a_src_abs_path = (
-            os.path.dirname(__file__).replace("\\", "/")
-            + "/../"
-            + json_dict["c2a_src_rel_path"]
+            os.path.dirname(__file__).replace("\\", "/") + "/../" + json_dict["c2a_src_rel_path"]
         )
 
     return c2a.load_enum(c2a_src_abs_path, "utf-8")

--- a/Examples/minimum_user_for_s2e/src/src_user/Test/utils/c2a_enum_utils.py
+++ b/Examples/minimum_user_for_s2e/src/src_user/Test/utils/c2a_enum_utils.py
@@ -9,7 +9,7 @@ def get_c2a_enum():
     c2a_src_abs_path = os.environ.get("C2A_SRC_ABS_PATH")
 
     # このifは環境変数が設定されているならsettings.jsonを無視したいという意図
-    if c2a_src_abs_path == None:
+    if c2a_src_abs_path is None:
         with open(os.path.dirname(__file__).replace("\\", "/") + "/../settings.json") as f:
             json_dict = json.load(f)
         c2a_src_abs_path = (

--- a/Examples/minimum_user_for_s2e/src/src_user/Test/utils/wings_utils.py
+++ b/Examples/minimum_user_for_s2e/src/src_user/Test/utils/wings_utils.py
@@ -4,13 +4,14 @@ import json
 import os
 import isslwings as wings
 
+
 def get_wings_operation():
     authorization = dict(
-        client_id = os.environ.get("WINGS_CLIENT_ID"),
-        client_secret = os.environ.get("WINGS_CLIENT_SECRET"),
-        grant_type = os.environ.get("WINGS_GRANT_TYPE"),
-        username = os.environ.get("WINGS_USERNAME"),
-        password = os.environ.get("WINGS_PASSWORD")
+        client_id=os.environ.get("WINGS_CLIENT_ID"),
+        client_secret=os.environ.get("WINGS_CLIENT_SECRET"),
+        grant_type=os.environ.get("WINGS_GRANT_TYPE"),
+        username=os.environ.get("WINGS_USERNAME"),
+        password=os.environ.get("WINGS_PASSWORD"),
     )
 
     # 環境変数があればそちらを優先

--- a/Script/CI/check_coding_rule.py
+++ b/Script/CI/check_coding_rule.py
@@ -161,7 +161,7 @@ def preprocess_inner_(path: str, settings: dict):
         if non_qualifier_line.startswith(tuple(control_identifier)):
             continue
         match = reptn_find_type.search(non_qualifier_line)
-        if not match is None:
+        if match is not None:
             # print(match.group(1))
             g_type_set.add(match.group(1))
 
@@ -352,7 +352,7 @@ def check_newline_(path: str, code_lines: list) -> int:
                 continue
 
             match = reptn.search(line)
-            if not match is None:
+            if match is not None:
                 print(path + ": " + str(idx + 1) + ": ALLMAN STYLE IS REQUIRED")
                 if IS_SHOW_CODE_AT_ERR:
                     print(line)
@@ -371,7 +371,7 @@ def check_newline_(path: str, code_lines: list) -> int:
                 continue
 
             match = reptn.search(line)
-            if not match is None:
+            if match is not None:
                 print(path + ": " + str(idx + 1) + ": ALLMAN STYLE IS REQUIRED")
                 if IS_SHOW_CODE_AT_ERR:
                     print(line)

--- a/Script/CI/check_coding_rule.py
+++ b/Script/CI/check_coding_rule.py
@@ -135,7 +135,9 @@ def preprocess_inner_(path: str, settings: dict):
     )
     reptn_replace_qualifier = re.compile(ptn_replace_qualifier)
 
-    # targets = ["for", "if", "while", "return", "switch", "case", "break", "else", "goto", "auto", "continue", "extern", "enum", "union", "register", "static", "struct", "typedef", "volatile"]
+    # targets = ["for", "if", "while", "return", "switch", "case", "break", "else", "goto",
+    #            "auto", "continue", "extern", "enum", "union", "register", "static",
+    #            "struct", "typedef", "volatile"]
 
     control_identifier = [
         "for",
@@ -302,9 +304,12 @@ def check_newline_(path: str, code_lines: list) -> int:
                     print(line)
                 flag = 1
         # 旧版
-        # # if not (line.find("[") != -1 and line.find("};") != -1):      # TODO: uint8_t command_id[3] = {0x76, 0x61, 0x73}; などを含めないため．今後治す
-        # # if line.find("};") == -1:                                   # TODO: uint8_t command_id[3] = {0x76, 0x61, 0x73}; などを含めないため．今後治す
-        # if line.find("[") == -1 and line.find("};") == -1:        # TODO: uint8_t command_id[3] = {0x76, 0x61, 0x73}; などを含めないため．今後治す
+        # # if not (line.find("[") != -1 and line.find("};") != -1):
+        #           ↑ # TODO: uint8_t command_id[3] = {0x76, 0x61, 0x73}; などを含めないため．今後治す
+        # # if line.find("};") == -1:
+        #           ↑ # TODO: uint8_t command_id[3] = {0x76, 0x61, 0x73}; などを含めないため．今後治す
+        # if line.find("[") == -1 and line.find("};") == -1:
+        #           ↑ # TODO: uint8_t command_id[3] = {0x76, 0x61, 0x73}; などを含めないため．今後治す
         #     if (has_line_ended_with_target_(line, "{") == 0):
         #         print(path + ": " + str(idx + 1) + ": ALLMAN STYLE IS REQUIRED")
         #         if IS_SHOW_CODE_AT_ERR:

--- a/Script/CI/check_coding_rule.py
+++ b/Script/CI/check_coding_rule.py
@@ -34,10 +34,10 @@ def main():
         print("Setting file not found.")
         sys.exit(1)
 
-    with open(setting_file_path, encoding='utf-8', mode='r') as fh:
+    with open(setting_file_path, encoding="utf-8", mode="r") as fh:
         settings = json.load(fh)
     if DEBUG:
-        pprint.pprint(settings);
+        pprint.pprint(settings)
 
     flag = check_coding_rule(settings)
 
@@ -53,14 +53,14 @@ def check_coding_rule(settings: dict) -> int:
     flag = 0
 
     target_dirs = []
-    for target_dir in settings['target_dirs']:
-        target_dirs.append(settings['c2a_root_dir'] + target_dir)
+    for target_dir in settings["target_dirs"]:
+        target_dirs.append(settings["c2a_root_dir"] + target_dir)
     ignore_dirs = []
-    for ignore_dir in settings['ignore_dirs']:
-        ignore_dirs.append(settings['c2a_root_dir'] + ignore_dir)
+    for ignore_dir in settings["ignore_dirs"]:
+        ignore_dirs.append(settings["c2a_root_dir"] + ignore_dir)
     ignore_files = []
-    for ignore_file in settings['ignore_files']:
-        ignore_files.append(settings['c2a_root_dir'] + ignore_file)
+    for ignore_file in settings["ignore_files"]:
+        ignore_files.append(settings["c2a_root_dir"] + ignore_file)
 
     preprocess_(target_dirs, ignore_dirs, ignore_files, settings)
 
@@ -96,7 +96,7 @@ def check_coding_rule(settings: dict) -> int:
                 if ret != 0:
                     # print(path)
                     flag = 1
-    return flag;
+    return flag
 
 
 def preprocess_(target_dirs: list, ignore_dirs: list, ignore_files: list, settings: dict):
@@ -120,22 +120,35 @@ def preprocess_(target_dirs: list, ignore_dirs: list, ignore_files: list, settin
         if ignore_type in g_type_set:
             g_type_set.remove(ignore_type)
     # pprint.pprint(settings['additional_type'])
-    g_type_set |= set(settings['additional_type'])
+    g_type_set |= set(settings["additional_type"])
     # pprint.pprint(g_type_set)
 
 
 def preprocess_inner_(path: str, settings: dict):
-    with open(path, encoding=settings['input_file_encoding']) as f:
+    with open(path, encoding=settings["input_file_encoding"]) as f:
         code_lines = f.read().split("\n")
 
-    ptn_find_type = '^ *(\w+)\*? +\w+'
+    ptn_find_type = "^ *(\w+)\*? +\w+"
     reptn_find_type = re.compile(ptn_find_type)
-    ptn_replace_qualifier = '^ *((const|static|extern|volatile|register)+ +)+'      # static const hoge も検出できるように
+    ptn_replace_qualifier = (
+        "^ *((const|static|extern|volatile|register)+ +)+"  # static const hoge も検出できるように
+    )
     reptn_replace_qualifier = re.compile(ptn_replace_qualifier)
 
     # targets = ["for", "if", "while", "return", "switch", "case", "break", "else", "goto", "auto", "continue", "extern", "enum", "union", "register", "static", "struct", "typedef", "volatile"]
 
-    control_identifier = ["for", "if", "while", "return", "switch", "case", "break", "else", "goto", "continue"]
+    control_identifier = [
+        "for",
+        "if",
+        "while",
+        "return",
+        "switch",
+        "case",
+        "break",
+        "else",
+        "goto",
+        "continue",
+    ]
     # control_identifier = ["auto", "signed", "unsigned"]
 
     for idx, line in enumerate(code_lines):
@@ -155,12 +168,11 @@ def preprocess_inner_(path: str, settings: dict):
 def check_file_(path: str, settings: dict) -> int:
     flag = 0
 
-    with open(path, encoding=settings['input_file_encoding']) as f:
+    with open(path, encoding=settings["input_file_encoding"]) as f:
         code_lines = f.read().split("\n")
 
     # print(path)
     # pprint.pprint(code_lines)
-
 
     if check_comment_(path, code_lines) != 0:
         flag = 1
@@ -177,7 +189,7 @@ def check_file_(path: str, settings: dict) -> int:
     # if check_include_guard_(path, code_lines) != 0:
     #     flag = 1
 
-    return flag;
+    return flag
 
 
 # TODO
@@ -200,7 +212,9 @@ def check_comment_(path: str, code_lines: list) -> int:
                     print(line)
                 flag = 1
         if "/*" in line:
-            if not has_started_with_list_after_target_(line, "/*", [" ", "!< ", "*"]):       # TODO: "*" を許すの．．．
+            if not has_started_with_list_after_target_(
+                line, "/*", [" ", "!< ", "*"]
+            ):  # TODO: "*" を許すの．．．
                 print(path + ": " + str(idx + 1) + ": SPACE IS REQUIRED AFTER '/*' OR '/*!<'")
                 if IS_SHOW_CODE_AT_ERR:
                     print(line)
@@ -225,7 +239,7 @@ def check_comment_(path: str, code_lines: list) -> int:
                     print(line)
                 flag = 1
         if "*/" in line:
-            if not has_ended_with_list_before_target_(line, "*/", [" ", "*"]):       # TODO: "*" を許すの．．．
+            if not has_ended_with_list_before_target_(line, "*/", [" ", "*"]):  # TODO: "*" を許すの．．．
                 print(path + ": " + str(idx + 1) + ": SPACE IS REQUIRED BEFORE '*/'")
                 if IS_SHOW_CODE_AT_ERR:
                     print(line)
@@ -253,18 +267,34 @@ def check_newline_(path: str, code_lines: list) -> int:
         if is_in_comment_context_in_multiline_(path, code_lines, idx):
             continue
 
-        if line.find("for") == -1:      # TODO: for があると文途中に ; があるので．今後治す
-            if (has_line_ended_with_target_(line, ";") == 0):
-                print(path + ": " + str(idx + 1) + ": THE END OF A STATEMENT SHOULD BE A COMMENT OR A LINE BREAK")
+        if line.find("for") == -1:  # TODO: for があると文途中に ; があるので．今後治す
+            if has_line_ended_with_target_(line, ";") == 0:
+                print(
+                    path
+                    + ": "
+                    + str(idx + 1)
+                    + ": THE END OF A STATEMENT SHOULD BE A COMMENT OR A LINE BREAK"
+                )
                 if IS_SHOW_CODE_AT_ERR:
                     print(line)
                 flag = 1
 
-        if (has_line_ended_with_target_(line, "{") == 0):
+        if has_line_ended_with_target_(line, "{") == 0:
             non_comment_line = remove_comment_and_strip_(line)
-            if non_comment_line[-1] in [",", "+" , "-", "*", "/", "%", "&", "|", "^", "~"]:         # 複数行で { 111, 111,
+            if non_comment_line[-1] in [
+                ",",
+                "+",
+                "-",
+                "*",
+                "/",
+                "%",
+                "&",
+                "|",
+                "^",
+                "~",
+            ]:  # 複数行で { 111, 111,
                 pass
-            elif non_comment_line[-2:] == "};":     # uint8_t command_id[3] = {0x76, 0x61, 0x73};
+            elif non_comment_line[-2:] == "};":  # uint8_t command_id[3] = {0x76, 0x61, 0x73};
                 pass
             else:
                 print(path + ": " + str(idx + 1) + ": ALLMAN STYLE IS REQUIRED")
@@ -296,14 +326,13 @@ def check_newline_(path: str, code_lines: list) -> int:
         if min(len(non_comment_line1), len(non_comment_line2)) > 150:
             if line[0:2] == "//" or line[0:2] == "/*":
                 pass
-            elif line[0:7] == "#define":        # TODO: これは改行すると怖いので許す？
+            elif line[0:7] == "#define":  # TODO: これは改行すると怖いので許す？
                 pass
             else:
                 print(path + ": " + str(idx + 1) + ": ONE LINE (EXCLUDING COMMENTS) IS TOO LONG")
                 if IS_SHOW_CODE_AT_ERR:
                     print(line)
                 flag = 1
-
 
     targets = ["class", "enum", "struct", "if", "for", "else", "while", "switch", "case"]
     for target in targets:
@@ -348,27 +377,27 @@ def check_newline_(path: str, code_lines: list) -> int:
 
 # 0: OK, 1: NG
 def check_eof_(path: str, code_lines: list) -> int:
-    max_line = len(code_lines);
+    max_line = len(code_lines)
     if max_line == 0:
-        return 0;
+        return 0
     if max_line == 1:
         if code_lines[-1] == "":
-            return 0;
+            return 0
         else:
             print(path + ": 1: NO NEW LINE AT EOF")
             if IS_SHOW_CODE_AT_ERR:
                 print(code_lines[-1])
-            return 1;
+            return 1
     if code_lines[-1] != "":
         print(path + ": " + str(max_line) + ": NO NEW LINE AT EOF")
         if IS_SHOW_CODE_AT_ERR:
             print(code_lines[-1])
-        return 1;
+        return 1
     if code_lines[-1] == "" and code_lines[-2] == "":
         print(path + ": " + str(max_line - 2) + ": TOO MANY LINE BREAKS AT EOF")
         if IS_SHOW_CODE_AT_ERR:
             print(code_lines[-2])
-        return 1;
+        return 1
     return 0
 
 
@@ -457,7 +486,14 @@ def check_operator_space_(path: str, code_lines: list) -> int:
         targets = ["}{", "){", "}("]
         for target in targets:
             if is_contained_pattern_(line, target):
-                print(path + ": " + str(idx + 1) + ": PROHIBITED PATTERNS:'" + target + "' (SPACE IS REQUIRED)")
+                print(
+                    path
+                    + ": "
+                    + str(idx + 1)
+                    + ": PROHIBITED PATTERNS:'"
+                    + target
+                    + "' (SPACE IS REQUIRED)"
+                )
                 if IS_SHOW_CODE_AT_ERR:
                     print(line)
                 flag = 1
@@ -488,7 +524,14 @@ def check_operator_space_(path: str, code_lines: list) -> int:
             poss = [x.start() for x in reptn.finditer(line)]
             for pos in poss:
                 if not is_in_comment_context_in_line_(line, pos):
-                    print(path + ": " + str(idx + 1) + ": '*' MUST BE PLACED TO THE SIDE OF TYPE AT '" + target + "'")
+                    print(
+                        path
+                        + ": "
+                        + str(idx + 1)
+                        + ": '*' MUST BE PLACED TO THE SIDE OF TYPE AT '"
+                        + target
+                        + "'"
+                    )
                     if IS_SHOW_CODE_AT_ERR:
                         print(line)
                     flag = 1
@@ -507,7 +550,14 @@ def check_operator_space_(path: str, code_lines: list) -> int:
             poss = [x.start() for x in reptn.finditer(line)]
             for pos in poss:
                 if not is_in_comment_context_in_line_(line, pos):
-                    print(path + ": " + str(idx + 1) + ": '&' MUST BE PLACED TO THE SIDE OF TYPE AT '" + target + "'")
+                    print(
+                        path
+                        + ": "
+                        + str(idx + 1)
+                        + ": '&' MUST BE PLACED TO THE SIDE OF TYPE AT '"
+                        + target
+                        + "'"
+                    )
                     if IS_SHOW_CODE_AT_ERR:
                         print(line)
                     flag = 1
@@ -527,9 +577,27 @@ def check_operator_space_(path: str, code_lines: list) -> int:
 
     targets = ["<", ">", "=", "&", "|", "^", "~", "=", "?", ":", "!", "+", "-", "*", "/", "%"]
     for target in targets:
-        ptn_before = "(\w+)(" + "[" + re.escape("<>=&|^~=?:!+-*/&") + "]*" + re.escape(target) + "[" + re.escape("<>=&|^~=?:!+-*/&") + "]*)(.*)"
+        ptn_before = (
+            "(\w+)("
+            + "["
+            + re.escape("<>=&|^~=?:!+-*/&")
+            + "]*"
+            + re.escape(target)
+            + "["
+            + re.escape("<>=&|^~=?:!+-*/&")
+            + "]*)(.*)"
+        )
         reptn_before = re.compile(ptn_before)
-        ptn_after = "(" + "[" + re.escape("<>=&|^~=?:!+-*/&") + "]*" + re.escape(target) + "[" + re.escape("<>=&|^~=?:!+-*/&") + "]*)(\w+)"
+        ptn_after = (
+            "("
+            + "["
+            + re.escape("<>=&|^~=?:!+-*/&")
+            + "]*"
+            + re.escape(target)
+            + "["
+            + re.escape("<>=&|^~=?:!+-*/&")
+            + "]*)(\w+)"
+        )
         reptn_after = re.compile(ptn_after)
 
         ptn_after_monadic_operator = "(\w+)( *)(" + re.escape(target) + ")(\w+)"
@@ -547,11 +615,13 @@ def check_operator_space_(path: str, code_lines: list) -> int:
                     continue
                 if match.group(2) in ["->", "++", "--", "::", "::~"]:
                     continue
-                if match.group(2) == ":" and line.find("case", 0, match.start()):   # case hoge:
+                if match.group(2) == ":" and line.find("case", 0, match.start()):  # case hoge:
                     continue
-                if match.group(2) in [">", "/"] and line[0:8] == "#include":        # #include <src_core/TlmCmd/command_dispatcher.h> など
+                if (
+                    match.group(2) in [">", "/"] and line[0:8] == "#include"
+                ):  # #include <src_core/TlmCmd/command_dispatcher.h> など
                     continue
-                if match.group(2) in ["-", "+"]:   # 10.5e-10 -> 5e, - でひっかかる
+                if match.group(2) in ["-", "+"]:  # 10.5e-10 -> 5e, - でひっかかる
                     ptn = "\d+(e|E)"
                     reptn = re.compile(ptn)
                     if not reptn.search(match.group(1)) is None:
@@ -567,7 +637,12 @@ def check_operator_space_(path: str, code_lines: list) -> int:
                 # print("#" + match.group(1) + "#")
                 # print("#" + match.group(2) + "#")
 
-                print(path + ": " + str(idx + 1) + ": SPACE IS REQUIRED BEFORE AND AFTER BINARY OPERATOR")
+                print(
+                    path
+                    + ": "
+                    + str(idx + 1)
+                    + ": SPACE IS REQUIRED BEFORE AND AFTER BINARY OPERATOR"
+                )
                 if IS_SHOW_CODE_AT_ERR:
                     print(line)
                 flag = 1
@@ -578,12 +653,22 @@ def check_operator_space_(path: str, code_lines: list) -> int:
                     continue
                 if is_in_string_context_(line, match.start()):
                     continue
-                if match.group(1) in ["->", "++", "--", "::", "::~", "&", "!"]:       # TOOD: "&" は二項演算子のときに漏れが発生する・・・
+                if match.group(1) in [
+                    "->",
+                    "++",
+                    "--",
+                    "::",
+                    "::~",
+                    "&",
+                    "!",
+                ]:  # TOOD: "&" は二項演算子のときに漏れが発生する・・・
                     continue
-                if match.group(1) in ["<", "/"] and line[0:8] == "#include":        # #include <src_core/TlmCmd/command_dispatcher.h> など
+                if (
+                    match.group(1) in ["<", "/"] and line[0:8] == "#include"
+                ):  # #include <src_core/TlmCmd/command_dispatcher.h> など
                     continue
-                if match.group(1) in ["+", "-", "*", "~"]:   # TODO 単項演算子問題
-                    before_line = line[:match.start()].strip()
+                if match.group(1) in ["+", "-", "*", "~"]:  # TODO 単項演算子問題
+                    before_line = line[: match.start()].strip()
                     if before_line == "":
                         continue
                     if before_line[-6:] == "return":
@@ -594,13 +679,13 @@ def check_operator_space_(path: str, code_lines: list) -> int:
                     # print(reptn.search(before_line))
                     if reptn.search(before_line) is None:
                         continue
-                    if  match.group(1) == "*":
+                    if match.group(1) == "*":
                         ptn = "\w+$"
                         reptn = re.compile(ptn)
                         m = reptn.search(before_line).group()
                         if m == "else" or m in g_type_set:
                             continue
-                    if  match.group(1) in ["-", "+"]:
+                    if match.group(1) in ["-", "+"]:
                         ptn = "\d+(e|E)$"
                         reptn = re.compile(ptn)
                         if not reptn.search(before_line) is None:
@@ -611,7 +696,12 @@ def check_operator_space_(path: str, code_lines: list) -> int:
                 # print("#" + match.group(1) + "#")
                 # print("#" + match.group(2) + "#")
 
-                print(path + ": " + str(idx + 1) + ": SPACE IS REQUIRED BEFORE AND AFTER BINARY OPERATOR")
+                print(
+                    path
+                    + ": "
+                    + str(idx + 1)
+                    + ": SPACE IS REQUIRED BEFORE AND AFTER BINARY OPERATOR"
+                )
                 if IS_SHOW_CODE_AT_ERR:
                     print(line)
                 flag = 1
@@ -632,7 +722,9 @@ def check_preprocessor_(path: str, code_lines: list) -> int:
             if is_in_non_string_code(path, code_lines, idx, pos):
                 continue
 
-            print(path + ": " + str(idx + 1) + ": PREPROCESSOR DIRECTIVES DO NOT REQUIRE INDENTATION")
+            print(
+                path + ": " + str(idx + 1) + ": PREPROCESSOR DIRECTIVES DO NOT REQUIRE INDENTATION"
+            )
             if IS_SHOW_CODE_AT_ERR:
                 print(line)
             flag = 1
@@ -683,15 +775,15 @@ def is_contained_pattern_(line: str, target: str) -> int:
     target_len = len(target)
     while 1:
         pos = line.find(target, find_begin)
-        if pos == -1:      # そもそも存在しない
+        if pos == -1:  # そもそも存在しない
             return 0
         if is_in_string_context_(line, pos):
             pass
         elif is_in_comment_context_in_line_(line, pos):
             pass
         else:
-            return 1;
-        find_begin = pos + target_len;
+            return 1
+        find_begin = pos + target_len
 
     return 0
 
@@ -714,17 +806,17 @@ def has_started_with_list_after_target_(line: str, target: str, starts: list) ->
     target_len = len(target)
     while 1:
         pos = line.find(target, find_begin)
-        if pos == -1:      # そもそも存在しない
+        if pos == -1:  # そもそも存在しない
             return 1
-        if pos + target_len == len(line):       # 行末
+        if pos + target_len == len(line):  # 行末
             return 1
         if is_in_string_context_(line, pos):
             pass
         elif is_in_comment_context_in_line_(line, pos):
             pass
-        elif not line[pos + target_len:].startswith(tuple(starts)):
-            return 0;
-        find_begin = pos + target_len;
+        elif not line[pos + target_len :].startswith(tuple(starts)):
+            return 0
+        find_begin = pos + target_len
 
     return 1
 
@@ -736,17 +828,17 @@ def has_ended_with_list_before_target_(line: str, target: str, ends: list) -> in
     target_len = len(target)
     while 1:
         pos = line.rfind(target, 0, find_end)
-        if pos == -1:      # そもそも存在しない
+        if pos == -1:  # そもそも存在しない
             return 1
-        if pos == 0:       # 行頭
+        if pos == 0:  # 行頭
             return 1
         if is_in_string_context_(line, pos):
             pass
         elif is_in_comment_context_in_line_(line, pos):
             pass
         elif not line[:pos].endswith(tuple(ends)):
-            return 0;
-        find_end = pos;
+            return 0
+        find_end = pos
 
     return 1
 
@@ -761,24 +853,24 @@ def has_line_ended_with_target_(line: str, target: str) -> int:
         # その場合，２番目移行も探索する
         # コメントコンテキストの場合は飛ばす
         pos_target = line.find(target, find_begin)
-        if pos_target == -1:      # そもそも存在しない
+        if pos_target == -1:  # そもそも存在しない
             return 1
-        if pos_target + target_len == len(line):       # 行末
+        if pos_target + target_len == len(line):  # 行末
             return 1
         if is_in_string_context_(line, pos_target):
-            find_begin = pos_target + target_len;
+            find_begin = pos_target + target_len
             continue
         else:
             if is_in_comment_context_in_line_(line, pos_target):
-                return 1            # TODO: コーナーケースは残ってるが．．．
+                return 1  # TODO: コーナーケースは残ってるが．．．
             break
 
-    for pos in range(pos_target + 1, len(line)):      # そのあとコメントであればOK
+    for pos in range(pos_target + 1, len(line)):  # そのあとコメントであればOK
         if line[pos] == " ":
             continue
         elif line[pos] == "/":
             if (pos + 1) < len(line):
-                if line[pos+1] == "/" or line[pos+1] == "*":
+                if line[pos + 1] == "/" or line[pos + 1] == "*":
                     return 1
             return 0
         else:
@@ -808,10 +900,10 @@ def is_in_non_string_code(path: str, lines: list, line_no: int, pos: int) -> int
 # 1: コメントの中, 0: 外
 # 単一行用
 def is_in_comment_context_in_line_(line: str, pos: int) -> int:
-    before = line[:pos]     # pos より先の文字列
-    after = ""              # pos より後の文字列
+    before = line[:pos]  # pos より先の文字列
+    after = ""  # pos より後の文字列
     if len(line) > pos:
-        after  = line[pos+1:]
+        after = line[pos + 1 :]
 
     find_begin = 0
     while 1:
@@ -855,21 +947,23 @@ def is_in_comment_context_in_multiline_(path: str, lines: list, line_no: int) ->
         is_in_comment_context_in_multiline_.memo[path][str(line_no)] = 0
 
     count_start = 0
-    count_end   = 0
+    count_end = 0
     for i in range(line_no):
         count_start += lines[i].count("/*")
-        count_end   += lines[i].count("*/")
+        count_end += lines[i].count("*/")
 
     if count_start > count_end:
         is_in_comment_context_in_multiline_.memo[path][str(line_no)] = 1
         return 1
     return 0
-is_in_comment_context_in_multiline_.memo = {}       # メモ最適化のためのstatic変数
+
+
+is_in_comment_context_in_multiline_.memo = {}  # メモ最適化のためのstatic変数
 
 
 # 1: 文字列リテラルの中, 0: 外
 def is_in_string_context_(line: str, pos: int) -> int:
-    before = line[:pos]     # pos より先の文字列
+    before = line[:pos]  # pos より先の文字列
 
     num_of_quotation = before.count('"') - before.count('\\"')
     if num_of_quotation % 2 == 1:
@@ -886,11 +980,13 @@ def remove_comment_and_strip_(line: str) -> str:
     line = remove_comment_and_strip_.reptn1.sub(" ", line)
     line = remove_comment_and_strip_.reptn2.sub(" ", line)
     return line.strip()
+
+
 remove_comment_and_strip_.pnt1 = re.escape("/*") + ".*" + re.escape("*/")
 remove_comment_and_strip_.reptn1 = re.compile(remove_comment_and_strip_.pnt1)
 remove_comment_and_strip_.pnt2 = re.escape("//") + ".*$"
 remove_comment_and_strip_.reptn2 = re.compile(remove_comment_and_strip_.pnt2)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/Script/CI/check_coding_rule.py
+++ b/Script/CI/check_coding_rule.py
@@ -128,7 +128,7 @@ def preprocess_inner_(path: str, settings: dict):
     with open(path, encoding=settings["input_file_encoding"]) as f:
         code_lines = f.read().split("\n")
 
-    ptn_find_type = "^ *(\w+)\*? +\w+"
+    ptn_find_type = r"^ *(\w+)\*? +\w+"
     reptn_find_type = re.compile(ptn_find_type)
     ptn_replace_qualifier = (
         "^ *((const|static|extern|volatile|register)+ +)+"  # static const hoge も検出できるように
@@ -345,7 +345,7 @@ def check_newline_(path: str, code_lines: list) -> int:
         if all_text.find(target) == -1:
             continue
 
-        ptn = "^(|.*(\W))(" + re.escape(target) + ")(\W).*\{.*(" + re.escape("//|/*") + ")?"
+        ptn = r"^(|.*(\W))(" + re.escape(target) + r")(\W).*\{.*(" + re.escape("//|/*") + ")?"
         reptn = re.compile(ptn)
         for idx, line in enumerate(code_lines):
             if is_in_comment_context_in_multiline_(path, code_lines, idx):
@@ -364,7 +364,7 @@ def check_newline_(path: str, code_lines: list) -> int:
         if all_text.find(target) == -1:
             continue
 
-        ptn = "^.*\}.*(\W)(" + re.escape(target) + ")(\W.*|)$"
+        ptn = r"^.*\}.*(\W)(" + re.escape(target) + r")(\W.*|)$"
         reptn = re.compile(ptn)
         for idx, line in enumerate(code_lines):
             if is_in_comment_context_in_multiline_(path, code_lines, idx):
@@ -520,7 +520,7 @@ def check_operator_space_(path: str, code_lines: list) -> int:
         if all_text.find(target) == -1:
             continue
 
-        ptn = "(\W)" + "(" + re.escape(target) + ")"
+        ptn = r"(\W)" + "(" + re.escape(target) + ")"
         reptn = re.compile(ptn)
         for idx, line in enumerate(code_lines):
             if is_in_comment_context_in_multiline_(path, code_lines, idx):
@@ -546,7 +546,7 @@ def check_operator_space_(path: str, code_lines: list) -> int:
         if all_text.find(target) == -1:
             continue
 
-        ptn = "(\W)" + "(" + re.escape(target) + ")"
+        ptn = r"(\W)" + "(" + re.escape(target) + ")"
         reptn = re.compile(ptn)
         for idx, line in enumerate(code_lines):
             if is_in_comment_context_in_multiline_(path, code_lines, idx):
@@ -583,7 +583,7 @@ def check_operator_space_(path: str, code_lines: list) -> int:
     targets = ["<", ">", "=", "&", "|", "^", "~", "=", "?", ":", "!", "+", "-", "*", "/", "%"]
     for target in targets:
         ptn_before = (
-            "(\w+)("
+            r"(\w+)("
             + "["
             + re.escape("<>=&|^~=?:!+-*/&")
             + "]*"
@@ -601,12 +601,12 @@ def check_operator_space_(path: str, code_lines: list) -> int:
             + re.escape(target)
             + "["
             + re.escape("<>=&|^~=?:!+-*/&")
-            + "]*)(\w+)"
+            + r"]*)(\w+)"
         )
         reptn_after = re.compile(ptn_after)
 
-        ptn_after_monadic_operator = "(\w+)( *)(" + re.escape(target) + ")(\w+)"
-        reptn_after_monadic_operator = re.compile(ptn_after_monadic_operator)
+        # ptn_after_monadic_operator = r"(\w+)( *)(" + re.escape(target) + r")(\w+)"
+        # reptn_after_monadic_operator = re.compile(ptn_after_monadic_operator)
 
         for idx, line in enumerate(code_lines):
             if is_in_comment_context_in_multiline_(path, code_lines, idx):
@@ -627,7 +627,7 @@ def check_operator_space_(path: str, code_lines: list) -> int:
                 ):  # #include <src_core/TlmCmd/command_dispatcher.h> など
                     continue
                 if match.group(2) in ["-", "+"]:  # 10.5e-10 -> 5e, - でひっかかる
-                    ptn = "\d+(e|E)"
+                    ptn = r"\d+(e|E)"
                     reptn = re.compile(ptn)
                     if not reptn.search(match.group(1)) is None:
                         continue
@@ -678,20 +678,20 @@ def check_operator_space_(path: str, code_lines: list) -> int:
                         continue
                     if before_line[-6:] == "return":
                         continue
-                    ptn = "[\w\]\}]$"
+                    ptn = r"[\w\]\}]$"
                     reptn = re.compile(ptn)
                     # print(line)
                     # print(reptn.search(before_line))
                     if reptn.search(before_line) is None:
                         continue
                     if match.group(1) == "*":
-                        ptn = "\w+$"
+                        ptn = r"\w+$"
                         reptn = re.compile(ptn)
                         m = reptn.search(before_line).group()
                         if m == "else" or m in g_type_set:
                             continue
                     if match.group(1) in ["-", "+"]:
-                        ptn = "\d+(e|E)$"
+                        ptn = r"\d+(e|E)$"
                         reptn = re.compile(ptn)
                         if not reptn.search(before_line) is None:
                             continue
@@ -830,7 +830,7 @@ def has_started_with_list_after_target_(line: str, target: str, starts: list) ->
 def has_ended_with_list_before_target_(line: str, target: str, ends: list) -> int:
     pos = 0
     find_end = len(line)
-    target_len = len(target)
+    # target_len = len(target)
     while 1:
         pos = line.rfind(target, 0, find_end)
         if pos == -1:  # そもそも存在しない
@@ -906,9 +906,9 @@ def is_in_non_string_code(path: str, lines: list, line_no: int, pos: int) -> int
 # 単一行用
 def is_in_comment_context_in_line_(line: str, pos: int) -> int:
     before = line[:pos]  # pos より先の文字列
-    after = ""  # pos より後の文字列
-    if len(line) > pos:
-        after = line[pos + 1 :]
+    # after = ""  # pos より後の文字列
+    # if len(line) > pos:
+    #     after = line[pos + 1 :]
 
     find_begin = 0
     while 1:

--- a/Script/CI/check_coding_rule.py
+++ b/Script/CI/check_coding_rule.py
@@ -483,7 +483,12 @@ def check_operator_space_(path: str, code_lines: list) -> int:
                 flag = 1
         # if "{" in line:
         #     if not has_ended_with_list_before_target_(line, "{", [" ", "{"]):
-        #         print(path + ": " + str(idx + 1) + ": ALLMAN STYLE IS REQUIRED OR SPACE IS REQUIRED BEFORE '{'")
+        #         print(
+        #             path
+        #             + ": "
+        #             + str(idx + 1)
+        #             + ": ALLMAN STYLE IS REQUIRED OR SPACE IS REQUIRED BEFORE '{'"
+        #         )
         #         if IS_SHOW_CODE_AT_ERR:
         #             print(line)
         #         flag = 1
@@ -568,14 +573,58 @@ def check_operator_space_(path: str, code_lines: list) -> int:
                     flag = 1
 
     # これは endif で ifとかがヒットするのでNG
-    # # targets = ["for", "if", "while", "return", "switch", "case", "break", "else", "goto", "auto", "continue", "extern", "enum", "union", "register", "static", "struct", "typedef", "volatile"]
-    # targets = ["for", "if", "while", "switch", "case", "else", "goto", "auto", "extern", "enum", "union", "register", "static", "struct", "typedef", "volatile"]
+    # # targets = [
+    # #     "for",
+    # #     "if",
+    # #     "while",
+    # #     "return",
+    # #     "switch",
+    # #     "case",
+    # #     "break",
+    # #     "else",
+    # #     "goto",
+    # #     "auto",
+    # #     "continue",
+    # #     "extern",
+    # #     "enum",
+    # #     "union",
+    # #     "register",
+    # #     "static",
+    # #     "struct",
+    # #     "typedef",
+    # #     "volatile",
+    # # ]
+    # targets = [
+    #     "for",
+    #     "if",
+    #     "while",
+    #     "switch",
+    #     "case",
+    #     "else",
+    #     "goto",
+    #     "auto",
+    #     "extern",
+    #     "enum",
+    #     "union",
+    #     "register",
+    #     "static",
+    #     "struct",
+    #     "typedef",
+    #     "volatile",
+    # ]
     # for idx, line in enumerate(code_lines):
     #     if is_in_comment_context_in_multiline_(path, code_lines, idx):
     #         continue
     #     for target in targets:
     #         if not is_there_space_befor_after_(line, target):
-    #             print(path + ": " + str(idx + 1) + ": SPACE IS REQUIRED BEFORE AND AFTER '" + target + "'")
+    #             print(
+    #                 path
+    #                 + ": "
+    #                 + str(idx + 1)
+    #                 + ": SPACE IS REQUIRED BEFORE AND AFTER '"
+    #                 + target
+    #                 + "'"
+    #             )
     #             if IS_SHOW_CODE_AT_ERR:
     #                 print(line)
     #             flag = 1

--- a/Script/CI/check_encoding.py
+++ b/Script/CI/check_encoding.py
@@ -16,6 +16,7 @@ DEBUG = 0
 # 0 : Release
 # 1 : all
 
+
 def main():
     if len(sys.argv) != 2:
         print("Please give a setting file as an argumente.")
@@ -26,14 +27,14 @@ def main():
         print("Setting file not found.")
         sys.exit(1)
 
-    with open(setting_file_path, mode='r') as fh:
+    with open(setting_file_path, mode="r") as fh:
         settings = json.load(fh)
     if DEBUG:
         pprint.pprint(settings)
 
     target_dirs = []
-    for target_dir in settings['target_dirs']:
-        target_dirs.append(settings['root_dir'] + target_dir)
+    for target_dir in settings["target_dirs"]:
+        target_dirs.append(settings["root_dir"] + target_dir)
 
     flag = 0
     for target_dir in target_dirs:
@@ -53,16 +54,16 @@ def check(target_dir, settings):
     flag = 0
     for root, dirs, files in os.walk(target_dir):
         for file in files:
-            ext = (os.path.splitext(file))[1].replace('.', '')
+            ext = (os.path.splitext(file))[1].replace(".", "")
             # print(ext)
-            if ext in settings['text_file_config']['extensions']:
-                encoding = settings['text_file_config']['input_encoding']
-            elif ext in settings['code_file_config']['extensions']:
-                encoding = settings['code_file_config']['input_encoding']
-            elif ext in settings['script_file_config']['extensions']:
-                encoding = settings['script_file_config']['input_encoding']
-            elif ext in settings['exceptional_file_config']['extensions']:
-                encoding = settings['exceptional_file_config']['input_encoding']
+            if ext in settings["text_file_config"]["extensions"]:
+                encoding = settings["text_file_config"]["input_encoding"]
+            elif ext in settings["code_file_config"]["extensions"]:
+                encoding = settings["code_file_config"]["input_encoding"]
+            elif ext in settings["script_file_config"]["extensions"]:
+                encoding = settings["script_file_config"]["input_encoding"]
+            elif ext in settings["exceptional_file_config"]["extensions"]:
+                encoding = settings["exceptional_file_config"]["input_encoding"]
             else:
                 continue
 
@@ -76,22 +77,22 @@ def check(target_dir, settings):
 
 # 0: OK, 1: NG
 def check_encoding(path, encoding):
-    with open(path, 'rb') as f:
+    with open(path, "rb") as f:
         # print(path)
         ret = chardet.detect(f.read())
-        enc = ret['encoding']
+        enc = ret["encoding"]
     # print(enc)
-    if encoding == 'utf-8':
-        if enc == 'utf-8' or enc == 'ascii':
+    if encoding == "utf-8":
+        if enc == "utf-8" or enc == "ascii":
             return 0
         # なぜか以下のような誤認もあるので
-        if enc == 'Windows-1252' or enc == 'ISO-8859-1' or enc is None:
+        if enc == "Windows-1252" or enc == "ISO-8859-1" or enc is None:
             return 0
-    elif encoding == 'shift_jis':
-        if enc == 'SHIFT_JIS' or enc == 'CP932' or enc == 'ascii':
+    elif encoding == "shift_jis":
+        if enc == "SHIFT_JIS" or enc == "CP932" or enc == "ascii":
             return 0
         # なぜか以下のような誤認もあるので
-        if enc == 'Windows-1252' or enc == 'Windows-1254' or enc is None:
+        if enc == "Windows-1252" or enc == "Windows-1254" or enc is None:
             return 0
     else:
         print("Invalid encoding in setting file!")
@@ -101,6 +102,5 @@ def check_encoding(path, encoding):
     return 1
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [tool.black]
 target-version = ['py38']
-line-length = 120
+line-length = 100
 include = '\.pyi?$'
 
 # TODO: .flake8 を消してこちらに移植する
 # [tool.flake8]
-# max-line-length = 120
+# max-line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,5 +3,6 @@ target-version = ['py38']
 line-length = 120
 include = '\.pyi?$'
 
-[tool.flake8]
-max-line-length = 120
+# TODO: .flake8 を消してこちらに移植する
+# [tool.flake8]
+# max-line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.black]
+target-version = ['py38']
+line-length = 120
+include = '\.pyi?$'
+
+[tool.flake8]
+max-line-length = 120


### PR DESCRIPTION
## 概要
pythonのフォーマットチェックCIとリンタCIをいれる

## Issue
- https://github.com/ut-issl/c2a-core/issues/89

## 詳細
- 以下を入れた
  - formatter: https://github.com/reviewdog/action-black
  - linter: https://github.com/reviewdog/action-flake8
- １行最大文字数はとりあえず100
- flake8 で `ignore = E203,W503,W504` としてるのは，blackと競合するから
- flake8 で `ignore = E402` としているのは https://github.com/ut-issl/c2a-core/issues/195 で対応
- blackは  https://github.com/ut-issl/c2a-core/blob/9e2faa95eb20abf2975ceea2cb96b5beb9045e70/.github/workflows/python_check_format.yml#L22-L23 としてる
- flake8 は https://github.com/ut-issl/c2a-core/blob/9e2faa95eb20abf2975ceea2cb96b5beb9045e70/pyproject.toml#L6-L8 としている．

## 検証結果
CIと既存のテストがすべて通ればOK

## 影響範囲
今後，このCIの通過が必須になる

