### PR TITLE
ALはdeprecatedなので，cmakelistsから外す

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ set(C2A_SRCS
   c2a_core_main.c
   Drivers/Super/driver_super.c
   Drivers/Super/driver_super_issl_format.c
-  # System/AnomalyLogger/anomaly_logger.c    # deprecated 使いたい場合は， user 側でビルドターゲットに入れる
+  # System/AnomalyLogger/anomaly_logger.c    # deprecated. 使いたい場合は， user 側でビルドターゲットに入れる．
   System/ApplicationManager/app_info.c
   System/ApplicationManager/app_manager.c
   System/EventManager/event_manager.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ set(C2A_SRCS
   c2a_core_main.c
   Drivers/Super/driver_super.c
   Drivers/Super/driver_super_issl_format.c
-  System/AnomalyLogger/anomaly_logger.c
+  # System/AnomalyLogger/anomaly_logger.c    # deprecated 使いたい場合は， user 側でビルドターゲットに入れる
   System/ApplicationManager/app_info.c
   System/ApplicationManager/app_manager.c
   System/EventManager/event_manager.c

--- a/Examples/minimum_user_for_s2e/CMakeLists.txt
+++ b/Examples/minimum_user_for_s2e/CMakeLists.txt
@@ -56,6 +56,7 @@ add_subdirectory(${C2A_USER_DIR}/TlmCmd)
 
 set(C2A_SRCS
   ${C2A_USER_DIR}/c2a_main.c
+  ${C2A_CORE_DIR}/System/AnomalyLogger/anomaly_logger.c   # ここでは保守のため， deprecated だがビルドする
 )
 
 if(BUILD_C2A_AS_CXX)


### PR DESCRIPTION
## 概要
ALはdeprecatedなので，cmakelistsから外す

## Issue
- https://github.com/ut-issl/c2a-core/issues/112

## 詳細
- Systemにあるのに，全然必須じゃないし，むしろ使わないほうが多いので
- 使いたいならuser側でビルドターゲットにいれる