### PR TITLE
Add E501 to ignore list for flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,6 +3,7 @@ max-line-length = 100
 ignore =
     # black と競合するので
     E203,
+    E501,
     W503,
     W504,
     # https://github.com/ut-issl/c2a-core/issues/195


### PR DESCRIPTION
## 概要
flake8のignoreにE501をいれた

## Issue
- https://github.com/ut-issl/c2a-core/issues/89

## 詳細
- https://github.com/ut-issl/c2a-tlm-cmd-code-generator/pull/14#issuecomment-1016605387 での議論でそうなったので，こちらにも反映

## 検証結果
CIが通ればOK
