### PR TITLE
s2e-core更新に伴うCmake関連ファイルの修正

### DIFF
--- a/.github/workflows/build_with_s2e.yml
+++ b/.github/workflows/build_with_s2e.yml
@@ -8,14 +8,12 @@ on:
   pull_request:
 
 env:
-  S2E_CORE_VERSION: bef17af9b13dbb9095183ba7de7af9d02d8cfe07
+  S2E_CORE_VERSION: v5.0.0
 
 jobs:
   build_s2e_win:
-    name: Build on Windows
-    # runs-on: windows-latest
-    # VS2022 ではなく VS2019 がほしい
-    runs-on: windows-2019
+    name: Build on Windows VS2022
+    runs-on: windows-2022
 
     steps:
       - name: checkout S2E core
@@ -53,8 +51,6 @@ jobs:
         uses: actions/cache@v3
         with:
           key: extlib-${{ runner.os }}-${{ hashFiles('./s2e-core/ExtLibraries/**') }}
-          restore-keys: |
-            extlib-${{ runner.os }}-
           path: ./s2e-core/ExtLibraries
 
       - name: build extlib
@@ -63,8 +59,8 @@ jobs:
         working-directory: ./s2e-core/ExtLibraries
         run: |
           $extlib_dir=(pwd).Path
-          cmake -G "Visual Studio 16 2019" -A Win32 -DCMAKE_CONFIGURATION_TYPES:STRING="Debug" -DEXT_LIB_DIR="${extlib_dir}"
-          cmake --build .
+          cmake -G "Visual Studio 17 2022" -A Win32 -DCMAKE_CONFIGURATION_TYPES:STRING="Debug" -DEXT_LIB_DIR="${extlib_dir}"
+          cmake --build . --clean-first
 
       - name: install extlib
         if: steps.cache-extlib.outputs.cache-hit != 'true'
@@ -78,7 +74,7 @@ jobs:
         working-directory: ./s2e-core/ExtLibraries
         run: |
           ls cspice
-          ls cspice/cspice_msvs
+          ls cspice/cspice_msvs/lib
           ls cspice/include
           ls cspice/generic_kernels
           ls nrlmsise00
@@ -92,5 +88,5 @@ jobs:
         shell: cmd
         run: |
           cl.exe
-          cmake -G "Visual Studio 16 2019" -A Win32 -DCMAKE_CONFIGURATION_TYPES:STRING="Debug" -DEXT_LIB_DIR=../s2e-core/ExtLibraries -DFLIGHT_SW_DIR=../c2a-core -DC2A_NAME=Examples/minimum_user_for_s2e -DUSE_C2A=ON
-          cmake --build .
+          cmake -G "Visual Studio 17 2022" -A Win32 -DCMAKE_CONFIGURATION_TYPES:STRING="Debug" -DEXT_LIB_DIR=../s2e-core/ExtLibraries -DFLIGHT_SW_DIR=../c2a-core -DC2A_NAME=Examples/minimum_user_for_s2e -DUSE_C2A=ON
+          cmake --build . --clean-first

--- a/common.cmake
+++ b/common.cmake
@@ -20,6 +20,7 @@ endif()
 # Build option
 if(MSVC)
   target_compile_options(${PROJECT_NAME} PUBLIC "/W4")
+  target_compile_options(${PROJECT_NAME} PUBLIC "/MT")
   target_compile_options(${PROJECT_NAME} PUBLIC "/TP") # Compile C codes as C++
   target_compile_options(${PROJECT_NAME} PUBLIC "/source-charset:utf-8")
 else()


### PR DESCRIPTION
## 概要
s2e-core更新に伴うCmake関連ファイルの修正

## Issue
issueではないが、
https://github.com/ut-issl/s2e-user-for-c2a-core/pull/18

## 詳細
- s2e-coreでwarningを消すためにVSの`/MT`オプションが必要になったので、c2a-core内のcmakeについてもそのオプションを追加
- (これから実装するが、)Linux用にWINGSと接続する部分を消す修正も行う

## 検証結果
手元でビルドできることを確認した

## 影響範囲
S2E/VS環境の人のみ

## 補足
NA

## 注意
NA