### PR TITLE
ビルドCIを，すべてのPRで回すように設定

### DIFF
--- a/.github/workflows/build_as_c89.yml
+++ b/.github/workflows/build_as_c89.yml
@@ -6,21 +6,6 @@ on:
       - main
       - develop
   pull_request:
-    paths:
-      - '.github/workflows/build_as_c89.yml'
-      - 'c2a_core_main.c'
-      - 'c2a_core_main.h'
-      - 'common.cmake'
-      - 'Applications/**'
-      - 'Drivers/**'
-      - 'IfWrapper/**'
-      - 'Library/**'
-      - 'System/**'
-      - 'TlmCmd/**'
-      - 'Examples/minimum_user_for_s2e/CMakeLists.txt'
-      - 'Examples/minimum_user_for_s2e/src/**'
-      - 'setup.bat'
-      - 'setup.sh'
 
 jobs:
   gen_build_matrix:

--- a/.github/workflows/build_as_cxx.yml
+++ b/.github/workflows/build_as_cxx.yml
@@ -6,21 +6,6 @@ on:
       - main
       - develop
   pull_request:
-    paths:
-      - '.github/workflows/build_as_cxx.yml'
-      - 'c2a_core_main.c'
-      - 'c2a_core_main.h'
-      - 'common.cmake'
-      - 'Applications/**'
-      - 'Drivers/**'
-      - 'IfWrapper/**'
-      - 'Library/**'
-      - 'System/**'
-      - 'TlmCmd/**'
-      - 'Examples/minimum_user_for_s2e/CMakeLists.txt'
-      - 'Examples/minimum_user_for_s2e/src/**'
-      - 'setup.bat'
-      - 'setup.sh'
 
 jobs:
   build_minimum_user_as_cxx:


### PR DESCRIPTION
## 概要
ビルドCIを，すべてのPRで回すように設定

## Issue
NA

## 詳細
https://github.com/ut-issl/c2a-core/pull/193#issuecomment-1014560773 で，発生．pathの管理がめんどくさいので，毎回回すようにする

## 検証結果
NA

