### PR TITLE
C2A Coreの搭載実績を書く

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,22 @@
 - `feature/*` : 開発ブランチ
 - `hotfix/*` : 重大バグ修正用ブランチ
 
+
+## 採用実績・動作実績
+C2A Core の採用実績のある衛星 OBC や動作実績のあるボードの情報をまとめる．
+
+| Name | Satellite | Lead Institution | Launch | CPU | Clock | ROM | RAM | NVRAM | Storage | Interface | Reference |
+| -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- |
+| MOBC | ONGLAISAT | ISSL at the University of Tokyo | - | Renesas Electronics SH-2A | 200 MHz | 2.5 MiB internal ROM | 128 KiB internal RAM, 8 MiB external SRAM | 2 MiB MRAM | 2 GiB NAND flash memory | UART (RS422, LVTTL), CCSDS (LVTTL), GPIO (LVTTL), ADC | [1] |
+| AOBC | ONGLAISAT | ISSL at the University of Tokyo | - | Microchip Technology PIC32MX7 | 80 MHz | 512 KiB internal ROM | 128 KiB internal RAM | 512 KiB FRAM | None | UART (RS422, RS485, LVTTL), SPI, I2C, GPIO (LVTTL), ADC | [1] |
+| TOBC | ONGLAISAT | ISSL at the University of Tokyo | - | Microchip Technology PIC32MX7 | 30 MHz | 512 KiB internal ROM | 128 KiB internal RAM | None | None | UART (LVTTL), I2C, GPIO (LVTTL), ADC | [1] |
+| OBC (2U) | MAGNARO (親機) | Inamori Lab. at Nagoya University | - | STMicroelectronics STM32F4 | 90 MHz | 2 MiB internal ROM | 384 KiB internal RAM, 500 KiB external SRAM | 524 KiB MRAM, 131 KiB EEPROM | 16 GiB SD card | UART, SPI, I2C, GPIO, ADC, DCMI | [1] |
+| OBC (1U) | MAGNARO (子機) | Inamori Lab. at Nagoya University | - | STMicroelectronics STM32F4 | 45 MHz | 2 MiB internal ROM | 384 KiB internal RAM, 500 KiB external SRAM | 524 KiB MRAM, 131 KiB EEPROM | 16 GiB SD card | UART, SPI, I2C, GPIO, ADC, DCMI | [1] |
+
+
+[1] Ryo Suzumoto, et al. Improvement of C2A (Command-Centric Architecture) Reusability for Multiple Types of OBCs and Development of Continuous Integration Environment for Reliability of Flight Software. _33rd International Symposium on Space Technology and Science_, 2022-f-58, 2022.
+
+
 ## 関連リポジトリ
 - https://github.com/ut-issl/tlm-cmd-db
 - https://github.com/ut-issl/c2a-tlm-cmd-code-generator


### PR DESCRIPTION
## 概要
C2A Coreの搭載実績を書く

## Issue
- https://github.com/ut-issl/c2a-core/issues/168

## 詳細
ISTS発表論文から転記

