### PR TITLE
DRのないOBCで，不要なメモリを確保しないようにする

### DIFF
--- a/Examples/minimum_user_for_s2e/src/src_user/Settings/Applications/data_recorder_define.h
+++ b/Examples/minimum_user_for_s2e/src/src_user/Settings/Applications/data_recorder_define.h
@@ -1,0 +1,12 @@
+/**
+ * @file
+ * @brief Data Recorder の各種定義
+ */
+#ifndef DATA_RECORDER_DEFINE_H_
+#define DATA_RECORDER_DEFINE_H_
+
+// DR を使うか
+// 将来的に DR は C2A Core App に移植される予定
+#define DR_ENABLE
+
+#endif

--- a/Examples/minimum_user_for_s2e/src/src_user/Settings/TlmCmd/packet_handler_params.h
+++ b/Examples/minimum_user_for_s2e/src/src_user/Settings/TlmCmd/packet_handler_params.h
@@ -31,4 +31,7 @@
 #define PH_ST_TLM_LIST_MAX       (16)
 #define PH_RP_TLM_LIST_MAX       (16)
 
+// DR は使用するので， define しない
+// #define PH_DISABLE_DATA_RECORDER
+
 #endif

--- a/Examples/minimum_user_for_s2e/src/src_user/Settings/TlmCmd/packet_handler_params.h
+++ b/Examples/minimum_user_for_s2e/src/src_user/Settings/TlmCmd/packet_handler_params.h
@@ -5,6 +5,10 @@
 #ifndef PACKET_HANDLER_PARAMS_H_
 #define PACKET_HANDLER_PARAMS_H_
 
+// DR の利用の有無で必要な PL が変わるので， include する
+#include "../Applications/data_recorder_define.h"
+
+
 #undef TL_TLM_PAGE_SIZE
 #undef TL_TLM_PAGE_MAX
 
@@ -28,10 +32,9 @@
 #define PH_TL1_CMD_LIST_MAX      (TL_TLM_PAGE_SIZE * 4)
 #define PH_TL2_CMD_LIST_MAX      (TL_TLM_PAGE_SIZE * 4)
 #define PH_MS_TLM_LIST_MAX       (16)
+#ifdef DR_ENABLE
 #define PH_ST_TLM_LIST_MAX       (16)
 #define PH_RP_TLM_LIST_MAX       (16)
-
-// DR は使用するので， define しない
-// #define PH_DISABLE_DATA_RECORDER
+#endif
 
 #endif

--- a/TlmCmd/packet_handler.c
+++ b/TlmCmd/packet_handler.c
@@ -59,8 +59,10 @@ static PH_ACK PH_add_tl_cmd_(int line_no,
  */
 static PH_ACK PH_add_utl_cmd_(const CommonCmdPacket* packet);
 static PH_ACK PH_add_ms_tlm_(const CommonTlmPacket* packet);
+#ifdef DR_ENABLE
 static PH_ACK PH_add_st_tlm_(const CommonTlmPacket* packet);
 static PH_ACK PH_add_rp_tlm_(const CommonTlmPacket* packet);
+#endif
 
 
 void PH_init(void)
@@ -187,11 +189,13 @@ PH_ACK PH_analyze_tlm_packet(const CommonTlmPacket* packet)
   // Mission Telemetry
   if (flags & CTP_DEST_FLAG_MS) PH_add_ms_tlm_(packet);
 
+#ifdef DR_ENABLE
   // Stored Telemetry
   if (flags & CTP_DEST_FLAG_ST) PH_add_st_tlm_(packet);
 
   // Replay Telemetry
   if (flags & CTP_DEST_FLAG_RP) PH_add_rp_tlm_(packet);
+#endif
 
   // [TODO] 要検討:各Queue毎の登録エラー判定は未実装
   return PH_ACK_SUCCESS;
@@ -290,33 +294,27 @@ static PH_ACK PH_add_ms_tlm_(const CommonTlmPacket* packet)
 }
 
 
+#ifdef DR_ENABLE
 static PH_ACK PH_add_st_tlm_(const CommonTlmPacket* packet)
 {
-#ifdef DR_ENABLE
   PL_ACK ack = PL_push_back(&PH_st_tlm_list, packet);
 
   if (ack != PL_SUCCESS) return PH_ACK_PL_LIST_FULL;
 
   return PH_ACK_SUCCESS;
-#else
-  (void)packet;
-  return PH_ACK_SUCCESS;
-#endif
 }
+#endif
 
 
+#ifdef DR_ENABLE
 static PH_ACK PH_add_rp_tlm_(const CommonTlmPacket* packet)
 {
-#ifdef DR_ENABLE
   PL_ACK ack = PL_push_back(&PH_rp_tlm_list, packet);
 
   if (ack != PL_SUCCESS) return PH_ACK_PL_LIST_FULL;
 
   return PH_ACK_SUCCESS;
-#else
-  (void)packet;
-  return PH_ACK_SUCCESS;
-#endif
 }
+#endif
 
 #pragma section

--- a/TlmCmd/packet_handler.c
+++ b/TlmCmd/packet_handler.c
@@ -18,7 +18,7 @@ PacketList PH_gs_cmd_list;
 PacketList PH_rt_cmd_list;
 PacketList PH_tl_cmd_list[TL_ID_MAX];
 PacketList PH_ms_tlm_list;
-#ifndef PH_DISABLE_DATA_RECORDER
+#ifdef DR_ENABLE
 PacketList PH_st_tlm_list;
 PacketList PH_rp_tlm_list;
 #endif
@@ -29,7 +29,7 @@ static PL_Node PH_tl0_cmd_stock_[PH_TL0_CMD_LIST_MAX];
 static PL_Node PH_tl1_cmd_stock_[PH_TL1_CMD_LIST_MAX];
 static PL_Node PH_tl2_cmd_stock_[PH_TL2_CMD_LIST_MAX];
 static PL_Node PH_ms_tlm_stock_[PH_MS_TLM_LIST_MAX];
-#ifndef PH_DISABLE_DATA_RECORDER
+#ifdef DR_ENABLE
 static PL_Node PH_st_tlm_stock_[PH_ST_TLM_LIST_MAX];
 static PL_Node PH_rp_tlm_stock_[PH_RP_TLM_LIST_MAX];
 #endif
@@ -40,7 +40,7 @@ static CommonCmdPacket PH_tl0_cmd_ccp_stock_[PH_TL0_CMD_LIST_MAX];
 static CommonCmdPacket PH_tl1_cmd_ccp_stock_[PH_TL1_CMD_LIST_MAX];
 static CommonCmdPacket PH_tl2_cmd_ccp_stock_[PH_TL2_CMD_LIST_MAX];
 static CommonTlmPacket PH_ms_tlm_ctp_stock_[PH_MS_TLM_LIST_MAX];
-#ifndef PH_DISABLE_DATA_RECORDER
+#ifdef DR_ENABLE
 static CommonTlmPacket PH_st_tlm_ctp_stock_[PH_ST_TLM_LIST_MAX];
 static CommonTlmPacket PH_rp_tlm_ctp_stock_[PH_RP_TLM_LIST_MAX];
 #endif
@@ -73,7 +73,7 @@ void PH_init(void)
   PL_initialize_with_ccp(PH_tl2_cmd_stock_, PH_tl2_cmd_ccp_stock_, PH_TL2_CMD_LIST_MAX, &PH_tl_cmd_list[2]);
 
   PL_initialize_with_ctp(PH_ms_tlm_stock_, PH_ms_tlm_ctp_stock_, PH_MS_TLM_LIST_MAX, &PH_ms_tlm_list);
-#ifndef PH_DISABLE_DATA_RECORDER
+#ifdef DR_ENABLE
   PL_initialize_with_ctp(PH_st_tlm_stock_, PH_st_tlm_ctp_stock_, PH_ST_TLM_LIST_MAX, &PH_st_tlm_list);
   PL_initialize_with_ctp(PH_rp_tlm_stock_, PH_rp_tlm_ctp_stock_, PH_RP_TLM_LIST_MAX, &PH_rp_tlm_list);
 #endif
@@ -292,7 +292,7 @@ static PH_ACK PH_add_ms_tlm_(const CommonTlmPacket* packet)
 
 static PH_ACK PH_add_st_tlm_(const CommonTlmPacket* packet)
 {
-#ifndef PH_DISABLE_DATA_RECORDER
+#ifdef DR_ENABLE
   PL_ACK ack = PL_push_back(&PH_st_tlm_list, packet);
 
   if (ack != PL_SUCCESS) return PH_ACK_PL_LIST_FULL;
@@ -307,7 +307,7 @@ static PH_ACK PH_add_st_tlm_(const CommonTlmPacket* packet)
 
 static PH_ACK PH_add_rp_tlm_(const CommonTlmPacket* packet)
 {
-#ifndef PH_DISABLE_DATA_RECORDER
+#ifdef DR_ENABLE
   PL_ACK ack = PL_push_back(&PH_rp_tlm_list, packet);
 
   if (ack != PL_SUCCESS) return PH_ACK_PL_LIST_FULL;

--- a/TlmCmd/packet_handler.c
+++ b/TlmCmd/packet_handler.c
@@ -18,8 +18,10 @@ PacketList PH_gs_cmd_list;
 PacketList PH_rt_cmd_list;
 PacketList PH_tl_cmd_list[TL_ID_MAX];
 PacketList PH_ms_tlm_list;
+#ifndef PH_DISABLE_DATA_RECORDER
 PacketList PH_st_tlm_list;
 PacketList PH_rp_tlm_list;
+#endif
 
 static PL_Node PH_gs_cmd_stock_[PH_GS_CMD_LIST_MAX];
 static PL_Node PH_rt_cmd_stock_[PH_RT_CMD_LIST_MAX];
@@ -27,8 +29,10 @@ static PL_Node PH_tl0_cmd_stock_[PH_TL0_CMD_LIST_MAX];
 static PL_Node PH_tl1_cmd_stock_[PH_TL1_CMD_LIST_MAX];
 static PL_Node PH_tl2_cmd_stock_[PH_TL2_CMD_LIST_MAX];
 static PL_Node PH_ms_tlm_stock_[PH_MS_TLM_LIST_MAX];
+#ifndef PH_DISABLE_DATA_RECORDER
 static PL_Node PH_st_tlm_stock_[PH_ST_TLM_LIST_MAX];
 static PL_Node PH_rp_tlm_stock_[PH_RP_TLM_LIST_MAX];
+#endif
 
 static CommonCmdPacket PH_gs_cmd_ccp_stock_[PH_GS_CMD_LIST_MAX];
 static CommonCmdPacket PH_rt_cmd_ccp_stock_[PH_RT_CMD_LIST_MAX];
@@ -36,8 +40,10 @@ static CommonCmdPacket PH_tl0_cmd_ccp_stock_[PH_TL0_CMD_LIST_MAX];
 static CommonCmdPacket PH_tl1_cmd_ccp_stock_[PH_TL1_CMD_LIST_MAX];
 static CommonCmdPacket PH_tl2_cmd_ccp_stock_[PH_TL2_CMD_LIST_MAX];
 static CommonTlmPacket PH_ms_tlm_ctp_stock_[PH_MS_TLM_LIST_MAX];
+#ifndef PH_DISABLE_DATA_RECORDER
 static CommonTlmPacket PH_st_tlm_ctp_stock_[PH_ST_TLM_LIST_MAX];
 static CommonTlmPacket PH_rp_tlm_ctp_stock_[PH_RP_TLM_LIST_MAX];
+#endif
 
 static PH_ACK PH_add_block_cmd_(const CommonCmdPacket* packet);
 static PH_ACK PH_add_gs_cmd_(const CommonCmdPacket* packet);
@@ -67,8 +73,10 @@ void PH_init(void)
   PL_initialize_with_ccp(PH_tl2_cmd_stock_, PH_tl2_cmd_ccp_stock_, PH_TL2_CMD_LIST_MAX, &PH_tl_cmd_list[2]);
 
   PL_initialize_with_ctp(PH_ms_tlm_stock_, PH_ms_tlm_ctp_stock_, PH_MS_TLM_LIST_MAX, &PH_ms_tlm_list);
+#ifndef PH_DISABLE_DATA_RECORDER
   PL_initialize_with_ctp(PH_st_tlm_stock_, PH_st_tlm_ctp_stock_, PH_ST_TLM_LIST_MAX, &PH_st_tlm_list);
   PL_initialize_with_ctp(PH_rp_tlm_stock_, PH_rp_tlm_ctp_stock_, PH_RP_TLM_LIST_MAX, &PH_rp_tlm_list);
+#endif
 
   PH_user_init();
 }
@@ -284,21 +292,31 @@ static PH_ACK PH_add_ms_tlm_(const CommonTlmPacket* packet)
 
 static PH_ACK PH_add_st_tlm_(const CommonTlmPacket* packet)
 {
+#ifndef PH_DISABLE_DATA_RECORDER
   PL_ACK ack = PL_push_back(&PH_st_tlm_list, packet);
 
   if (ack != PL_SUCCESS) return PH_ACK_PL_LIST_FULL;
 
   return PH_ACK_SUCCESS;
+#else
+  (void)packet;
+  return PH_ACK_SUCCESS;
+#endif
 }
 
 
 static PH_ACK PH_add_rp_tlm_(const CommonTlmPacket* packet)
 {
+#ifndef PH_DISABLE_DATA_RECORDER
   PL_ACK ack = PL_push_back(&PH_rp_tlm_list, packet);
 
   if (ack != PL_SUCCESS) return PH_ACK_PL_LIST_FULL;
 
   return PH_ACK_SUCCESS;
+#else
+  (void)packet;
+  return PH_ACK_SUCCESS;
+#endif
 }
 
 #pragma section

--- a/TlmCmd/packet_handler.h
+++ b/TlmCmd/packet_handler.h
@@ -18,7 +18,20 @@
 #define PH_ST_TLM_LIST_MAX  (16)
 #define PH_RP_TLM_LIST_MAX  (16)
 
+// 以下で，上記の PL のキューサイズを再定義する
+// また， 以下で #define PH_DISABLE_DATA_RECORDER をすると，
+// DR 関連 PL がすべて無効となり，メモリが節約できる
+// #define PH_DISABLE_DATA_RECORDER
 #include <src_user/Settings/TlmCmd/packet_handler_params.h>
+
+#ifdef PH_DISABLE_DATA_RECORDER
+#ifdef PH_ST_TLM_LIST_MAX
+#undef PH_ST_TLM_LIST_MAX
+#endif
+#ifdef PH_RP_TLM_LIST_MAX
+#undef PH_RP_TLM_LIST_MAX
+#endif
+#endif
 
 // 循環参照を防ぐためにここでinclude
 #include "common_tlm_cmd_packet.h"

--- a/TlmCmd/packet_handler.h
+++ b/TlmCmd/packet_handler.h
@@ -19,12 +19,11 @@
 #define PH_RP_TLM_LIST_MAX  (16)
 
 // 以下で，上記の PL のキューサイズを再定義する
-// また， 以下で #define PH_DISABLE_DATA_RECORDER をすると，
+// また， data_recorder_define.h の #define DR_ENABLE をコメントアウトすると，
 // DR 関連 PL がすべて無効となり，メモリが節約できる
-// #define PH_DISABLE_DATA_RECORDER
 #include <src_user/Settings/TlmCmd/packet_handler_params.h>
 
-#ifdef PH_DISABLE_DATA_RECORDER
+#ifndef DR_ENABLE
 #ifdef PH_ST_TLM_LIST_MAX
 #undef PH_ST_TLM_LIST_MAX
 #endif
@@ -58,7 +57,7 @@ extern PacketList PH_rt_cmd_list;
 extern PacketList PH_tl_cmd_list[TL_ID_MAX];
 // extern PacketList PH_hk_tlm_list;    // 現在は MS TLM に統合されている（ TODO: 今後また分離させても良いかも．要検討）
 extern PacketList PH_ms_tlm_list;
-#ifndef PH_DISABLE_DATA_RECORDER
+#ifdef DR_ENABLE
 extern PacketList PH_st_tlm_list;
 extern PacketList PH_rp_tlm_list;
 #endif

--- a/TlmCmd/packet_handler.h
+++ b/TlmCmd/packet_handler.h
@@ -58,8 +58,10 @@ extern PacketList PH_rt_cmd_list;
 extern PacketList PH_tl_cmd_list[TL_ID_MAX];
 // extern PacketList PH_hk_tlm_list;    // 現在は MS TLM に統合されている（ TODO: 今後また分離させても良いかも．要検討）
 extern PacketList PH_ms_tlm_list;
+#ifndef PH_DISABLE_DATA_RECORDER
 extern PacketList PH_st_tlm_list;
 extern PacketList PH_rp_tlm_list;
+#endif
 
 /**
  * @brief Packet Handler を初期化


### PR DESCRIPTION
## 概要
DRのないOBCで，不要なメモリを確保しないようにする

## Issue
NA

## 詳細
stored tlmとreploay tlmのpacket listを，DRのないボードではメモリ確保しないようにした

## 検証結果
- https://github.com/ut-issl/c2a-core/blob/a8eb378c663acea13099271cb9f94f8142687eee/Examples/minimum_user_for_s2e/src/src_user/Settings/TlmCmd/packet_handler_params.h#L35 をコメントインしてもビルドできることを確認（もちろん該当PLの参照は消した上で）
