### PR TITLE
test_command_dispatcher 内の sleep の時間を変更

### DIFF
--- a/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/TlmCmd/test_command_dispatcher.py
+++ b/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/TlmCmd/test_command_dispatcher.py
@@ -51,7 +51,7 @@ def test_cdis_exec_err():
     wings.util.send_tl_cmd(
         ope, ti_now + 55, c2a_enum.Cmd_CODE_AM_SET_PAGE_FOR_TLM, (AM_TLM_PAGE_MAX + 100,)
     )
-    time.sleep(2)
+    time.sleep(5)
 
     # === ELのチェック
     tlm_EL = wings.util.generate_and_receive_tlm(


### PR DESCRIPTION
## 概要
test_command_dispatcher 内の sleep の時間を変更

## Issue
N/A

## 詳細
これをやったところ，待機時間が足りずにテストが落ちたため修正した。
- https://github.com/ut-issl/python-wings-interface/pull/18

## 検証結果
pytestが通った。