### PR TITLE
Draft: TLCD_insert_tl_cmd_asap の追加

### DIFF
--- a/Applications/timeline_command_dispatcher.h
+++ b/Applications/timeline_command_dispatcher.h
@@ -33,6 +33,28 @@ AppInfo TLCD0_create_app(void);
 AppInfo TLCD1_create_app(void);
 AppInfo TLCD2_create_app(void);
 
+
+/**
+ * @brief CCP が時系列に並ぶように CCP を挿入する
+ * @note TimeLine だけでなく TaskList もこれを使い，その場合， now は step_t になることに注意
+ * @note asap と違うのは，そこに挿入出来なければ挿入しない
+ * @param[in,out] pl: CCP を挿入する PacketList
+ * @param[in] packet: 挿入する CCP
+ * @param[in] now: 基準時刻 (TimeLine なら現在時刻， TaskList なら現在 step)
+ * @return PL_ACK
+ */
+PL_ACK TLCD_insert_tl_cmd_strictly(PacketList* pl, const CommonCmdPacket* packet, cycle_t now);
+
+/**
+ * @brief CCP が時系列に並ぶように CCP を挿入する
+ * @note strictly と違うのは同時刻に既に入ってもいてもそこ以降に最速で入れる
+ * @param[in,out] pl: CCP を挿入する PacketList
+ * @param[in] packet: 挿入する CCP
+ * @param[in] now: 基準時刻 (TimeLine なら現在時刻， TaskList なら現在 step)
+ * @return PL_ACK
+ */
+PL_ACK TLCD_insert_tl_cmd_asap(PacketList* pl, const CommonCmdPacket* packet, cycle_t now);
+
 /**
  * @brief TLM の内容を自動更新する.
  * @param[in] line_no TLCD_line_no_for_tlm が入ることを想定している

--- a/TlmCmd/packet_handler.c
+++ b/TlmCmd/packet_handler.c
@@ -244,7 +244,7 @@ static PH_ACK PH_add_tl_cmd_(int line_no,
                             const CommonCmdPacket* packet,
                             cycle_t now)
 {
-  PL_ACK ack = PL_insert_tl_cmd(&(PH_tl_cmd_list[line_no]), packet, now);
+  PL_ACK ack = TLCD_insert_tl_cmd_strictly(&(PH_tl_cmd_list[line_no]), packet, now);
 
   switch (ack)
   {

--- a/TlmCmd/packet_list.c
+++ b/TlmCmd/packet_list.c
@@ -11,6 +11,7 @@
 #include "block_command_table.h"
 #include <src_user/Library/stdint.h>
 #include <string.h>
+#include "../Applications/timeline_command_dispatcher.h"
 
 
 /**
@@ -375,7 +376,7 @@ PL_ACK PL_deploy_block_cmd(PacketList* pl, const bct_id_t block, cycle_t start_a
     for (j = 0; j <= pl->active_nodes_; ++j)
     {
       // コマンドをTLCに登録を試みる
-      ack = PL_insert_tl_cmd(pl, &temp_, start_at);
+      ack = TLCD_insert_tl_cmd_strictly(pl, &temp_, start_at);
       if (ack != PL_TLC_ALREADY_EXISTS) break;    // PL_SUCCESS なはず． TODO: 一応 event 発行しておく？
 
       // 同一時刻で既に登録されていた場合は時刻をずらして再登録

--- a/TlmCmd/packet_list.h
+++ b/TlmCmd/packet_list.h
@@ -243,21 +243,6 @@ PL_ACK PL_drop_node(PacketList* pl, PL_Node* prev, PL_Node* current);
 // 以下，特定の packet を想定した PacketList の関数
 
 /**
- * @brief CCP が時系列に並ぶように CCP を挿入する
- * @note TimeLine だけでなく TaskList もこれを使い，その場合， now は step_t になることに注意
- * @param[in,out] pl: CCP を挿入する PacketList
- * @param[in] packet: 挿入する CCP
- * @param[in] now: 基準時刻 (TimeLine なら現在時刻， TaskList なら現在 step)
- * @retval PL_SUCCESS: 成功
- * @retval PL_LIST_FULL: PacketList が満杯
- * @retval PL_TLC_PAST_TIME: 実行時間がすでに過ぎている
- * @retval PL_TLC_ALREADY_EXISTS: 指定した実行時間にはすでにコマンドが登録されている
- * @retval PL_NO_SUCH_NODE: 何かがおかしい
- * @retval PL_PACKET_TYPE_ERR: 指定した PacketList の packet が CCP ではない
- */
-PL_ACK PL_insert_tl_cmd(PacketList* pl, const CommonCmdPacket* packet, cycle_t now);
-
-/**
  * @brief PacketList 上に BC を展開する
  * @note TimeLine だけでなく TaskList もこれを使い，その場合， start_at は step_t になることに注意
  * @param[in,out] pl: BC を展開する PacketList


### PR DESCRIPTION
## 概要
TLCD_insert_tl_cmd_asap の追加

## Issue
- https://github.com/ut-issl/c2a-core/issues/296

## 詳細
TL (time line cmd) 登録時に，時刻がかぶってると棄却されるので，指定時刻より後で最も近い時刻に登録するラッパーを追加した

## 検証結果
N/A

## 影響範囲
TL への挿入が変わるのでそれなりに大きい?
