### PR TITLE
GSCD，TLCD，RTCDなどの実行時エラー履歴を残す

### DIFF
--- a/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/EventManager/test_event_logger.py
+++ b/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/EventManager/test_event_logger.py
@@ -96,13 +96,7 @@ g_clog_capacity_pre = g_clog_capacity
 @pytest.mark.sils
 def test_event_logger_init_check():
     update_all_tlm()
-
-    # ### 初期化
-    ret = wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_INIT, (), c2a_enum.Tlm_CODE_HK
-    )
-    assert ret == "SUC"
-
+    initialize_el()
     update_all_tlm()
     assert g_count_total == 0
     for err_level in range(EL_ERROR_LEVEL_MAX):
@@ -147,11 +141,7 @@ def test_event_logger_set_params():
 @pytest.mark.real
 @pytest.mark.sils
 def test_event_logger_record_event():
-    # ### 初期化
-    ret = wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_INIT, (), c2a_enum.Tlm_CODE_HK
-    )
-
+    initialize_el()
     change_tlog_tlm_page(0, EL_ERROR_LEVEL_HIGH)
     change_clog_tlm_page(0, EL_ERROR_LEVEL_HIGH)
     update_all_tlm()
@@ -276,10 +266,7 @@ def test_event_logger_record_event():
 @pytest.mark.real
 @pytest.mark.sils
 def test_event_logger_clear_log():
-    # ### 初期化
-    ret = wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_INIT, (), c2a_enum.Tlm_CODE_HK
-    )
+    initialize_el()
 
     local0 = 1
     local1 = 5
@@ -405,10 +392,7 @@ def test_event_logger_clear_log():
 @pytest.mark.real
 @pytest.mark.sils
 def test_event_logger_tlog_overflow():
-    # ### 初期化
-    ret = wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_INIT, (), c2a_enum.Tlm_CODE_HK
-    )
+    initialize_el()
 
     # ### 設定コマンドのアサーション確認
     change_tlog_tlm_page(0, EL_ERROR_LEVEL_HIGH)
@@ -630,9 +614,7 @@ def test_event_logger_tlog_overflow():
 @pytest.mark.real
 @pytest.mark.sils
 def test_event_logger_clog_overflow():
-    # ### 初期化
-    wings.util.send_rt_cmd_and_confirm(ope, c2a_enum.Cmd_CODE_EL_INIT, (), c2a_enum.Tlm_CODE_HK)
-
+    initialize_el()
     update_el_tlm()
     update_el_clog_tlm()
 
@@ -686,10 +668,7 @@ def test_event_logger_clog_overflow():
 @pytest.mark.real
 @pytest.mark.sils
 def test_event_logger_logging_setting():
-    # ### 初期化
-    ret = wings.util.send_rt_cmd_and_confirm(
-        ope, c2a_enum.Cmd_CODE_EL_INIT, (), c2a_enum.Tlm_CODE_HK
-    )
+    initialize_el()
 
     # ### 切り替え
     ret = wings.util.send_rt_cmd_and_confirm(
@@ -767,6 +746,22 @@ def test_event_logger_final_check():
     # ### 初期化
     ret = wings.util.send_rt_cmd_and_confirm(
         ope, c2a_enum.Cmd_CODE_EL_INIT, (), c2a_enum.Tlm_CODE_HK
+    )
+    assert ret == "SUC"
+
+
+def initialize_el():
+    # ### 初期化
+    ret = wings.util.send_rt_cmd_and_confirm(
+        ope, c2a_enum.Cmd_CODE_EL_INIT, (), c2a_enum.Tlm_CODE_HK
+    )
+    assert ret == "SUC"
+    # ### 不正引数のチェックをするtestでEL登録されないように無効化
+    ret = wings.util.send_rt_cmd_and_confirm(
+        ope,
+        c2a_enum.Cmd_CODE_EL_DISABLE_LOGGING,
+        (c2a_enum.EL_CORE_GROUP_CDIS_EXEC_ERR,),
+        c2a_enum.Tlm_CODE_HK,
     )
     assert ret == "SUC"
 

--- a/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/TlmCmd/test_command_dispatcher.py
+++ b/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/TlmCmd/test_command_dispatcher.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+import time
+
+import isslwings as wings
+import pytest
+
+ROOT_PATH = "../../../"
+sys.path.append(os.path.dirname(__file__) + "/" + ROOT_PATH + "utils")
+import c2a_enum_utils
+import wings_utils
+
+c2a_enum = c2a_enum_utils.get_c2a_enum()
+ope = wings_utils.get_wings_operation()
+
+# C2Aでのdefine値
+AM_TLM_PAGE_MAX = 4
+
+
+@pytest.mark.sils
+@pytest.mark.real
+def test_cdis_exec_err():
+
+    # === ELの初期化
+    assert "SUC" == wings.util.send_rt_cmd_and_confirm(
+        ope, c2a_enum.Cmd_CODE_EL_INIT, (), c2a_enum.Tlm_CODE_HK
+    )
+    tlm_EL = wings.util.generate_and_receive_tlm(
+        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_EL
+    )
+    ti_now = tlm_EL["EL.SH.TI"]
+
+    # === 以下の4つを無効パラメタでコマンド登録する
+    # RT Cmd_CODE_TMGR_UPDATE_UNIXTIME
+    # RT Cmd_CODE_AM_SET_PAGE_FOR_TLM
+    # TL Cmd_CODE_TMGR_UPDATE_UNIXTIME
+    # TL Cmd_CODE_AM_SET_PAGE_FOR_TLM
+    assert "PRM" == wings.util.send_rt_cmd_and_confirm(
+        ope, c2a_enum.Cmd_CODE_TMGR_UPDATE_UNIXTIME, (-10, 0, 0), c2a_enum.Tlm_CODE_HK
+    )
+    assert "PRM" == wings.util.send_rt_cmd_and_confirm(
+        ope,
+        c2a_enum.Cmd_CODE_AM_SET_PAGE_FOR_TLM,
+        (AM_TLM_PAGE_MAX + 100,),
+        c2a_enum.Tlm_CODE_HK,
+    )
+    wings.util.send_tl_cmd(ope, ti_now + 50, c2a_enum.Cmd_CODE_TMGR_UPDATE_UNIXTIME, (-10, 0, 0))
+    wings.util.send_tl_cmd(
+        ope, ti_now + 55, c2a_enum.Cmd_CODE_AM_SET_PAGE_FOR_TLM, (AM_TLM_PAGE_MAX + 100,)
+    )
+    time.sleep(2)
+
+    # === ELのチェック
+    tlm_EL = wings.util.generate_and_receive_tlm(
+        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_EL
+    )
+    # GS_cmd_dispatcher
+    assert tlm_EL["EL.TLOGS.LOW.EVENTS3.GROUP"] == c2a_enum.EL_CORE_GROUP_CDIS_EXEC_ERR
+    assert tlm_EL["EL.TLOGS.LOW.EVENTS2.GROUP"] == c2a_enum.EL_CORE_GROUP_CDIS_EXEC_ERR
+    assert tlm_EL["EL.TLOGS.LOW.EVENTS3.LOCAL"] == tlm_EL["EL.TLOGS.LOW.EVENTS2.LOCAL"]
+    note = (c2a_enum.Cmd_CODE_TMGR_UPDATE_UNIXTIME << 16) | c2a_enum.CCP_EXEC_ILLEGAL_PARAMETER
+    assert tlm_EL["EL.TLOGS.LOW.EVENTS3.NOTE"] == note
+    note = (c2a_enum.Cmd_CODE_AM_SET_PAGE_FOR_TLM << 16) | c2a_enum.CCP_EXEC_ILLEGAL_PARAMETER
+    assert tlm_EL["EL.TLOGS.LOW.EVENTS2.NOTE"] == note
+    # TL_cmd_dispatcher
+    assert tlm_EL["EL.TLOGS.LOW.EVENTS1.GROUP"] == c2a_enum.EL_CORE_GROUP_CDIS_EXEC_ERR
+    assert tlm_EL["EL.TLOGS.LOW.EVENTS0.GROUP"] == c2a_enum.EL_CORE_GROUP_CDIS_EXEC_ERR
+    assert tlm_EL["EL.TLOGS.LOW.EVENTS1.LOCAL"] == tlm_EL["EL.TLOGS.LOW.EVENTS0.LOCAL"]
+    note = (c2a_enum.Cmd_CODE_TMGR_UPDATE_UNIXTIME << 16) | c2a_enum.CCP_EXEC_ILLEGAL_PARAMETER
+    assert tlm_EL["EL.TLOGS.LOW.EVENTS1.NOTE"] == note
+    note = (c2a_enum.Cmd_CODE_AM_SET_PAGE_FOR_TLM << 16) | c2a_enum.CCP_EXEC_ILLEGAL_PARAMETER
+    assert tlm_EL["EL.TLOGS.LOW.EVENTS0.NOTE"] == note
+    # GSとTLをlocalで区別できているか
+    assert tlm_EL["EL.TLOGS.LOW.EVENTS1.LOCAL"] != tlm_EL["EL.TLOGS.LOW.EVENTS3.LOCAL"]
+
+    # === 最後にもう一度初期化
+    assert "SUC" == wings.util.send_rt_cmd_and_confirm(
+        ope, c2a_enum.Cmd_CODE_EL_INIT, (), c2a_enum.Tlm_CODE_HK
+    )
+
+
+if __name__ == "__main__":
+    test_cdis_exec_err()
+    pass

--- a/System/EventManager/event_logger.h
+++ b/System/EventManager/event_logger.h
@@ -215,8 +215,8 @@ typedef enum
   EL_CORE_GROUP_EH_MATCH_RULE,        //!< EH_Rule でマッチした（詳細は event_handler.h 参照）
   EL_CORE_GROUP_EH_RESPOND_WITH_HIGHER_LEVEL_RULE,  //!< EH_Rule でマッチしたが，そのルールで対応せずに，上位のルールで対応させた（詳細は event_handler.h 参照）
   EL_CORE_GROUP_COMMAND_ANALYZE,
-  EL_CORE_GROUP_COMMAND_DISPATCHER,
-  EL_CORE_GROUP_CDIS_EXEC_STS,
+  EL_CORE_GROUP_CDIS_INTERNAL_ERR,
+  EL_CORE_GROUP_CDIS_EXEC_ERR,
   // TODO: Driver Super
 #ifdef EL_IS_ENABLE_EL_ERROR_LEVEL
   EL_CORE_GROUP_EL_DROP_CLOG1,        //!< EL CLogs で古いエラーを上書きするとき (group, err_level を保存)

--- a/System/EventManager/event_logger.h
+++ b/System/EventManager/event_logger.h
@@ -216,6 +216,7 @@ typedef enum
   EL_CORE_GROUP_EH_RESPOND_WITH_HIGHER_LEVEL_RULE,  //!< EH_Rule でマッチしたが，そのルールで対応せずに，上位のルールで対応させた（詳細は event_handler.h 参照）
   EL_CORE_GROUP_COMMAND_ANALYZE,
   EL_CORE_GROUP_COMMAND_DISPATCHER,
+  EL_CORE_GROUP_CDIS_EXEC_STS,
   // TODO: Driver Super
 #ifdef EL_IS_ENABLE_EL_ERROR_LEVEL
   EL_CORE_GROUP_EL_DROP_CLOG1,        //!< EL CLogs で古いエラーを上書きするとき (group, err_level を保存)

--- a/TlmCmd/command_dispatcher.c
+++ b/TlmCmd/command_dispatcher.c
@@ -128,16 +128,16 @@ void CDIS_dispatch_command(CommandDispatcher* cdis)
 
   if (cdis->prev.sts != CCP_EXEC_SUCCESS)
   {
-    // 実行したコマンドが実行異常ステータスを返した場合
-    // エラー発生カウンタをカウントアップ
-    ++(cdis->error_counter);
-
     // 実行時エラー情報をELにも記録. エラー発生場所(GSCD,TLCDなど)はcdisのポインタアドレスで区別
     uint32_t note = ((0x0000ffff & cdis->prev.code) << 16) | (0x0000ffff & cdis->prev.sts);
     EL_record_event((EL_GROUP)EL_CORE_GROUP_CDIS_EXEC_ERR,
                     (uint32_t)cdis,
                     EL_ERROR_LEVEL_LOW,
                     note);
+
+    // 実行したコマンドが実行異常ステータスを返した場合
+    // エラー発生カウンタをカウントアップ
+    ++(cdis->error_counter);
 
     if (cdis->stop_on_error == 1)
     {

--- a/TlmCmd/command_dispatcher.c
+++ b/TlmCmd/command_dispatcher.c
@@ -14,16 +14,16 @@
 //       現状 PL が NULL チェックをしてないので，できない
 
 /**
- * @enum  CIDS_EL_LOCAL_ID
+ * @enum  CDIS_EL_LOCAL_ID
  * @brief CDIS 内部の event の local ID
  * @note  uint8_t
  */
 typedef enum
 {
-  CIDS_EL_LOCAL_ID_NULL_PARAM,    //!< NULL 引数
-  CIDS_EL_LOCAL_ID_INVALID_PL,    //!< 不正な PL
-  CIDS_EL_LOCAL_ID_UNKNOWN
-} CIDS_EL_LOCAL_ID;
+  CDIS_EL_LOCAL_ID_NULL_PARAM,    //!< NULL 引数
+  CDIS_EL_LOCAL_ID_INVALID_PL,    //!< 不正な PL
+  CDIS_EL_LOCAL_ID_UNKNOWN
+} CDIS_EL_LOCAL_ID;
 
 /**
  * @brief  CDIS_ExecInfo の初期化
@@ -55,7 +55,7 @@ CommandDispatcher CDIS_init(PacketList* pl)
   {
     // 初期化時エラーは試験時に確認され，打ち上げ後はありえないので，イベント発行のみしかしない
     EL_record_event((EL_GROUP)EL_CORE_GROUP_COMMAND_DISPATCHER,
-                    CIDS_EL_LOCAL_ID_NULL_PARAM,
+                    CDIS_EL_LOCAL_ID_NULL_PARAM,
                     EL_ERROR_LEVEL_HIGH,
                     0);
     return cdis;
@@ -64,7 +64,7 @@ CommandDispatcher CDIS_init(PacketList* pl)
   {
     // 初期化時エラーは試験時に確認され，打ち上げ後はありえないので，イベント発行のみしかしない
     EL_record_event((EL_GROUP)EL_CORE_GROUP_COMMAND_DISPATCHER,
-                    CIDS_EL_LOCAL_ID_INVALID_PL,
+                    CDIS_EL_LOCAL_ID_INVALID_PL,
                     EL_ERROR_LEVEL_HIGH,
                     (uint32_t)pl);
     return cdis;

--- a/TlmCmd/command_dispatcher.c
+++ b/TlmCmd/command_dispatcher.c
@@ -54,7 +54,7 @@ CommandDispatcher CDIS_init(PacketList* pl)
   if (pl == NULL)
   {
     // 初期化時エラーは試験時に確認され，打ち上げ後はありえないので，イベント発行のみしかしない
-    EL_record_event((EL_GROUP)EL_CORE_GROUP_COMMAND_DISPATCHER,
+    EL_record_event((EL_GROUP)EL_CORE_GROUP_CDIS_INTERNAL_ERR,
                     CDIS_EL_LOCAL_ID_NULL_PARAM,
                     EL_ERROR_LEVEL_HIGH,
                     0);
@@ -63,7 +63,7 @@ CommandDispatcher CDIS_init(PacketList* pl)
   if (PL_get_packet_type(pl) != PL_PACKET_TYPE_CCP)
   {
     // 初期化時エラーは試験時に確認され，打ち上げ後はありえないので，イベント発行のみしかしない
-    EL_record_event((EL_GROUP)EL_CORE_GROUP_COMMAND_DISPATCHER,
+    EL_record_event((EL_GROUP)EL_CORE_GROUP_CDIS_INTERNAL_ERR,
                     CDIS_EL_LOCAL_ID_INVALID_PL,
                     EL_ERROR_LEVEL_HIGH,
                     (uint32_t)pl);
@@ -134,9 +134,9 @@ void CDIS_dispatch_command(CommandDispatcher* cdis)
     ++(cdis->error_counter);
 
     // 実行時エラー情報をELにも記録. エラー発生場所(GSCD,TLCDなど)はcdisのポインタアドレスで区別
-    EL_record_event((EL_GROUP)EL_CORE_GROUP_CDIS_EXEC_STS,
+    EL_record_event((EL_GROUP)EL_CORE_GROUP_CDIS_EXEC_ERR,
                     cdis->prev.sts,
-                    EL_ERROR_LEVEL_HIGH,
+                    EL_ERROR_LEVEL_LOW,
                     (uint32_t)cdis);
 
     if (cdis->stop_on_error == 1)

--- a/TlmCmd/command_dispatcher.c
+++ b/TlmCmd/command_dispatcher.c
@@ -86,8 +86,8 @@ static void CDIS_clear_exec_info_(CDIS_ExecInfo* exec_info)
 
 void CDIS_dispatch_command(CommandDispatcher* cdis)
 {
-  // パケットコピー用．サイズが大きいため静的変数として宣言
-  static CommonCmdPacket packet_;
+  static CommonCmdPacket packet_; // パケットコピー用．サイズが大きいため静的変数として宣言
+  uint32_t note; // 実行時エラー情報のEL登録で用いる
 
   // 実行有効フラグが無効化されている場合は処理打ち切り
   if (cdis->lockout) return;
@@ -134,10 +134,11 @@ void CDIS_dispatch_command(CommandDispatcher* cdis)
     ++(cdis->error_counter);
 
     // 実行時エラー情報をELにも記録. エラー発生場所(GSCD,TLCDなど)はcdisのポインタアドレスで区別
+    note = (cdis->prev.code << 16) | cdis->prev.sts;
     EL_record_event((EL_GROUP)EL_CORE_GROUP_CDIS_EXEC_ERR,
-                    cdis->prev.sts,
+                    (uint32_t)cdis,
                     EL_ERROR_LEVEL_LOW,
-                    (uint32_t)cdis);
+                    note);
 
     if (cdis->stop_on_error == 1)
     {

--- a/TlmCmd/command_dispatcher.c
+++ b/TlmCmd/command_dispatcher.c
@@ -87,7 +87,6 @@ static void CDIS_clear_exec_info_(CDIS_ExecInfo* exec_info)
 void CDIS_dispatch_command(CommandDispatcher* cdis)
 {
   static CommonCmdPacket packet_; // パケットコピー用．サイズが大きいため静的変数として宣言
-  uint32_t note; // 実行時エラー情報のEL登録で用いる
 
   // 実行有効フラグが無効化されている場合は処理打ち切り
   if (cdis->lockout) return;
@@ -134,7 +133,7 @@ void CDIS_dispatch_command(CommandDispatcher* cdis)
     ++(cdis->error_counter);
 
     // 実行時エラー情報をELにも記録. エラー発生場所(GSCD,TLCDなど)はcdisのポインタアドレスで区別
-    note = (cdis->prev.code << 16) | cdis->prev.sts;
+    uint32_t note = ((0x0000ffff & cdis->prev.code) << 16) | (0x0000ffff & cdis->prev.sts);
     EL_record_event((EL_GROUP)EL_CORE_GROUP_CDIS_EXEC_ERR,
                     (uint32_t)cdis,
                     EL_ERROR_LEVEL_LOW,

--- a/TlmCmd/command_dispatcher.c
+++ b/TlmCmd/command_dispatcher.c
@@ -133,6 +133,12 @@ void CDIS_dispatch_command(CommandDispatcher* cdis)
     // エラー発生カウンタをカウントアップ
     ++(cdis->error_counter);
 
+    // 実行時エラー情報をELにも記録. エラー発生場所(GSCD,TLCDなど)はcdisのポインタアドレスで区別
+    EL_record_event((EL_GROUP)EL_CORE_GROUP_CDIS_EXEC_STS,
+                    cdis->prev.sts,
+                    EL_ERROR_LEVEL_HIGH,
+                    (uint32_t)cdis);
+
     if (cdis->stop_on_error == 1)
     {
       // 異常時実行中断フラグが有効な場合


### PR DESCRIPTION
## 概要
GSCD，TLCD，RTCDなどの実行時エラー履歴をELに記録して残す

## Issue
- https://github.com/ut-issl/c2a-core/issues/129

## 詳細

## 検証結果
実行時エラーがEL_TLOGテレメに登録されるのを SILSとwingsで確認した

## 影響範囲
小