### PR TITLE
check_coding_ruleの出力をreviewdogから出す

### DIFF
--- a/.github/workflows/check_coding_rule.yml
+++ b/.github/workflows/check_coding_rule.yml
@@ -28,6 +28,12 @@ jobs:
       - name: install reviewdog
         uses: reviewdog/action-setup@v1.0.3
 
+      - name: fix error log source file path
+        run: |
+          sed 's/.\/src_core\///g' < /tmp/coding-rule.log \
+          | > ./coding-rule.log \
+            sed 's/.\/src_user/Examples\/minimum_user_for_s2e\/src\/src_user/g'
+
       - name: reviewdog
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -42,4 +48,4 @@ jobs:
             -efm="%-GThe above files are invalid coding rule." \
             -efm="%E%f: %l: %m" \
             -efm="%Z%s" \
-            < /tmp/coding-rule.log
+            < coding-rule.log

--- a/.github/workflows/check_coding_rule.yml
+++ b/.github/workflows/check_coding_rule.yml
@@ -20,5 +20,26 @@ jobs:
         shell: bash
         run: ./setup.sh
       - name: check_coding_rule
-        run: python ./src_core/Script/CI/check_coding_rule.py ./src_core/Script/CI/check_coding_rule.json
+        continue-on-error: true
         working-directory: ./Examples/minimum_user_for_s2e/src
+        run: |
+          python ./src_core/Script/CI/check_coding_rule.py ./src_core/Script/CI/check_coding_rule.json | tee /tmp/coding-rule.log
+
+      - name: install reviewdog
+        uses: reviewdog/action-setup@v1.0.3
+
+      - name: reviewdog
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          reviewdog \
+            -name 'check_coding_rule' \
+            -level error \
+            -fail-on-error=true \
+            -filter-mode=nofilter \
+            -diff="git diff FETCH_HEAD" \
+            -reporter=github-pr-check \
+            -efm="%-GThe above files are invalid coding rule." \
+            -efm="%E%f: %l: %m" \
+            -efm="%Z%s" \
+            < /tmp/coding-rule.log

--- a/.github/workflows/check_coding_rule.yml
+++ b/.github/workflows/check_coding_rule.yml
@@ -34,7 +34,7 @@ jobs:
           | > ./coding-rule.log \
             sed 's/.\/src_user/Examples\/minimum_user_for_s2e\/src\/src_user/g'
 
-      - name: reviewdog
+      - name: reviewdog(github-pr-review)
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -42,9 +42,9 @@ jobs:
             -name 'check_coding_rule' \
             -level error \
             -fail-on-error=true \
-            -filter-mode=nofilter \
+            -filter-mode=added \
             -diff="git diff FETCH_HEAD" \
-            -reporter=github-pr-check \
+            -reporter=github-pr-review \
             -efm="%-GThe above files are invalid coding rule." \
             -efm="%E%f: %l: %m" \
             -efm="%Z%s" \


### PR DESCRIPTION
## 概要
独自スクリプトによるコーディングスタイルチェックの結果をreviewdogを使って表示する

## Issue
- https://github.com/ut-issl/c2a-core/issues/22

## 詳細
詳しく

## 検証結果
test へのリンクや，検証結果へのリンク

## 影響範囲
XX系の動作がガラッと変わる，とか．

## 補足
何かあれば

## 注意
- 関連する Projects が存在する場合，それの紐付けを行うこと
- Assignees を設定すること
- 可能ならば Reviewers を設定すること
- 可能ならば `priority` ラベルを付けること
