### PR TITLE
Pre Release (v3.6.0-beta.4): WINGS側でUTLが0.1s精度で打てるようになったことへの対応

### DIFF
--- a/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/TimeManager/test_time_manager.py
+++ b/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/System/TimeManager/test_time_manager.py
@@ -25,8 +25,8 @@ OBCT_CYCLES_PER_SEC = 1000 // OBCT_STEP_IN_MSEC // OBCT_STEPS_PER_CYCLE  # 1 s �
 TMGR_DEFAULT_UNIXTIME_EPOCH_FOR_UTL = 1577836800.0
 
 
-# @pytest.mark.sils
-# @pytest.mark.real
+@pytest.mark.sils
+@pytest.mark.real
 def test_tmgr_set_time():
 
     assert "PRM" == wings.util.send_rt_cmd_and_confirm(
@@ -49,8 +49,8 @@ def test_tmgr_set_time():
     assert tlm_HK["HK.SH.TI"] < target_ti + 50
 
 
-# @pytest.mark.sils
-# @pytest.mark.real
+@pytest.mark.sils
+@pytest.mark.real
 def test_tmgr_set_unixtime():
 
     # unixtime_at_ti0 を current_unixtime とランダムな TI で更新
@@ -84,8 +84,8 @@ def test_tmgr_set_unixtime():
     )
 
 
-# @pytest.mark.sils
-# @pytest.mark.real
+@pytest.mark.sils
+@pytest.mark.real
 def test_tmgr_set_utl_unixtime_epoch():
 
     # 負の値ではコマンドが通らないことを確認
@@ -105,8 +105,8 @@ def test_tmgr_set_utl_unixtime_epoch():
     assert tlm_MOBC["MOBC.TM_UTL_UNIXTIME_EPOCH"] == new_epoch
 
 
-# @pytest.mark.sils
-# @pytest.mark.real
+@pytest.mark.sils
+@pytest.mark.real
 def test_tmgr_set_and_reset_cycle_correction():
 
     # 負の値ではコマンドが通らないことを確認
@@ -153,37 +153,25 @@ def test_tmgr_utl_cmd():
         c2a_enum.Tlm_CODE_HK,
     )
 
-    # unixtime を同期する
-    tlm_HK = ope.get_latest_tlm(c2a_enum.Tlm_CODE_HK)[0]
-    ti_now = tlm_HK["HK.SH.TI"]
-    unixtime_now = time.time()
-    assert "SUC" == wings.util.send_rt_cmd_and_confirm(
-        ope,
-        c2a_enum.Cmd_CODE_TMGR_UPDATE_UNIXTIME,
-        (unixtime_now, ti_now, 0),
-        c2a_enum.Tlm_CODE_HK,
-    )
-    unixtime_at_ti0 = unixtime_now - ti_now / OBCT_CYCLES_PER_SEC
-
     # ===== 実行unixtime < unixtime_at_ti0 の場合 =====
     # TODO: TL_gsに登録されないことを確認する
 
     # ===== 通常時 =====
-    check_utl_cmd_with(unixtime_at_ti0, TMGR_DEFAULT_UNIXTIME_EPOCH_FOR_UTL, 1.0)
+    check_utl_cmd_with(TMGR_DEFAULT_UNIXTIME_EPOCH_FOR_UTL, 1.0)
 
     # ===== CYCLES_PER_SEC を補正した場合 =====
     # 0.7 <= set_value <= 1.3 でランダムに補正倍率をセット
     set_value = random.uniform(0.7, 1.3)
-    check_utl_cmd_with(unixtime_at_ti0, TMGR_DEFAULT_UNIXTIME_EPOCH_FOR_UTL, set_value)
+    check_utl_cmd_with(TMGR_DEFAULT_UNIXTIME_EPOCH_FOR_UTL, set_value)
 
     # ===== epoch を変えた場合 =====
     # 例えば epoch を30日前の unixtime に変更する
     new_epoch = time.time() - 86400 * 30
-    check_utl_cmd_with(unixtime_at_ti0, new_epoch, 1.0)
+    check_utl_cmd_with(new_epoch, 1.0)
 
     # ===== epoch を変えて CYCLES_PER_SEC も補正した場合 =====
     set_value = random.uniform(0.7, 1.3)
-    check_utl_cmd_with(unixtime_at_ti0, new_epoch, set_value)
+    check_utl_cmd_with(new_epoch, set_value)
 
 
 @pytest.mark.sils
@@ -206,7 +194,7 @@ def test_tmgr_final_check():
     )
 
 
-def check_utl_cmd_with(unixtime_at_ti0, utl_unixtime_epoch, cycle_correction):
+def check_utl_cmd_with(utl_unixtime_epoch, cycle_correction):
     # utl_unixtime_epoch, cycle_correction を設定する
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
         ope,
@@ -217,6 +205,18 @@ def check_utl_cmd_with(unixtime_at_ti0, utl_unixtime_epoch, cycle_correction):
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
         ope, c2a_enum.Cmd_CODE_TMGR_SET_CYCLE_CORRECTION, (cycle_correction,), c2a_enum.Tlm_CODE_HK
     )
+
+    # unixtime_info を現在の ti と unixtime で同期する
+    tlm_HK = ope.get_latest_tlm(c2a_enum.Tlm_CODE_HK)[0]
+    ti_now = tlm_HK["HK.SH.TI"]
+    unixtime_now = time.time()
+    assert "SUC" == wings.util.send_rt_cmd_and_confirm(
+        ope,
+        c2a_enum.Cmd_CODE_TMGR_UPDATE_UNIXTIME,
+        (unixtime_now, ti_now, 0),
+        c2a_enum.Tlm_CODE_HK,
+    )
+    unixtime_at_ti0 = unixtime_now - ti_now / (OBCT_CYCLES_PER_SEC * cycle_correction)
 
     # 最初にTL_gsをクリアしておく
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(

--- a/System/TimeManager/time_manager.c
+++ b/System/TimeManager/time_manager.c
@@ -204,11 +204,11 @@ cycle_t TMGR_get_ti_from_utl_unixtime(const cycle_t utl_unixtime)
 {
   double unixtime = TMGR_get_unixtime_from_utl_unixtime(utl_unixtime);
   double ti_double = (unixtime - TMGR_get_unixtime_at_ti0()) * TMGR_get_precice_cycles_per_sec();
+  cycle_t ti = (cycle_t)ti_double;
 
   // unixtime_at_ti0 より小さい実行時刻は無効なのでゼロを返す
-  if (ti_double < 0) return 0;
+  if (ti < 0) return 0;
 
-  cycle_t ti = (cycle_t)ti_double;
   if (ti_double - ti >= 0.5)
   {
     ti += 1;

--- a/System/TimeManager/time_manager.c
+++ b/System/TimeManager/time_manager.c
@@ -203,12 +203,17 @@ double TMGR_get_unixtime_from_utl_unixtime(const cycle_t utl_unixtime)
 cycle_t TMGR_get_ti_from_utl_unixtime(const cycle_t utl_unixtime)
 {
   double unixtime = TMGR_get_unixtime_from_utl_unixtime(utl_unixtime);
-  double ti_in_sec = unixtime - TMGR_get_unixtime_at_ti0();
+  double ti_double = (unixtime - TMGR_get_unixtime_at_ti0()) * TMGR_get_precice_cycles_per_sec();
 
   // unixtime_at_ti0 より小さい実行時刻は無効なのでゼロを返す
-  if (ti_in_sec < 0) return 0;
+  if (ti_double < 0) return 0;
 
-  return (cycle_t)(ti_in_sec * TMGR_get_precice_cycles_per_sec() );
+  cycle_t ti = (cycle_t)ti_double;
+  if (ti_double - ti >= 0.5)
+  {
+    ti += 1;
+  }
+  return ti;
 }
 
 static TMGR_ACK TMGR_set_utl_unixtime_epoch_(double utl_unixtime_epoch)

--- a/System/TimeManager/time_manager.c
+++ b/System/TimeManager/time_manager.c
@@ -134,7 +134,7 @@ void TMGR_clear_unixtime_info(void)
 
 TMGR_ACK TMGR_update_unixtime(const double unixtime, const ObcTime* time)
 {
-  double ti_sec = TMGR_get_precice_ti_in_sec(time);
+  double ti_sec = TMGR_get_precise_ti_in_sec(time);
 
   // unixtime が ti より小さいと困る
   if (unixtime < ti_sec) return TMGR_ACK_PARAM_ERR;
@@ -154,25 +154,25 @@ double TMGR_get_utl_unixtime_epoch(void)
   return time_manager_.unixtime_info_.utl_unixtime_epoch;
 }
 
-double TMGR_get_precice_cycles_per_sec(void)
+double TMGR_get_precise_cycles_per_sec(void)
 {
   return OBCT_CYCLES_PER_SEC * time_manager_.unixtime_info_.cycle_correction;
 }
 
-double TMGR_get_precice_ti_in_sec(const ObcTime* time)
+double TMGR_get_precise_ti_in_sec(const ObcTime* time)
 {
   double cycle = time->total_cycle + (double)time->step / OBCT_STEPS_PER_CYCLE;
-  return cycle / TMGR_get_precice_cycles_per_sec();
+  return cycle / TMGR_get_precise_cycles_per_sec();
 }
 
 double TMGR_get_current_unixtime(void)
 {
-  return TMGR_get_unixtime_at_ti0() + TMGR_get_precice_ti_in_sec(&time_manager_.master_clock_);
+  return TMGR_get_unixtime_at_ti0() + TMGR_get_precise_ti_in_sec(&time_manager_.master_clock_);
 }
 
 double TMGR_get_unixtime_from_obc_time(const ObcTime* time)
 {
-  return TMGR_get_unixtime_at_ti0() + TMGR_get_precice_ti_in_sec(time);
+  return TMGR_get_unixtime_at_ti0() + TMGR_get_precise_ti_in_sec(time);
 }
 
 double TMGR_get_unixtime_from_utl_unixtime(const cycle_t utl_unixtime)
@@ -182,7 +182,7 @@ double TMGR_get_unixtime_from_utl_unixtime(const cycle_t utl_unixtime)
 
 double TMGR_get_precise_ti_from_unixtime(const double unixtime)
 {
-  double ti = (unixtime - TMGR_get_unixtime_at_ti0()) * TMGR_get_precice_cycles_per_sec();
+  double ti = (unixtime - TMGR_get_unixtime_at_ti0()) * TMGR_get_precise_cycles_per_sec();
 
   // unixtime_at_ti0 より小さい引数は無効なのでゼロを返す
   if (ti < 0) return 0;

--- a/System/TimeManager/time_manager.c
+++ b/System/TimeManager/time_manager.c
@@ -202,13 +202,14 @@ double TMGR_get_unixtime_from_utl_unixtime(const cycle_t utl_unixtime)
 
 cycle_t TMGR_get_ti_from_utl_unixtime(const cycle_t utl_unixtime)
 {
+  cycle_t ti;
   double unixtime = TMGR_get_unixtime_from_utl_unixtime(utl_unixtime);
   double ti_double = (unixtime - TMGR_get_unixtime_at_ti0()) * TMGR_get_precice_cycles_per_sec();
-  cycle_t ti = (cycle_t)ti_double;
 
   // unixtime_at_ti0 より小さい実行時刻は無効なのでゼロを返す
-  if (ti < 0) return 0;
+  if (ti_double < 0) return 0;
 
+  ti = (cycle_t)ti_double;
   if (ti_double - ti >= 0.5)
   {
     ti += 1;

--- a/System/TimeManager/time_manager.h
+++ b/System/TimeManager/time_manager.h
@@ -196,20 +196,28 @@ double TMGR_get_current_unixtime(void);
 double TMGR_get_unixtime_from_obc_time(const ObcTime* time);
 
 /**
- * @brief unixtime を ObcTime に変換する
- * @param[in] unixtime
- * @retval {0, 0, 0} : 引数の unixtime が unixtime_at_ti0 より小さいとき
- * @retval ObcTime   : それ以外
- */
-ObcTime TMGR_get_obc_time_from_unixtime(const double unixtime);
-
-/**
  * @brief UTL_cmdで用いる utl_unixtime を 一般的なunixtimeに変換する
  * @note utl_unixtime の単位としての cycle は, OBC のクロック誤差を含まない定義通りの値であることに注意
  * @param[in] utl_unixtime
  * @return unixtime
  */
 double TMGR_get_unixtime_from_utl_unixtime(const cycle_t utl_unixtime);
+
+/**
+ * @brief unixtime を TI (cycle単位) に変換する
+ * @param[in] unixtime
+ * @retval 0  : 引数の unixtime が unixtime_at_ti0 より小さいとき
+ * @retval TI : それ以外. 整数に丸めず double のまま返す
+ */
+double TMGR_get_precise_ti_from_unixtime(const double unixtime);
+
+/**
+ * @brief unixtime を ObcTime に変換する
+ * @param[in] unixtime
+ * @retval {0, 0, 0} : 引数の unixtime が unixtime_at_ti0 より小さいとき
+ * @retval ObcTime   : それ以外
+ */
+ObcTime TMGR_get_obc_time_from_unixtime(const double unixtime);
 
 /**
  * @brief 引数で指定された utl_unixtime に対応する TI を返す

--- a/System/TimeManager/time_manager.h
+++ b/System/TimeManager/time_manager.h
@@ -172,14 +172,14 @@ double TMGR_get_utl_unixtime_epoch(void);
  * @param void
  * @return cycles_per_sec
  */
-double TMGR_get_precice_cycles_per_sec(void);
+double TMGR_get_precise_cycles_per_sec(void);
 
 /**
  * @brief OBC のクロック誤差を反映した正確な ti を秒単位で返す
  * @param[in] time ti を保持している OBCTime
  * @return ti（秒単位, 小数点以下も保持）
  */
-double TMGR_get_precice_ti_in_sec(const ObcTime* time);
+double TMGR_get_precise_ti_in_sec(const ObcTime* time);
 
 /**
  * @brief 現在の unixtime を OBC の ti をもとに計算して返す

--- a/c2a_core_main.h
+++ b/c2a_core_main.h
@@ -10,6 +10,6 @@ void C2A_core_main(void);
 #define C2A_CORE_VER_MAJOR (3)
 #define C2A_CORE_VER_MINOR (6)
 #define C2A_CORE_VER_PATCH (0)
-#define C2A_CORE_VER_PRE   ("beta.3")
+#define C2A_CORE_VER_PRE   ("beta.4")
 
 #endif


### PR DESCRIPTION
## 概要
WINGS側でUTLが0.1s精度で打てるようになったことへの対応

## Issue
- https://github.com/ut-issl/c2a-core/issues/175

## 詳細
issueの残タスクである以下をやった
- 0.1sに対応
- 現実の時刻にテストを合わせる
- 過去時刻で通らないことの確認

## 検証結果
手元でpytestが通った

## 補足
- https://github.com/ut-issl/python-wings-interface/pull/22
と一緒にマージする。非互換なのでpre-releaseを打つ。