### PR TITLE
Ignore example user's main() on SILS environment

### DIFF
--- a/Examples/minimum_user_for_s2e/CMakeLists.txt
+++ b/Examples/minimum_user_for_s2e/CMakeLists.txt
@@ -61,6 +61,7 @@ if(BUILD_C2A_AS_CXX)
 endif()
 
 if(USE_SILS_MOCKUP)
+  add_definitions(-DDEFINE_MAIN_ON_SILS)
   add_executable(${PROJECT_NAME} ${C2A_SRCS})
 else()
   add_library(${PROJECT_NAME} STATIC ${C2A_SRCS})

--- a/Examples/minimum_user_for_s2e/src/src_user/c2a_main.c
+++ b/Examples/minimum_user_for_s2e/src/src_user/c2a_main.c
@@ -4,17 +4,23 @@
 #include <src_core/System/WatchdogTimer/watchdog_timer.h>
 #include "./Settings/sils_define.h"
 
+// SILSの時はmain関数はC2A外にある
+#ifndef SILS_FW
 int main(void);
+#endif
+
 static void address_fixed_main_(void);
 static void C2A_init_(void);
 static void C2A_main_(void);
 static void timer_setting_(void);
 
+#ifndef SILS_FW
 int main(void)
 {
   address_fixed_main_();
   return 0;
 }
+#endif
 
 
 // RAM上でのアドレス固定main関数

--- a/Examples/minimum_user_for_s2e/src/src_user/c2a_main.c
+++ b/Examples/minimum_user_for_s2e/src/src_user/c2a_main.c
@@ -4,8 +4,8 @@
 #include <src_core/System/WatchdogTimer/watchdog_timer.h>
 #include "./Settings/sils_define.h"
 
-// SILSの時はmain関数はC2A外にある
-#ifndef SILS_FW
+// SILSの時，通常main関数はC2A外にある
+#ifdef DEFINE_MAIN_ON_SILS
 int main(void);
 #endif
 
@@ -14,7 +14,7 @@ static void C2A_init_(void);
 static void C2A_main_(void);
 static void timer_setting_(void);
 
-#ifndef SILS_FW
+#ifdef DEFINE_MAIN_ON_SILS
 int main(void)
 {
   address_fixed_main_();


### PR DESCRIPTION
## 概要
Example userのmain関数をSILSの時には定義しないようにする

## Issue
- 関連する issue

## 詳細
今のところこれで困っていることはあまりないが，libC2Aを他のものとリンクさせる時に`multiple definition`エラーが出ることがあるので，その修正

