### PR TITLE
ApplicationsとLibraryを必要な場合のみadd_subdirectoryする修正

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,14 +42,13 @@ endif()
 
 add_library(${PROJECT_NAME} STATIC ${C2A_SRCS})
 
-add_subdirectory(Applications)
-add_subdirectory(Library)
-
 if(USE_ALL_C2A_CORE_APPS)
+  add_subdirectory(Applications)
   target_link_libraries(${PROJECT_NAME} C2A_CORE_APPS)
 endif()
 
 if(USE_ALL_C2A_CORE_LIB)
+  add_subdirectory(Library)
   target_link_libraries(${PROJECT_NAME} C2A_CORE_LIB)
 endif()
 


### PR DESCRIPTION
## 概要
ApplicationsとLibraryを使わない場合でも、add_subdirectoryによって
サブディレクトリ内のCMakeLists.txtが読み込まれていた

## Issue
NA

## 検証結果
別環境で確認