### PR TITLE
Fix/Add CMake build options for user

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ project(C2A_CORE)
 option(USE_ALL_C2A_CORE_APPS    "use C2A-core all Applications" ON)
 option(USE_ALL_C2A_CORE_LIB     "use C2A-core all Library" ON)
 option(USE_32BIT_COMPILER       "use 32bit compiler" OFF)
+
+option(BUULD_C2A_AS_SILS_FW     "build C2A as SILS firmware" ON)
 option(BUILD_C2A_AS_CXX         "build C2A as C++" OFF)
 option(BUILD_C2A_AS_UTF8        "build C2A as UTF-8" ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ project(C2A_CORE)
 option(USE_ALL_C2A_CORE_APPS    "use C2A-core all Applications" ON)
 option(USE_ALL_C2A_CORE_LIB     "use C2A-core all Library" ON)
 option(USE_32BIT_COMPILER       "use 32bit compiler" OFF)
+option(BUILD_C2A_AS_CXX         "build C2A as C++" OFF)
 option(BUILD_C2A_AS_UTF8        "build C2A as UTF-8" ON)
 
 set(C2A_CORE_DIR ${CMAKE_CURRENT_SOURCE_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ project(C2A_CORE)
 option(USE_ALL_C2A_CORE_APPS    "use C2A-core all Applications" ON)
 option(USE_ALL_C2A_CORE_LIB     "use C2A-core all Library" ON)
 option(USE_32BIT_COMPILER       "use 32bit compiler" OFF)
+option(BUILD_C2A_AS_UTF8        "build C2A as UTF-8" ON)
 
 set(C2A_CORE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/Examples/minimum_user_for_s2e/CMakeLists.txt
+++ b/Examples/minimum_user_for_s2e/CMakeLists.txt
@@ -19,6 +19,8 @@ option(USE_SCI_COM_UART "Use SCI_COM_UART" OFF)
 
 option(USE_SILS_MOCKUP "Use SILS mockup for build C2A with minimal user in C89 only" OFF)
 
+option(BUILD_C2A_AS_SILS_FW "Build C2A as SILS firmware" ON)
+
 if(USE_SILS_MOCKUP)
   set(BUILD_C2A_AS_CXX OFF)
 endif()
@@ -31,7 +33,6 @@ set(C2A_CORE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/src_core)
 set(C2A_USER_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/src_user)
 
 include_directories(src)
-add_definitions(-DSILS_FW)
 
 # Output debug print to SILS console window
 option(SHOW_DEBUG_PRINT_ON_SILS "Show debug print")

--- a/common.cmake
+++ b/common.cmake
@@ -21,7 +21,9 @@ endif()
 if(MSVC)
   target_compile_options(${PROJECT_NAME} PUBLIC "/W4")
   target_compile_options(${PROJECT_NAME} PUBLIC "/MT")
-  target_compile_options(${PROJECT_NAME} PUBLIC "/TP") # Compile C codes as C++
+  if(BUILD_C2A_AS_CXX)
+    target_compile_options(${PROJECT_NAME} PUBLIC "/TP") # Compile C codes as C++
+  endif()
   target_compile_options(${PROJECT_NAME} PUBLIC "/source-charset:utf-8")
 else()
   # SJIS

--- a/common.cmake
+++ b/common.cmake
@@ -24,7 +24,9 @@ if(MSVC)
   if(BUILD_C2A_AS_CXX)
     target_compile_options(${PROJECT_NAME} PUBLIC "/TP") # Compile C codes as C++
   endif()
-  target_compile_options(${PROJECT_NAME} PUBLIC "/source-charset:utf-8")
+  if(BUILD_C2A_AS_UTF8)
+    target_compile_options(${PROJECT_NAME} PUBLIC "/source-charset:utf-8")
+  endif()
 else()
   # SJIS
   # if (NOT CMAKE_C_COMPILER_ID STREQUAL "Clang")

--- a/common.cmake
+++ b/common.cmake
@@ -17,6 +17,10 @@ else()
   endif()
 endif()
 
+if(BUULD_C2A_AS_SILS_FW)
+  target_compile_definitions(${PROJECT_NAME} PUBLIC SILS_FW)
+endif()
+
 # Build option
 if(MSVC)
   target_compile_options(${PROJECT_NAME} PUBLIC "/W4")


### PR DESCRIPTION
## 概要
CMakeでのビルド設定オプションの修正及び追加

## Issue
NA

## 詳細
- [x] `BUILD_C2A_AS_CXX` が MSVC 環境下で意味を成していなかったのを修正
- [x] `BUILD_C2A_AS_UTF8` オプションの追加
- [x] `BUILD_C2A_AS_SILS_FW` オプションの追加

## 検証結果
