### PR TITLE
Remove duplicate error on reviewdog

### DIFF
--- a/.github/workflows/build_as_c89.yml
+++ b/.github/workflows/build_as_c89.yml
@@ -122,12 +122,16 @@ jobs:
         working-directory: ./Examples/minimum_user_for_s2e/build
         run: cat clang_tidy.log
 
+      - name: remove duplicate error
+        if: matrix.compiler == 'clang'
+        run: |
+          python Script/CI/remove_duplicate_error.py ./Examples/minimum_user_for_s2e/build/clang_tidy.log "clang-tidy" | tee clang_tidy.log
+
       - name: reviewdog clang-tidy (github-pr-review)
         if: matrix.compiler == 'clang' && matrix.warning == 'Werror'
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          cp ./Examples/minimum_user_for_s2e/build/clang_tidy.log .
           reviewdog \
             -name 'clang-tidy(Werror)' \
             -level warning \
@@ -147,7 +151,6 @@ jobs:
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          cp ./Examples/minimum_user_for_s2e/build/clang_tidy.log .
           reviewdog \
             -name 'clang-tidy(Wextra)' \
             -level warning \

--- a/Script/CI/remove_duplicate_error.py
+++ b/Script/CI/remove_duplicate_error.py
@@ -15,7 +15,6 @@ with open(file) as f:
         (cmd, err) = l.split("\n", 1)
         if err in errors:
             print("duplicate: " + cmd, file=sys.stderr)
-            pass
         else:
             errors.append(err)
             print(compiler + l, end="")

--- a/Script/CI/remove_duplicate_error.py
+++ b/Script/CI/remove_duplicate_error.py
@@ -11,7 +11,7 @@ with open(file) as f:
     # print(log)
 
     errors = []
-    for l in log:
+    for l in log:  # noqa: E741
         (cmd, err) = l.split("\n", 1)
         if err in errors:
             print("duplicate: " + cmd, file=sys.stderr)

--- a/Script/CI/remove_duplicate_error.py
+++ b/Script/CI/remove_duplicate_error.py
@@ -1,0 +1,21 @@
+import sys
+
+file = sys.argv[1]
+compiler = sys.argv[2]
+
+with open(file) as f:
+    s = f.read()
+    log = s.split(compiler)
+    if "" in log:
+        log.remove("")
+    # print(log)
+
+    errors = []
+    for l in log:
+        (cmd, err) = l.split("\n", 1)
+        if err in errors:
+            print("duplicate: " + cmd, file=sys.stderr)
+            pass
+        else:
+            errors.append(err)
+            print(compiler + l, end="")


### PR DESCRIPTION
## 概要
同一のファイルに対して同一のエラーが(異なるファイルから)出ている時にreviewdogの出力が重複するのを避ける

## Issue
NA

## 詳細
- 例: https://github.com/ut-issl/c2a-core/runs/4952194939?check_suite_focus=true
