### PR TITLE
EH のルールがactive状態か取得する関数を追加

### DIFF
--- a/System/EventManager/event_handler.c
+++ b/System/EventManager/event_handler.c
@@ -1150,6 +1150,15 @@ EH_CHECK_RULE_ACK EH_inactivate_rule_for_multi_level(EH_RULE_ID id)
   return EH_CHECK_RULE_ACK_OK;
 }
 
+EH_CHECK_RULE_ACK EH_get_rule_is_active(EH_RULE_ID id, uint8_t* is_active)
+{
+  EH_CHECK_RULE_ACK ack = EH_check_rule_id_(id);
+  if (ack != EH_CHECK_RULE_ACK_OK) return ack;
+
+  *is_active = event_handler_.rule_table.rules[id].settings.is_active;
+
+  return EH_CHECK_RULE_ACK_OK;
+}
 
 EH_CHECK_RULE_ACK EH_set_rule_counter(EH_RULE_ID id, uint16_t counter)
 {

--- a/System/EventManager/event_handler.h
+++ b/System/EventManager/event_handler.h
@@ -414,7 +414,7 @@ EH_CHECK_RULE_ACK EH_inactivate_rule_for_multi_level(EH_RULE_ID id);
 /**
  * @brief ルールが有効かどうか取得する
  * @param[in]  id: EH_RULE_ID
- * @param[out] is_active: 
+ * @param[out] is_active: 有効かどうか
  * @return EH_CHECK_RULE_ACK
  */
 EH_CHECK_RULE_ACK EH_get_rule_is_active(EH_RULE_ID id, uint8_t* is_active);

--- a/System/EventManager/event_handler.h
+++ b/System/EventManager/event_handler.h
@@ -412,6 +412,14 @@ EH_CHECK_RULE_ACK EH_activate_rule_for_multi_level(EH_RULE_ID id);
 EH_CHECK_RULE_ACK EH_inactivate_rule_for_multi_level(EH_RULE_ID id);
 
 /**
+ * @brief ルールが有効かどうか取得する
+ * @param[in]  id: EH_RULE_ID
+ * @param[out] is_active: 
+ * @return EH_CHECK_RULE_ACK
+ */
+EH_CHECK_RULE_ACK EH_get_rule_is_active(EH_RULE_ID id, uint8_t* is_active);
+
+/**
  * @brief  EH_Rule の counter をセット
  * @note   基本的にはコマンドで操作するので，直接使うことはあまり想定していない
  * @param  id: EH_RULE_ID


### PR DESCRIPTION
## 概要
EH のルールがactive状態か取得する関数を追加

## Issue
N/A

## 詳細
EH rule は activate時にcounter clear を行うので、既にactive な状態でactivate したくなかったため、関数を追加した

## 検証結果
手元で関数を追加し、動くことをチェックした

## 影響範囲
小
