### PR TITLE
pytest confest で EL_CORE_GROUP_TLCD_DEPLOY_BLOCK EL が出るのを防ぐ

### DIFF
--- a/Examples/minimum_user_for_s2e/src/src_user/Test/test/conftest.py
+++ b/Examples/minimum_user_for_s2e/src/src_user/Test/test/conftest.py
@@ -24,6 +24,12 @@ def increase_hk_frequency():
 def _increase_hk_frequency():
 
     ope.send_rt_cmd(
+        c2a_enum.Cmd_CODE_TLCD_CLEAR_ALL_TIMELINE,
+        (2,),
+    )
+    time.sleep(0.1)
+
+    ope.send_rt_cmd(
         c2a_enum.Cmd_CODE_BCT_CLEAR_BLOCK,
         (c2a_enum.BC_HK_CYCLIC_TLM,),
     )


### PR DESCRIPTION
## 概要
pytest confest で EL_CORE_GROUP_TLCD_DEPLOY_BLOCK EL が出るのを防ぐ

## Issue
NA

## 詳細
TL2を消す前にBCを消していて，無効なBC展開が走り，ELが出ていた
