### PR TITLE
WIP：TL0をバス用とミッション用の二つに分割する

### DIFF
--- a/Applications/timeline_command_dispatcher.c
+++ b/Applications/timeline_command_dispatcher.c
@@ -27,6 +27,10 @@ static void TLCD1_init_(void);
 static void TLCD1_dispatch_(void);
 static void TLCD2_init_(void);
 static void TLCD2_dispatch_(void);
+#ifdef TL_IS_ENABLE_MISSION_TL
+static void TLCD_mis_init_(void);
+static void TLCD_mis_dispatch_(void);
+#endif
 static void tlc_dispatcher_(int line_no);
 // FIXME: 返り値が PH_ACK なのはおかしい
 static PH_ACK drop_tl_cmd_at_(int line_no, cycle_t time);
@@ -88,6 +92,23 @@ static void TLCD2_dispatch_(void)
 {
   tlc_dispatcher_(2);
 }
+
+#ifdef TL_IS_ENABLE_MISSION_TL
+AppInfo TLCD_mis_create_app(void)
+{
+  return AI_create_app_info("tlcd_mis", TLCD_mis_init_, TLCD_mis_dispatch_);
+}
+
+static void TLCD_mis_init_(void)
+{
+  timeline_command_dispatcher_[TL_ID_FROM_GS_FOR_MISSION] = CDIS_init(&(PH_tl_cmd_list[TL_ID_FROM_GS_FOR_MISSION]));
+}
+
+static void TLCD_mis_dispatch_(void)
+{
+  tlc_dispatcher_(TL_ID_FROM_GS_FOR_MISSION);
+}
+#endif
 
 static void tlc_dispatcher_(int line_no)
 {

--- a/Applications/timeline_command_dispatcher.h
+++ b/Applications/timeline_command_dispatcher.h
@@ -1,6 +1,8 @@
 #ifndef TIMELINE_COMMAND_DISPATCHER_H_
 #define TIMELINE_COMMAND_DISPATCHER_H_
 
+#include "../TlmCmd/common_cmd_packet.h"
+
 /**
  * @enum   TL_ID
  * @brief  TimeLineを選ぶときに統一的に使うコード
@@ -11,6 +13,9 @@ typedef enum
   TL_ID_DEPLOY_FROM_GS = 0,
   TL_ID_DEPLOY_BC      = 1,
   TL_ID_DEPLOY_TLM     = 2,
+#ifdef TL_IS_ENABLE_MISSION_TL
+  TL_ID_FROM_GS_FOR_MISSION,
+#endif
   TL_ID_MAX
 } TL_ID;
 // FIXME: 全体的に， line_no が int なので， enum にする
@@ -18,7 +23,6 @@ typedef enum
 
 // 循環参照を防ぐためにここでinclude
 #include "../TlmCmd/command_dispatcher.h"
-#include "../TlmCmd/common_cmd_packet.h"
 #include "../TlmCmd/packet_handler.h"
 #include "../System/ApplicationManager/app_info.h"
 
@@ -32,6 +36,9 @@ extern const int* TLCD_page_no;
 AppInfo TLCD0_create_app(void);
 AppInfo TLCD1_create_app(void);
 AppInfo TLCD2_create_app(void);
+#ifdef TL_IS_ENABLE_MISSION_TL
+AppInfo TLCD_mis_create_app(void);
+#endif
 
 /**
  * @brief TLM の内容を自動更新する.

--- a/Examples/minimum_user_for_s2e/src/src_user/Applications/app_registry.c
+++ b/Examples/minimum_user_for_s2e/src/src_user/Applications/app_registry.c
@@ -20,6 +20,9 @@ void AR_load_initial_settings(void)
   add_application_(AR_TLC0_DISPATCHER, TLCD0_create_app);
   add_application_(AR_TLC1_DISPATCHER, TLCD1_create_app);
   add_application_(AR_TLC2_DISPATCHER, TLCD2_create_app);
+  #ifdef TL_IS_ENABLE_MISSION_TL
+  add_application_(AR_TLC_MIS_DISPATCHER, TLCD_mis_create_app);
+  #endif
   add_application_(AR_EVENT_UTILITY, EVENT_UTIL_create_app);
   add_application_(AR_ANOMALY_HANDLER, AH_create_app);
   add_application_(AR_MEM_DUMP, MEM_create_app);

--- a/Examples/minimum_user_for_s2e/src/src_user/Applications/app_registry.h
+++ b/Examples/minimum_user_for_s2e/src/src_user/Applications/app_registry.h
@@ -1,5 +1,7 @@
 #ifndef APP_REGISTRY_H_
 #define APP_REGISTRY_H_
+#include <src_core/TlmCmd/common_cmd_packet.h>
+
 // こいつの自動生成がほしい．．．
 typedef enum
 {
@@ -13,6 +15,9 @@ typedef enum
   AR_TLC0_DISPATCHER,
   AR_TLC1_DISPATCHER,
   AR_TLC2_DISPATCHER,
+  #ifdef TL_IS_ENABLE_MISSION_TL
+  AR_TLC_MIS_DISPATCHER,
+  #endif
   AR_EVENT_UTILITY,
   AR_ANOMALY_HANDLER,
   AR_MEM_DUMP,

--- a/Examples/minimum_user_for_s2e/src/src_user/Settings/Modes/TaskLists/tl_initial.c
+++ b/Examples/minimum_user_for_s2e/src/src_user/Settings/Modes/TaskLists/tl_initial.c
@@ -10,7 +10,10 @@ void BCL_load_tl_initial(void)
 {
   BCL_tool_register_rotate ( 0, BC_AR_GS_RELATED_PROCESS);
   BCL_tool_register_app    ( 4, AR_TLC0_DISPATCHER);
-  BCL_tool_register_combine( 6, BC_AC_TLM_CMD_HIRATE);
+  #ifdef TL_IS_ENABLE_MISSION_TL
+  BCL_tool_register_app    ( 6, AR_TLC_MIS_DISPATCHER);
+  #endif
+  BCL_tool_register_combine( 8, BC_AC_TLM_CMD_HIRATE);
   BCL_tool_register_rotate (30, BC_AR_DRIVERS_UPDATE_INI);
   BCL_tool_register_app    (40, AR_EVENT_UTILITY);
   BCL_tool_register_app    (50, AR_ANOMALY_HANDLER);

--- a/TlmCmd/Ccsds/cmd_space_packet.c
+++ b/TlmCmd/Ccsds/cmd_space_packet.c
@@ -214,6 +214,9 @@ CCP_EXEC_TYPE CSP_get_exec_type(const CmdSpacePacket* csp)
   case CCP_EXEC_TYPE_UTL: // FALL THROUGH
   case CCP_EXEC_TYPE_TL1: // FALL THROUGH
   case CCP_EXEC_TYPE_TL2:
+  #ifdef TL_IS_ENABLE_MISSION_TL
+  case CCP_EXEC_TYPE_TL_MIS:
+  #endif
     return exec_type;
   default:
     return CCP_EXEC_TYPE_UNKNOWN;

--- a/TlmCmd/common_cmd_packet.h
+++ b/TlmCmd/common_cmd_packet.h
@@ -5,6 +5,7 @@
  */
 #ifndef COMMON_CMD_PACKET_H_
 #define COMMON_CMD_PACKET_H_
+#define TL_IS_ENABLE_MISSION_TL
 
 #include "../System/TimeManager/obc_time.h"
 #include <src_user/TlmCmd/command_definitions.h>
@@ -62,6 +63,9 @@ typedef enum
   CCP_EXEC_TYPE_UTL,    //!< UTL: Unixtime Timeline Command
   CCP_EXEC_TYPE_TL1,
   CCP_EXEC_TYPE_TL2,
+  #ifdef TL_IS_ENABLE_MISSION_TL
+  CCP_EXEC_TYPE_TL_MIS,
+  #endif
   CCP_EXEC_TYPE_UNKNOWN
 } CCP_EXEC_TYPE;
 

--- a/TlmCmd/packet_handler.c
+++ b/TlmCmd/packet_handler.c
@@ -28,6 +28,9 @@ static PL_Node PH_rt_cmd_stock_[PH_RT_CMD_LIST_MAX];
 static PL_Node PH_tl0_cmd_stock_[PH_TL0_CMD_LIST_MAX];
 static PL_Node PH_tl1_cmd_stock_[PH_TL1_CMD_LIST_MAX];
 static PL_Node PH_tl2_cmd_stock_[PH_TL2_CMD_LIST_MAX];
+#ifdef TL_IS_ENABLE_MISSION_TL
+static PL_Node PH_tl_mis_cmd_stock_[PH_TL2_CMD_LIST_MAX];
+#endif
 static PL_Node PH_ms_tlm_stock_[PH_MS_TLM_LIST_MAX];
 #ifdef DR_ENABLE
 static PL_Node PH_st_tlm_stock_[PH_ST_TLM_LIST_MAX];
@@ -39,6 +42,9 @@ static CommonCmdPacket PH_rt_cmd_ccp_stock_[PH_RT_CMD_LIST_MAX];
 static CommonCmdPacket PH_tl0_cmd_ccp_stock_[PH_TL0_CMD_LIST_MAX];
 static CommonCmdPacket PH_tl1_cmd_ccp_stock_[PH_TL1_CMD_LIST_MAX];
 static CommonCmdPacket PH_tl2_cmd_ccp_stock_[PH_TL2_CMD_LIST_MAX];
+#ifdef TL_IS_ENABLE_MISSION_TL
+static CommonCmdPacket PH_tl_mis_cmd_ccp_stock_[PH_TL2_CMD_LIST_MAX];
+#endif
 static CommonTlmPacket PH_ms_tlm_ctp_stock_[PH_MS_TLM_LIST_MAX];
 #ifdef DR_ENABLE
 static CommonTlmPacket PH_st_tlm_ctp_stock_[PH_ST_TLM_LIST_MAX];
@@ -73,6 +79,9 @@ void PH_init(void)
   PL_initialize_with_ccp(PH_tl0_cmd_stock_, PH_tl0_cmd_ccp_stock_, PH_TL0_CMD_LIST_MAX, &PH_tl_cmd_list[0]);
   PL_initialize_with_ccp(PH_tl1_cmd_stock_, PH_tl1_cmd_ccp_stock_, PH_TL1_CMD_LIST_MAX, &PH_tl_cmd_list[1]);
   PL_initialize_with_ccp(PH_tl2_cmd_stock_, PH_tl2_cmd_ccp_stock_, PH_TL2_CMD_LIST_MAX, &PH_tl_cmd_list[2]);
+  #ifdef TL_IS_ENABLE_MISSION_TL
+  PL_initialize_with_ccp(PH_tl_mis_cmd_stock_, PH_tl_mis_cmd_ccp_stock_, PH_TL2_CMD_LIST_MAX, &PH_tl_cmd_list[TL_ID_FROM_GS_FOR_MISSION]);
+  #endif
 
   PL_initialize_with_ctp(PH_ms_tlm_stock_, PH_ms_tlm_ctp_stock_, PH_MS_TLM_LIST_MAX, &PH_ms_tlm_list);
 #ifdef DR_ENABLE
@@ -142,6 +151,11 @@ PH_ACK PH_analyze_cmd_packet(const CommonCmdPacket* packet)
 
   case CCP_EXEC_TYPE_TL2:
     return PH_add_tl_cmd_(2, packet, TMGR_get_master_total_cycle());
+
+  #ifdef TL_IS_ENABLE_MISSION_TL
+  case CCP_EXEC_TYPE_TL_MIS:
+    return PH_add_tl_cmd_(3, packet, TMGR_get_master_total_cycle());
+  #endif
 
   default:
     return PH_ACK_UNKNOWN;


### PR DESCRIPTION
## 概要
TL0をバス用とミッション用の二つに分割する

## Issue
- https://github.com/ut-issl/c2a-core/issues/138

## 詳細
ひとまず、TL3を追加して以下を確認した。

- line_no=3でTLテレメに表示される
- SILSから`CCP_EXEC_TYPE`をいじることでTL3に追加できる
- TL3のコマンドも正しく実行される

CCP_EXEC_TYPEの整理や、TLの命名変更などは、以下でまとめてやる予定。
- https://github.com/ut-issl/c2a-core/issues/164

## 検証結果
SILSとwingsで動作確認した

## 影響範囲

## 補足
何かあれば