### PR TITLE
CCP register cmd 関数の追加

### DIFF
--- a/TlmCmd/common_cmd_packet_util.c
+++ b/TlmCmd/common_cmd_packet_util.c
@@ -10,6 +10,8 @@
 #include <stddef.h>     // for NULL
 #include <string.h>
 
+static CommonCmdPacket* CCP_util_packet_;
+
 /**
  * @brief NOP cmd の RTC CCP を作る
  * @param[in,out] packet: CCP
@@ -111,40 +113,40 @@ CCP_UTIL_ACK CCP_form_block_deploy_cmd(CommonCmdPacket* packet, TLCD_ID tl_no, b
   return CCP_form_rtc(packet, Cmd_CODE_TLCD_DEPLOY_BLOCK, param, 1 + SIZE_OF_BCT_ID_T);
 }
 
-PH_ACK CCP_register_app_cmd(CommonCmdPacket* packet, cycle_t ti, AR_APP_ID id)
+PH_ACK CCP_register_app_cmd(cycle_t ti, AR_APP_ID id)
 {
-  CCP_form_app_cmd(packet, ti, id);
-  return PH_analyze_cmd_packet(packet);
+  CCP_form_app_cmd(CCP_util_packet_, ti, id);
+  return PH_analyze_cmd_packet(CCP_util_packet_);
 }
 
-PH_ACK CCP_register_rtc(CommonCmdPacket* packet, CMD_CODE cmd_id, const uint8_t* param, uint16_t len)
+PH_ACK CCP_register_rtc(CMD_CODE cmd_id, const uint8_t* param, uint16_t len)
 {
-  if (CCP_form_rtc(packet, cmd_id, param, len) != CCP_UTIL_ACK_OK)
+  if (CCP_form_rtc(CCP_util_packet_, cmd_id, param, len) != CCP_UTIL_ACK_OK)
   {
     return PH_ACK_INVALID_PACKET;
   }
 
-  return PH_analyze_cmd_packet(packet);
+  return PH_analyze_cmd_packet(CCP_util_packet_);
 }
 
-PH_ACK CCP_register_tlc(CommonCmdPacket* packet, cycle_t ti, CMD_CODE cmd_id, const uint8_t* param, uint16_t len)
+PH_ACK CCP_register_tlc(cycle_t ti, CMD_CODE cmd_id, const uint8_t* param, uint16_t len)
 {
-  if (CCP_form_tlc(packet, ti, cmd_id, param, len) != CCP_UTIL_ACK_OK)
+  if (CCP_form_tlc(CCP_util_packet_, ti, cmd_id, param, len) != CCP_UTIL_ACK_OK)
   {
     return PH_ACK_INVALID_PACKET;
   }
 
-  return PH_analyze_cmd_packet(packet);
+  return PH_analyze_cmd_packet(CCP_util_packet_);
 }
 
-PH_ACK CCP_register_block_deploy_cmd(CommonCmdPacket* packet, TLCD_ID tl_no, bct_id_t block_no)
+PH_ACK CCP_register_block_deploy_cmd(TLCD_ID tl_no, bct_id_t block_no)
 {
-  if (CCP_form_block_deploy_cmd(packet, tl_no, block_no) != CCP_UTIL_ACK_OK)
+  if (CCP_form_block_deploy_cmd(CCP_util_packet_, tl_no, block_no) != CCP_UTIL_ACK_OK)
   {
     return PH_ACK_INVALID_PACKET;
   }
 
-  return PH_analyze_cmd_packet(packet);
+  return PH_analyze_cmd_packet(CCP_util_packet_);
 }
 
 void CCP_convert_rtc_to_tlc(CommonCmdPacket* packet, cycle_t ti)

--- a/TlmCmd/common_cmd_packet_util.c
+++ b/TlmCmd/common_cmd_packet_util.c
@@ -37,7 +37,7 @@ void CCP_form_app_cmd(CommonCmdPacket* packet, cycle_t ti, AR_APP_ID id)
   // FIXME: この4は環境依存なので，依存しないように直す
   //        適切に直すことで， CCP_form_tlc の返り値をみなくて良くなるはず．
   //        Cmd_AM_EXECUTE_APP の引数取得部分と同時に直すべきだが，パラメタサイズは CmdDB から取得可能なはず．
-  uint8_t param[4];
+  static uint8_t param[4];
   size_t  id_temp = id;
   endian_memcpy(param, &id_temp, 4);
 
@@ -109,6 +109,42 @@ CCP_UTIL_ACK CCP_form_block_deploy_cmd(CommonCmdPacket* packet, TLCD_ID tl_no, b
   endian_memcpy(&param[1], &block_no, SIZE_OF_BCT_ID_T);
 
   return CCP_form_rtc(packet, Cmd_CODE_TLCD_DEPLOY_BLOCK, param, 1 + SIZE_OF_BCT_ID_T);
+}
+
+PH_ACK CCP_register_app_cmd(CommonCmdPacket* packet, cycle_t ti, AR_APP_ID id)
+{
+  CCP_form_app_cmd(packet, ti, id);
+  return PH_analyze_cmd_packet(packet);
+}
+
+PH_ACK CCP_register_rtc(CommonCmdPacket* packet, CMD_CODE cmd_id, const uint8_t* param, uint16_t len)
+{
+  if (CCP_form_rtc(packet, cmd_id, param, len) != CCP_UTIL_ACK_OK)
+  {
+    return PH_ACK_INVALID_PACKET;
+  }
+
+  return PH_analyze_cmd_packet(packet);
+}
+
+PH_ACK CCP_register_tlc(CommonCmdPacket* packet, cycle_t ti, CMD_CODE cmd_id, const uint8_t* param, uint16_t len)
+{
+  if (CCP_form_tlc(packet, ti, cmd_id, param, len) != CCP_UTIL_ACK_OK)
+  {
+    return PH_ACK_INVALID_PACKET;
+  }
+
+  return PH_analyze_cmd_packet(packet);
+}
+
+PH_ACK CCP_register_block_deploy_cmd(CommonCmdPacket* packet, TLCD_ID tl_no, bct_id_t block_no)
+{
+  if (CCP_form_block_deploy_cmd(packet, tl_no, block_no) != CCP_UTIL_ACK_OK)
+  {
+    return PH_ACK_INVALID_PACKET;
+  }
+
+  return PH_analyze_cmd_packet(packet);
 }
 
 void CCP_convert_rtc_to_tlc(CommonCmdPacket* packet, cycle_t ti)

--- a/TlmCmd/common_cmd_packet_util.c
+++ b/TlmCmd/common_cmd_packet_util.c
@@ -39,7 +39,7 @@ void CCP_form_app_cmd(CommonCmdPacket* packet, cycle_t ti, AR_APP_ID id)
   // FIXME: この4は環境依存なので，依存しないように直す
   //        適切に直すことで， CCP_form_tlc の返り値をみなくて良くなるはず．
   //        Cmd_AM_EXECUTE_APP の引数取得部分と同時に直すべきだが，パラメタサイズは CmdDB から取得可能なはず．
-  static uint8_t param[4];
+  uint8_t param[4];
   size_t  id_temp = id;
   endian_memcpy(param, &id_temp, 4);
 

--- a/TlmCmd/common_cmd_packet_util.h
+++ b/TlmCmd/common_cmd_packet_util.h
@@ -71,10 +71,46 @@ CCP_UTIL_ACK CCP_form_block_deploy_cmd(CommonCmdPacket* packet, TLCD_ID tl_no, b
  */
 void CCP_convert_rtc_to_tlc(CommonCmdPacket* packet, cycle_t ti);
 
+/**
+ * @brief  App 実行コマンドを登録
+ * @param[in,out] packet: CCP
+ * @param[in]     ti: TI
+ * @param[in]     id: AR_APP_ID
+ * @return PH_ACK
+ */
 PH_ACK CCP_register_app_cmd(CommonCmdPacket* packet, cycle_t ti, AR_APP_ID id);
 
+/**
+ * @brief  Realtime command を登録
+ * @note   引数が不正なとき， packet は NOP RTC を返す
+ * @param[in,out] packet: CCP
+ * @param[in]     packet: CMD_CODE
+ * @param[in]     param:  パラメタ
+ * @param[in]     len:    パラメタ長
+ * @return CCP_UTIL_ACK
+ */
 PH_ACK CCP_register_rtc(CommonCmdPacket* packet, CMD_CODE cmd_id, const uint8_t* param, uint16_t len);
+
+/**
+ * @brief  Timeline command を登録
+ * @note   引数が不正なとき， packet は NOP TLC を返す
+ * @param[in,out] packet: CCP
+ * @param[in]     ti:     TI
+ * @param[in]     packet: CMD_CODE
+ * @param[in]     param:  パラメタ
+ * @param[in]     len:    パラメタ長
+ * @return CCP_UTIL_ACK
+ */
 PH_ACK CCP_register_tlc(CommonCmdPacket* packet, cycle_t ti, CMD_CODE cmd_id, const uint8_t* param, uint16_t len);
+
+/**
+ * @brief  BC展開 command を登録
+ * @note   引数が不正なとき， packet は NOP RTC を返す
+ * @param[in,out] packet: CCP
+ * @param[in]     tl_no: Timeline no
+ * @param[in]     block_no: BC ID
+ * @return CCP_UTIL_ACK
+ */
 PH_ACK CCP_register_block_deploy_cmd(CommonCmdPacket* packet, TLCD_ID tl_no, bct_id_t block_no);
 
 /**

--- a/TlmCmd/common_cmd_packet_util.h
+++ b/TlmCmd/common_cmd_packet_util.h
@@ -77,27 +77,27 @@ void CCP_convert_rtc_to_tlc(CommonCmdPacket* packet, cycle_t ti);
 
 /**
  * @brief  App 実行コマンドを登録
- * @param[in]     ti: TI
- * @param[in]     id: AR_APP_ID
+ * @param[in] ti: TI
+ * @param[in] id: AR_APP_ID
  * @return PH_ACK
  */
 PH_ACK CCP_register_app_cmd(cycle_t ti, AR_APP_ID id);
 
 /**
  * @brief  Realtime command を登録
- * @param[in]     cmd_id: CMD_CODE
- * @param[in]     param:  パラメタ
- * @param[in]     len:    パラメタ長
+ * @param[in] cmd_id: CMD_CODE
+ * @param[in] param:  パラメタ
+ * @param[in] len:    パラメタ長
  * @return CCP_UTIL_ACK
  */
 PH_ACK CCP_register_rtc(CMD_CODE cmd_id, const uint8_t* param, uint16_t len);
 
 /**
  * @brief  Timeline command を登録
- * @param[in]     ti:     TI
- * @param[in]     cmd_id: CMD_CODE
- * @param[in]     param:  パラメタ
- * @param[in]     len:    パラメタ長
+ * @param[in] ti:     TI
+ * @param[in] cmd_id: CMD_CODE
+ * @param[in] param:  パラメタ
+ * @param[in] len:    パラメタ長
  * @return CCP_UTIL_ACK
  */
 PH_ACK CCP_register_tlc(cycle_t ti, CMD_CODE cmd_id, const uint8_t* param, uint16_t len);
@@ -105,8 +105,8 @@ PH_ACK CCP_register_tlc(cycle_t ti, CMD_CODE cmd_id, const uint8_t* param, uint1
 /**
  * @brief  BC展開 command を登録
  * @note   RTC に登録される
- * @param[in]     tl_no: Timeline no
- * @param[in]     block_no: BC ID
+ * @param[in] tl_no: Timeline no
+ * @param[in] block_no: BC ID
  * @return CCP_UTIL_ACK
  */
 PH_ACK CCP_register_block_deploy_cmd(TLCD_ID tl_no, bct_id_t block_no);

--- a/TlmCmd/common_cmd_packet_util.h
+++ b/TlmCmd/common_cmd_packet_util.h
@@ -77,7 +77,6 @@ void CCP_convert_rtc_to_tlc(CommonCmdPacket* packet, cycle_t ti);
 
 /**
  * @brief  App 実行コマンドを登録
- * @param[in,out] packet: CCP
  * @param[in]     ti: TI
  * @param[in]     id: AR_APP_ID
  * @return PH_ACK
@@ -86,9 +85,7 @@ PH_ACK CCP_register_app_cmd(cycle_t ti, AR_APP_ID id);
 
 /**
  * @brief  Realtime command を登録
- * @note   引数が不正なとき， packet は NOP RTC を返す
- * @param[in,out] packet: CCP
- * @param[in]     packet: CMD_CODE
+ * @param[in]     cmd_id: CMD_CODE
  * @param[in]     param:  パラメタ
  * @param[in]     len:    パラメタ長
  * @return CCP_UTIL_ACK
@@ -97,10 +94,8 @@ PH_ACK CCP_register_rtc(CMD_CODE cmd_id, const uint8_t* param, uint16_t len);
 
 /**
  * @brief  Timeline command を登録
- * @note   引数が不正なとき， packet は NOP TLC を返す
- * @param[in,out] packet: CCP
  * @param[in]     ti:     TI
- * @param[in]     packet: CMD_CODE
+ * @param[in]     cmd_id: CMD_CODE
  * @param[in]     param:  パラメタ
  * @param[in]     len:    パラメタ長
  * @return CCP_UTIL_ACK
@@ -109,9 +104,7 @@ PH_ACK CCP_register_tlc(cycle_t ti, CMD_CODE cmd_id, const uint8_t* param, uint1
 
 /**
  * @brief  BC展開 command を登録
- * @note   引数が不正なとき， packet は NOP RTC を返す
  * @note   RTC に登録される
- * @param[in,out] packet: CCP
  * @param[in]     tl_no: Timeline no
  * @param[in]     block_no: BC ID
  * @return CCP_UTIL_ACK

--- a/TlmCmd/common_cmd_packet_util.h
+++ b/TlmCmd/common_cmd_packet_util.h
@@ -71,6 +71,12 @@ CCP_UTIL_ACK CCP_form_block_deploy_cmd(CommonCmdPacket* packet, TLCD_ID tl_no, b
  */
 void CCP_convert_rtc_to_tlc(CommonCmdPacket* packet, cycle_t ti);
 
+PH_ACK CCP_register_app_cmd(CommonCmdPacket* packet, cycle_t ti, AR_APP_ID id);
+
+PH_ACK CCP_register_rtc(CommonCmdPacket* packet, CMD_CODE cmd_id, const uint8_t* param, uint16_t len);
+PH_ACK CCP_register_tlc(CommonCmdPacket* packet, cycle_t ti, CMD_CODE cmd_id, const uint8_t* param, uint16_t len);
+PH_ACK CCP_register_block_deploy_cmd(CommonCmdPacket* packet, TLCD_ID tl_no, bct_id_t block_no);
+
 /**
  * @brief  CCP packet から，サイズが 1 byte のコマンド引数を取得する
  * @note   セグメンテーション違反の場合は， 0 が代入されたポインタを返す

--- a/TlmCmd/common_cmd_packet_util.h
+++ b/TlmCmd/common_cmd_packet_util.h
@@ -23,6 +23,7 @@ typedef enum
 
 /**
  * @brief  App 実行コマンドを生成
+ * @note   TL登録まで行う場合は `CCP_register_app_cmd` を使用
  * @param[in,out] packet: CCP
  * @param[in]     ti: TI
  * @param[in]     id: AR_APP_ID
@@ -33,6 +34,7 @@ void CCP_form_app_cmd(CommonCmdPacket* packet, cycle_t ti, AR_APP_ID id);
 /**
  * @brief  Realtime command を生成
  * @note   引数が不正なとき， packet は NOP RTC を返す
+ * @note   RTC のキューに登録までする場合は `CCP_register_rtc` を使用
  * @param[in,out] packet: CCP
  * @param[in]     packet: CMD_CODE
  * @param[in]     param:  パラメタ
@@ -44,6 +46,7 @@ CCP_UTIL_ACK CCP_form_rtc(CommonCmdPacket* packet, CMD_CODE cmd_id, const uint8_
 /**
  * @brief  Timeline command を生成
  * @note   引数が不正なとき， packet は NOP TLC を返す
+ * @note   TL に登録までする場合は `CCP_register_tlc` を使用
  * @param[in,out] packet: CCP
  * @param[in]     ti:     TI
  * @param[in]     packet: CMD_CODE
@@ -56,6 +59,7 @@ CCP_UTIL_ACK CCP_form_tlc(CommonCmdPacket* packet, cycle_t ti, CMD_CODE cmd_id, 
 /**
  * @brief  BC展開 command を生成
  * @note   引数が不正なとき， packet は NOP RTC を返す
+ * @note   RTC のキューに登録までする場合は `CCP_register_block_deploy_cmd` を使用
  * @param[in,out] packet: CCP
  * @param[in]     tl_no: Timeline no
  * @param[in]     block_no: BC ID
@@ -78,7 +82,7 @@ void CCP_convert_rtc_to_tlc(CommonCmdPacket* packet, cycle_t ti);
  * @param[in]     id: AR_APP_ID
  * @return PH_ACK
  */
-PH_ACK CCP_register_app_cmd(CommonCmdPacket* packet, cycle_t ti, AR_APP_ID id);
+PH_ACK CCP_register_app_cmd(cycle_t ti, AR_APP_ID id);
 
 /**
  * @brief  Realtime command を登録
@@ -89,7 +93,7 @@ PH_ACK CCP_register_app_cmd(CommonCmdPacket* packet, cycle_t ti, AR_APP_ID id);
  * @param[in]     len:    パラメタ長
  * @return CCP_UTIL_ACK
  */
-PH_ACK CCP_register_rtc(CommonCmdPacket* packet, CMD_CODE cmd_id, const uint8_t* param, uint16_t len);
+PH_ACK CCP_register_rtc(CMD_CODE cmd_id, const uint8_t* param, uint16_t len);
 
 /**
  * @brief  Timeline command を登録
@@ -101,17 +105,18 @@ PH_ACK CCP_register_rtc(CommonCmdPacket* packet, CMD_CODE cmd_id, const uint8_t*
  * @param[in]     len:    パラメタ長
  * @return CCP_UTIL_ACK
  */
-PH_ACK CCP_register_tlc(CommonCmdPacket* packet, cycle_t ti, CMD_CODE cmd_id, const uint8_t* param, uint16_t len);
+PH_ACK CCP_register_tlc(cycle_t ti, CMD_CODE cmd_id, const uint8_t* param, uint16_t len);
 
 /**
  * @brief  BC展開 command を登録
  * @note   引数が不正なとき， packet は NOP RTC を返す
+ * @note   RTC に登録される
  * @param[in,out] packet: CCP
  * @param[in]     tl_no: Timeline no
  * @param[in]     block_no: BC ID
  * @return CCP_UTIL_ACK
  */
-PH_ACK CCP_register_block_deploy_cmd(CommonCmdPacket* packet, TLCD_ID tl_no, bct_id_t block_no);
+PH_ACK CCP_register_block_deploy_cmd(TLCD_ID tl_no, bct_id_t block_no);
 
 /**
  * @brief  CCP packet から，サイズが 1 byte のコマンド引数を取得する


### PR DESCRIPTION
## 概要
CCP register cmd 関数の追加

## Issue
- https://github.com/ut-issl/c2a-core/issues/313

## 詳細
form と `PH_analyze_packet` をまとめた register を作成した

## 検証結果
N/A

## 影響範囲
小

