### PR TITLE
CCP UTIL と BCL で sub OBC のコマンドに対応

### DIFF
--- a/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/TlmCmd/test_block_command_loader.py
+++ b/Examples/minimum_user_for_s2e/src/src_user/Test/test/src_core/TlmCmd/test_block_command_loader.py
@@ -26,6 +26,8 @@ PARAMS_LIST = [
     # Cmd_TMGR_SET_UTL_UNIXTIME_EPOCH
     [("double", 12345.6789)],
     [("double", -12345.6789)],
+    # AOBC_Cmd_CODE_MM_START_TRANSITION
+    [("uint8", 3)],
 ]
 
 

--- a/Examples/minimum_user_for_s2e/src/src_user/TlmCmd/NormalBlockCommandDefinition/nbc_test_bcl.c
+++ b/Examples/minimum_user_for_s2e/src/src_user/TlmCmd/NormalBlockCommandDefinition/nbc_test_bcl.c
@@ -8,6 +8,7 @@
 #include <src_core/TlmCmd/block_command_loader.h>
 
 #include "../command_definitions.h"
+#include "../../Drivers/Aocs/aobc_command_definitions.h"
 #include "../block_command_definitions.h"
 
 void BCL_load_test_bcl(void)
@@ -26,6 +27,11 @@ void BCL_load_test_bcl(void)
 
   BCL_tool_prepare_param_double(-12345.6789);
   BCL_tool_register_cmd(4, Cmd_CODE_TMGR_SET_UTL_UNIXTIME_EPOCH);
+
+  // sub obc コマンドのチェック
+  // FIXME: sub OBC のコマンド数が MOBC より多くなるとキャストできなくて困る
+  BCL_tool_prepare_param_uint8(3);
+  BCL_tool_register_sub_obc_cmd(5, APID_AOBC_CMD, (CMD_CODE)AOBC_Cmd_CODE_MM_START_TRANSITION);
 }
 
 #pragma section

--- a/Examples/minimum_user_for_s2e/src/src_user/TlmCmd/NormalBlockCommandDefinition/nbc_test_bcl.c
+++ b/Examples/minimum_user_for_s2e/src/src_user/TlmCmd/NormalBlockCommandDefinition/nbc_test_bcl.c
@@ -28,8 +28,8 @@ void BCL_load_test_bcl(void)
   BCL_tool_prepare_param_double(-12345.6789);
   BCL_tool_register_cmd(4, Cmd_CODE_TMGR_SET_UTL_UNIXTIME_EPOCH);
 
-  // sub obc コマンドのチェック
-  // FIXME: sub OBC のコマンド数が MOBC より多くなるとキャストできなくて困る
+  // other_obc コマンドのチェック
+  // FIXME: other OBC のコマンド数が 本OBC より多くなるとキャストできなくて困る
   BCL_tool_prepare_param_uint8(3);
   BCL_tool_register_other_obc_cmd(5, APID_AOBC_CMD, (CMD_CODE)AOBC_Cmd_CODE_MM_START_TRANSITION);
 }

--- a/Examples/minimum_user_for_s2e/src/src_user/TlmCmd/NormalBlockCommandDefinition/nbc_test_bcl.c
+++ b/Examples/minimum_user_for_s2e/src/src_user/TlmCmd/NormalBlockCommandDefinition/nbc_test_bcl.c
@@ -31,7 +31,7 @@ void BCL_load_test_bcl(void)
   // sub obc コマンドのチェック
   // FIXME: sub OBC のコマンド数が MOBC より多くなるとキャストできなくて困る
   BCL_tool_prepare_param_uint8(3);
-  BCL_tool_register_sub_obc_cmd(5, APID_AOBC_CMD, (CMD_CODE)AOBC_Cmd_CODE_MM_START_TRANSITION);
+  BCL_tool_register_other_obc_cmd(5, APID_AOBC_CMD, (CMD_CODE)AOBC_Cmd_CODE_MM_START_TRANSITION);
 }
 
 #pragma section

--- a/Examples/minimum_user_for_s2e/src/src_user/TlmCmd/NormalBlockCommandDefinition/nbc_test_bcl.c
+++ b/Examples/minimum_user_for_s2e/src/src_user/TlmCmd/NormalBlockCommandDefinition/nbc_test_bcl.c
@@ -31,7 +31,7 @@ void BCL_load_test_bcl(void)
   // other_obc コマンドのチェック
   // FIXME: other OBC のコマンド数が 本OBC より多くなるとキャストできなくて困る
   BCL_tool_prepare_param_uint8(3);
-  BCL_tool_register_other_obc_cmd(5, APID_AOBC_CMD, (CMD_CODE)AOBC_Cmd_CODE_MM_START_TRANSITION);
+  BCL_tool_register_cmd_to_other_obc(5, APID_AOBC_CMD, (CMD_CODE)AOBC_Cmd_CODE_MM_START_TRANSITION);
 }
 
 #pragma section

--- a/TlmCmd/block_command_loader.c
+++ b/TlmCmd/block_command_loader.c
@@ -18,7 +18,7 @@
 #define BCL_PARAM_MAX_LENGTH BCT_CMD_MAX_LENGTH
 
 static void BCL_register_cmd_(cycle_t ti, CMD_CODE cmd_id);
-static void BCL_register_sub_obc_cmd_(cycle_t ti, APID apid, CMD_CODE cmd_id);
+static void BCL_register_other_obc_cmd_(cycle_t ti, APID apid, CMD_CODE cmd_id);
 static void BCL_register_app_(cycle_t ti, AR_APP_ID app_id);
 static void BCL_clear_info_(void);
 
@@ -75,9 +75,9 @@ void BCL_tool_register_cmd(cycle_t ti, CMD_CODE cmd_id)
   BCL_clear_info_();
 }
 
-void BCL_tool_register_sub_obc_cmd(cycle_t ti, APID apid, CMD_CODE cmd_id)
+void BCL_tool_register_other_obc_cmd(cycle_t ti, APID apid, CMD_CODE cmd_id)
 {
-  BCL_register_sub_obc_cmd_(ti, apid, cmd_id);
+  BCL_register_other_obc_cmd_(ti, apid, cmd_id);
   BCL_clear_info_();
 }
 
@@ -227,14 +227,14 @@ void BCL_register_cmd_(cycle_t ti, CMD_CODE cmd_id)
   BCT_register_cmd(&block_command_loader_.packet);
 }
 
-void BCL_register_sub_obc_cmd_(cycle_t ti, APID apid, CMD_CODE cmd_id)
+void BCL_register_other_obc_cmd_(cycle_t ti, APID apid, CMD_CODE cmd_id)
 {
-  CCP_form_sub_obc_tlc(&block_command_loader_.packet,
-                       ti,
-                       apid,
-                       cmd_id,
-                       &block_command_loader_.params[0],
-                       (uint16_t)block_command_loader_.param_idx);
+  CCP_form_tlc_to_another_obc(&block_command_loader_.packet,
+                              ti,
+                              apid,
+                              cmd_id,
+                              &block_command_loader_.params[0],
+                              (uint16_t)block_command_loader_.param_idx);
   BCT_register_cmd(&block_command_loader_.packet);
 }
 

--- a/TlmCmd/block_command_loader.c
+++ b/TlmCmd/block_command_loader.c
@@ -18,6 +18,7 @@
 #define BCL_PARAM_MAX_LENGTH BCT_CMD_MAX_LENGTH
 
 static void BCL_register_cmd_(cycle_t ti, CMD_CODE cmd_id);
+static void BCL_register_sub_obc_cmd_(cycle_t ti, APID apid, CMD_CODE cmd_id);
 static void BCL_register_app_(cycle_t ti, AR_APP_ID app_id);
 static void BCL_clear_info_(void);
 
@@ -71,6 +72,12 @@ void BCL_safe_load_sl(bct_id_t pos, void (*BCL_load_func)(void))
 void BCL_tool_register_cmd(cycle_t ti, CMD_CODE cmd_id)
 {
   BCL_register_cmd_(ti, cmd_id);
+  BCL_clear_info_();
+}
+
+void BCL_tool_register_sub_obc_cmd(cycle_t ti, APID apid, CMD_CODE cmd_id)
+{
+  BCL_register_sub_obc_cmd_(ti, apid, cmd_id);
   BCL_clear_info_();
 }
 
@@ -217,6 +224,17 @@ void BCL_register_cmd_(cycle_t ti, CMD_CODE cmd_id)
                cmd_id,
                &block_command_loader_.params[0],
                (uint16_t)block_command_loader_.param_idx);
+  BCT_register_cmd(&block_command_loader_.packet);
+}
+
+void BCL_register_sub_obc_cmd_(cycle_t ti, APID apid, CMD_CODE cmd_id)
+{
+  CCP_form_sub_obc_tlc(&block_command_loader_.packet,
+                       ti,
+                       apid,
+                       cmd_id,
+                       &block_command_loader_.params[0],
+                       (uint16_t)block_command_loader_.param_idx);
   BCT_register_cmd(&block_command_loader_.packet);
 }
 

--- a/TlmCmd/block_command_loader.c
+++ b/TlmCmd/block_command_loader.c
@@ -18,7 +18,7 @@
 #define BCL_PARAM_MAX_LENGTH BCT_CMD_MAX_LENGTH
 
 static void BCL_register_cmd_(cycle_t ti, CMD_CODE cmd_id);
-static void BCL_register_other_obc_cmd_(cycle_t ti, APID apid, CMD_CODE cmd_id);
+static void BCL_register_cmd_to_other_obc_(cycle_t ti, APID apid, CMD_CODE cmd_id);
 static void BCL_register_app_(cycle_t ti, AR_APP_ID app_id);
 static void BCL_clear_info_(void);
 
@@ -75,9 +75,9 @@ void BCL_tool_register_cmd(cycle_t ti, CMD_CODE cmd_id)
   BCL_clear_info_();
 }
 
-void BCL_tool_register_other_obc_cmd(cycle_t ti, APID apid, CMD_CODE cmd_id)
+void BCL_tool_register_cmd_to_other_obc(cycle_t ti, APID apid, CMD_CODE cmd_id)
 {
-  BCL_register_other_obc_cmd_(ti, apid, cmd_id);
+  BCL_register_cmd_to_other_obc_(ti, apid, cmd_id);
   BCL_clear_info_();
 }
 
@@ -227,14 +227,14 @@ void BCL_register_cmd_(cycle_t ti, CMD_CODE cmd_id)
   BCT_register_cmd(&block_command_loader_.packet);
 }
 
-void BCL_register_other_obc_cmd_(cycle_t ti, APID apid, CMD_CODE cmd_id)
+void BCL_register_cmd_to_other_obc_(cycle_t ti, APID apid, CMD_CODE cmd_id)
 {
-  CCP_form_tlc_to_another_obc(&block_command_loader_.packet,
-                              ti,
-                              apid,
-                              cmd_id,
-                              &block_command_loader_.params[0],
-                              (uint16_t)block_command_loader_.param_idx);
+  CCP_form_tlc_to_other_obc(&block_command_loader_.packet,
+                            ti,
+                            apid,
+                            cmd_id,
+                            &block_command_loader_.params[0],
+                            (uint16_t)block_command_loader_.param_idx);
   BCT_register_cmd(&block_command_loader_.packet);
 }
 

--- a/TlmCmd/block_command_loader.h
+++ b/TlmCmd/block_command_loader.h
@@ -49,7 +49,7 @@ void BCL_tool_register_cmd(cycle_t ti, CMD_CODE cmd_id);
  * @param  cmd_id     実行する sub OBC のコマンドID
  * @return void
  */
-void BCL_tool_register_sub_obc_cmd(cycle_t ti, APID apid, CMD_CODE cmd_id);
+void BCL_tool_register_other_obc_cmd(cycle_t ti, APID apid, CMD_CODE cmd_id);
 
 /**
  * @brief  ブロックコマンドの最後にローテーターの実行コマンドを追加する

--- a/TlmCmd/block_command_loader.h
+++ b/TlmCmd/block_command_loader.h
@@ -42,14 +42,14 @@ void BCL_load_sl(bct_id_t pos, void (*func)(void));
 void BCL_tool_register_cmd(cycle_t ti, CMD_CODE cmd_id);
 
 /**
- * @brief  ブロックコマンドの最後に sub OBC コマンドを追加する
+ * @brief  ブロックコマンドの最後に他の OBC のコマンドを追加する
  * @note   ブロックコマンドの定義時に使用する
  * @param  ti         コマンドを実行する相対TI
  * @param  apid       sub OBC を識別する APID
  * @param  cmd_id     実行する sub OBC のコマンドID
  * @return void
  */
-void BCL_tool_register_other_obc_cmd(cycle_t ti, APID apid, CMD_CODE cmd_id);
+void BCL_tool_register_cmd_to_other_obc(cycle_t ti, APID apid, CMD_CODE cmd_id);
 
 /**
  * @brief  ブロックコマンドの最後にローテーターの実行コマンドを追加する

--- a/TlmCmd/block_command_loader.h
+++ b/TlmCmd/block_command_loader.h
@@ -42,6 +42,16 @@ void BCL_load_sl(bct_id_t pos, void (*func)(void));
 void BCL_tool_register_cmd(cycle_t ti, CMD_CODE cmd_id);
 
 /**
+ * @brief  ブロックコマンドの最後に sub OBC コマンドを追加する
+ * @note   ブロックコマンドの定義時に使用する
+ * @param  ti         コマンドを実行する相対TI
+ * @param  apid       sub OBC を識別する APID
+ * @param  cmd_id     実行する sub OBC のコマンドID
+ * @return void
+ */
+void BCL_tool_register_sub_obc_cmd(cycle_t ti, APID apid, CMD_CODE cmd_id);
+
+/**
  * @brief  ブロックコマンドの最後にローテーターの実行コマンドを追加する
  * @note   ブロックコマンドの定義時に使用する
  * @param  ti         コマンドを実行する相対TI

--- a/TlmCmd/common_cmd_packet_util.c
+++ b/TlmCmd/common_cmd_packet_util.c
@@ -108,6 +108,59 @@ CCP_UTIL_ACK CCP_form_tlc(CommonCmdPacket* packet, cycle_t ti, CMD_CODE cmd_id, 
   return CCP_UTIL_ACK_OK;
 }
 
+CCP_UTIL_ACK CCP_form_sub_obc_rtc(CommonCmdPacket* packet, APID apid, CMD_CODE cmd_id, const uint8_t* param, uint16_t len)
+{
+  if (packet == NULL)
+  {
+    return CCP_UTIL_ACK_PARAM_ERR;
+  }
+
+  if (param == NULL && len != 0)
+  {
+    CCP_form_nop_rtc_(packet);
+    return CCP_UTIL_ACK_PARAM_ERR;
+  }
+
+  // FIXME: sub OBC のコマンドは cmd_table に保存されていないので param チェックできない
+
+  CCP_set_common_hdr(packet);
+  CCP_set_apid(packet, apid);
+  CCP_set_id(packet, cmd_id);
+  CCP_set_exec_type(packet, CCP_EXEC_TYPE_RT);
+  CCP_set_dest_type(packet, CCP_DEST_TYPE_TO_ME);
+  CCP_set_ti(packet, 0); // RTの場合、TIは0固定。
+  CCP_set_param(packet, param, len);
+
+  return CCP_UTIL_ACK_OK;
+}
+
+CCP_UTIL_ACK CCP_form_sub_obc_tlc(CommonCmdPacket* packet, cycle_t ti, APID apid, CMD_CODE cmd_id, const uint8_t* param, uint16_t len)
+{
+  if (packet == NULL)
+  {
+    return CCP_UTIL_ACK_PARAM_ERR;
+  }
+
+  if (param == NULL && len != 0)
+  {
+    CCP_form_nop_rtc_(packet);
+    CCP_convert_rtc_to_tlc(packet, ti);
+    return CCP_UTIL_ACK_PARAM_ERR;
+  }
+
+  // FIXME: sub OBC のコマンドは cmd_table に保存されていないので param チェックできない
+
+  CCP_set_common_hdr(packet);
+  CCP_set_apid(packet, apid);
+  CCP_set_id(packet, cmd_id);
+  CCP_set_exec_type(packet, CCP_EXEC_TYPE_TL_FROM_GS);  // TL なので，一旦仮で入れる
+  CCP_set_dest_type(packet, CCP_DEST_TYPE_TO_ME);
+  CCP_set_ti(packet, ti);
+  CCP_set_param(packet, param, len);
+
+  return CCP_UTIL_ACK_OK;
+}
+
 CCP_UTIL_ACK CCP_form_block_deploy_cmd(CommonCmdPacket* packet, TLCD_ID tl_no, bct_id_t block_no)
 {
   uint8_t param[1 + SIZE_OF_BCT_ID_T];

--- a/TlmCmd/common_cmd_packet_util.c
+++ b/TlmCmd/common_cmd_packet_util.c
@@ -3,7 +3,6 @@
  * @file
  * @brief  CCP の汎用 Utility
  */
-
 #include "common_cmd_packet_util.h"
 #include "command_analyze.h"
 #include "../Library/endian_memcpy.h"
@@ -37,6 +36,7 @@ CCP_UTIL_ACK CCP_calc_param_offset_(CMD_CODE cmd_id, uint8_t n, uint16_t* offset
  * @return void
  */
 static void CCP_form_rtc_(CommonCmdPacket* packet, CMD_CODE cmd_id, const uint8_t* param, uint16_t len);
+
 
 void CCP_form_nop_rtc_(CommonCmdPacket* packet)
 {

--- a/TlmCmd/common_cmd_packet_util.c
+++ b/TlmCmd/common_cmd_packet_util.c
@@ -108,7 +108,7 @@ CCP_UTIL_ACK CCP_form_tlc(CommonCmdPacket* packet, cycle_t ti, CMD_CODE cmd_id, 
   return CCP_UTIL_ACK_OK;
 }
 
-CCP_UTIL_ACK CCP_form_rtc_to_another_obc(CommonCmdPacket* packet, APID apid, CMD_CODE cmd_id, const uint8_t* param, uint16_t len)
+CCP_UTIL_ACK CCP_form_rtc_to_other_obc(CommonCmdPacket* packet, APID apid, CMD_CODE cmd_id, const uint8_t* param, uint16_t len)
 {
   if (packet == NULL)
   {
@@ -129,7 +129,7 @@ CCP_UTIL_ACK CCP_form_rtc_to_another_obc(CommonCmdPacket* packet, APID apid, CMD
   return CCP_UTIL_ACK_OK;
 }
 
-CCP_UTIL_ACK CCP_form_tlc_to_another_obc(CommonCmdPacket* packet, cycle_t ti, APID apid, CMD_CODE cmd_id, const uint8_t* param, uint16_t len)
+CCP_UTIL_ACK CCP_form_tlc_to_other_obc(CommonCmdPacket* packet, cycle_t ti, APID apid, CMD_CODE cmd_id, const uint8_t* param, uint16_t len)
 {
   if (packet == NULL)
   {

--- a/TlmCmd/common_cmd_packet_util.c
+++ b/TlmCmd/common_cmd_packet_util.c
@@ -28,6 +28,15 @@ void CCP_form_nop_rtc_(CommonCmdPacket* packet);
  */
 CCP_UTIL_ACK CCP_calc_param_offset_(CMD_CODE cmd_id, uint8_t n, uint16_t* offset);
 
+/**
+ * @brief RealTime Command を生成する. CCP_form_* の実体.
+ * @param[in,out] packet: CCP
+ * @param[in]     cmd_id: CMD_CODE
+ * @param[in]     param:  パラメタの先頭アドレス
+ * @param[in]     len:    パラメタ長
+ * @return void
+ */
+static void CCP_form_rtc_(CommonCmdPacket* packet, CMD_CODE cmd_id, const uint8_t* param, uint16_t len);
 
 void CCP_form_nop_rtc_(CommonCmdPacket* packet)
 {
@@ -67,12 +76,7 @@ CCP_UTIL_ACK CCP_form_rtc(CommonCmdPacket* packet, CMD_CODE cmd_id, const uint8_
     return CCP_UTIL_ACK_PARAM_ERR;
   }
 
-  CCP_set_common_hdr(packet);
-  CCP_set_id(packet, cmd_id);
-  CCP_set_exec_type(packet, CCP_EXEC_TYPE_RT);
-  CCP_set_dest_type(packet, CCP_DEST_TYPE_TO_ME);
-  CCP_set_ti(packet, 0); // RTの場合、TIは0固定。
-  CCP_set_param(packet, param, len);
+  CCP_form_rtc_(packet, cmd_id, param, len);
 
   return CCP_UTIL_ACK_OK;
 }
@@ -98,17 +102,13 @@ CCP_UTIL_ACK CCP_form_tlc(CommonCmdPacket* packet, cycle_t ti, CMD_CODE cmd_id, 
     return CCP_UTIL_ACK_PARAM_ERR;
   }
 
-  CCP_set_common_hdr(packet);
-  CCP_set_id(packet, cmd_id);
-  CCP_set_exec_type(packet, CCP_EXEC_TYPE_TL_FROM_GS);  // TL なので，一旦仮で入れる
-  CCP_set_dest_type(packet, CCP_DEST_TYPE_TO_ME);
-  CCP_set_ti(packet, ti);
-  CCP_set_param(packet, param, len);
+  CCP_form_rtc_(packet, cmd_id, param, len);
+  CCP_convert_rtc_to_tlc(packet, ti);
 
   return CCP_UTIL_ACK_OK;
 }
 
-CCP_UTIL_ACK CCP_form_sub_obc_rtc(CommonCmdPacket* packet, APID apid, CMD_CODE cmd_id, const uint8_t* param, uint16_t len)
+CCP_UTIL_ACK CCP_form_rtc_to_another_obc(CommonCmdPacket* packet, APID apid, CMD_CODE cmd_id, const uint8_t* param, uint16_t len)
 {
   if (packet == NULL)
   {
@@ -121,20 +121,15 @@ CCP_UTIL_ACK CCP_form_sub_obc_rtc(CommonCmdPacket* packet, APID apid, CMD_CODE c
     return CCP_UTIL_ACK_PARAM_ERR;
   }
 
-  // FIXME: sub OBC のコマンドは cmd_table に保存されていないので param チェックできない
+  // NOTE: 他の OBC のコマンドは cmd_table に保存されていないので param チェックできない
 
-  CCP_set_common_hdr(packet);
+  CCP_form_rtc_(packet, cmd_id, param, len);
   CCP_set_apid(packet, apid);
-  CCP_set_id(packet, cmd_id);
-  CCP_set_exec_type(packet, CCP_EXEC_TYPE_RT);
-  CCP_set_dest_type(packet, CCP_DEST_TYPE_TO_ME);
-  CCP_set_ti(packet, 0); // RTの場合、TIは0固定。
-  CCP_set_param(packet, param, len);
 
   return CCP_UTIL_ACK_OK;
 }
 
-CCP_UTIL_ACK CCP_form_sub_obc_tlc(CommonCmdPacket* packet, cycle_t ti, APID apid, CMD_CODE cmd_id, const uint8_t* param, uint16_t len)
+CCP_UTIL_ACK CCP_form_tlc_to_another_obc(CommonCmdPacket* packet, cycle_t ti, APID apid, CMD_CODE cmd_id, const uint8_t* param, uint16_t len)
 {
   if (packet == NULL)
   {
@@ -148,15 +143,11 @@ CCP_UTIL_ACK CCP_form_sub_obc_tlc(CommonCmdPacket* packet, cycle_t ti, APID apid
     return CCP_UTIL_ACK_PARAM_ERR;
   }
 
-  // FIXME: sub OBC のコマンドは cmd_table に保存されていないので param チェックできない
+  // NOTE: 他の OBC のコマンドは cmd_table に保存されていないので param チェックできない
 
-  CCP_set_common_hdr(packet);
+  CCP_form_rtc_(packet, cmd_id, param, len);
+  CCP_convert_rtc_to_tlc(packet, ti);
   CCP_set_apid(packet, apid);
-  CCP_set_id(packet, cmd_id);
-  CCP_set_exec_type(packet, CCP_EXEC_TYPE_TL_FROM_GS);  // TL なので，一旦仮で入れる
-  CCP_set_dest_type(packet, CCP_DEST_TYPE_TO_ME);
-  CCP_set_ti(packet, ti);
-  CCP_set_param(packet, param, len);
 
   return CCP_UTIL_ACK_OK;
 }
@@ -183,10 +174,20 @@ CCP_UTIL_ACK CCP_form_block_deploy_cmd(CommonCmdPacket* packet, TLCD_ID tl_no, b
   return CCP_form_rtc(packet, Cmd_CODE_TLCD_DEPLOY_BLOCK, param, 1 + SIZE_OF_BCT_ID_T);
 }
 
+static void CCP_form_rtc_(CommonCmdPacket* packet, CMD_CODE cmd_id, const uint8_t* param, uint16_t len)
+{
+  CCP_set_common_hdr(packet);
+  CCP_set_id(packet, cmd_id);
+  CCP_set_exec_type(packet, CCP_EXEC_TYPE_RT);
+  CCP_set_dest_type(packet, CCP_DEST_TYPE_TO_ME);
+  CCP_set_ti(packet, 0);  // RTの場合、TIは0固定
+  CCP_set_param(packet, param, len);
+}
+
 void CCP_convert_rtc_to_tlc(CommonCmdPacket* packet, cycle_t ti)
 {
   if (packet == NULL) return;
-  CCP_set_exec_type(packet, CCP_EXEC_TYPE_TL_FROM_GS);
+  CCP_set_exec_type(packet, CCP_EXEC_TYPE_TL_FROM_GS);  // TL なので，一旦仮で入れる
   CCP_set_ti(packet, ti);
 }
 

--- a/TlmCmd/common_cmd_packet_util.c
+++ b/TlmCmd/common_cmd_packet_util.c
@@ -29,6 +29,7 @@ CCP_UTIL_ACK CCP_calc_param_offset_(CMD_CODE cmd_id, uint8_t n, uint16_t* offset
 
 /**
  * @brief RealTime Command を生成する. CCP_form_* の実体.
+ * @note  packet, param は NULL 出ないことが保証されていることを前提とする
  * @param[in,out] packet: CCP
  * @param[in]     cmd_id: CMD_CODE
  * @param[in]     param:  パラメタの先頭アドレス

--- a/TlmCmd/common_cmd_packet_util.h
+++ b/TlmCmd/common_cmd_packet_util.h
@@ -57,20 +57,20 @@ CCP_UTIL_ACK CCP_form_rtc(CommonCmdPacket* packet, CMD_CODE cmd_id, const uint8_
 CCP_UTIL_ACK CCP_form_tlc(CommonCmdPacket* packet, cycle_t ti, CMD_CODE cmd_id, const uint8_t* param, uint16_t len);
 
 /**
- * @brief sub OBC のコマンドを MOBC の RT として生成
- * @note  MOBC で RT として処理されたあと sub OBC に送られ RT として実行される
+ * @brief 他の OBC のコマンドを RT として生成
+ * @note  本OBC で RT として処理されたあと 他の OBC に送られ RT として実行される
  * @note  param チェックは未実装
- * @param[in] apid: どの OBC かを指定する APID
+ * @param[in] apid:   どの OBC かを指定する APID
  * @param[in] cmd_id: CMD_CODE
  * @param[in] param:  パラメタ
  * @param[in] len:    パラメタ長
  * @return CCP_UTIL_ACK
  */
-CCP_UTIL_ACK CCP_form_sub_obc_rtc(CommonCmdPacket* packet, APID apid, CMD_CODE cmd_id, const uint8_t* param, uint16_t len);
+CCP_UTIL_ACK CCP_form_rtc_to_another_obc(CommonCmdPacket* packet, APID apid, CMD_CODE cmd_id, const uint8_t* param, uint16_t len);
 
 /**
- * @brief sub OBC のコマンドを MOBC の TL として生成
- * @note  MOBC で TL として処理されたあと sub OBC に送られ RT として実行される
+ * @brief 他の OBC のコマンドを TL として生成
+ * @note  本OBC で TL として処理されたあと 他の OBC に送られ RT として実行される
  * @note  param チェックは未実装
  * @param[in] ti:     TI
  * @param[in] apid:   どの OBC かを指定する APID
@@ -79,7 +79,7 @@ CCP_UTIL_ACK CCP_form_sub_obc_rtc(CommonCmdPacket* packet, APID apid, CMD_CODE c
  * @param[in] len:    パラメタ長
  * @return CCP_UTIL_ACK
  */
-CCP_UTIL_ACK CCP_form_sub_obc_tlc(CommonCmdPacket* packet, cycle_t ti, APID apid, CMD_CODE cmd_id, const uint8_t* param, uint16_t len);
+CCP_UTIL_ACK CCP_form_tlc_to_another_obc(CommonCmdPacket* packet, cycle_t ti, APID apid, CMD_CODE cmd_id, const uint8_t* param, uint16_t len);
 
 /**
  * @brief BC展開 command を生成

--- a/TlmCmd/common_cmd_packet_util.h
+++ b/TlmCmd/common_cmd_packet_util.h
@@ -66,7 +66,7 @@ CCP_UTIL_ACK CCP_form_tlc(CommonCmdPacket* packet, cycle_t ti, CMD_CODE cmd_id, 
  * @param[in] len:    パラメタ長
  * @return CCP_UTIL_ACK
  */
-CCP_UTIL_ACK CCP_form_rtc_to_another_obc(CommonCmdPacket* packet, APID apid, CMD_CODE cmd_id, const uint8_t* param, uint16_t len);
+CCP_UTIL_ACK CCP_form_rtc_to_other_obc(CommonCmdPacket* packet, APID apid, CMD_CODE cmd_id, const uint8_t* param, uint16_t len);
 
 /**
  * @brief 他の OBC のコマンドを TL として生成
@@ -79,7 +79,7 @@ CCP_UTIL_ACK CCP_form_rtc_to_another_obc(CommonCmdPacket* packet, APID apid, CMD
  * @param[in] len:    パラメタ長
  * @return CCP_UTIL_ACK
  */
-CCP_UTIL_ACK CCP_form_tlc_to_another_obc(CommonCmdPacket* packet, cycle_t ti, APID apid, CMD_CODE cmd_id, const uint8_t* param, uint16_t len);
+CCP_UTIL_ACK CCP_form_tlc_to_other_obc(CommonCmdPacket* packet, cycle_t ti, APID apid, CMD_CODE cmd_id, const uint8_t* param, uint16_t len);
 
 /**
  * @brief BC展開 command を生成

--- a/TlmCmd/common_cmd_packet_util.h
+++ b/TlmCmd/common_cmd_packet_util.h
@@ -57,6 +57,31 @@ CCP_UTIL_ACK CCP_form_rtc(CommonCmdPacket* packet, CMD_CODE cmd_id, const uint8_
 CCP_UTIL_ACK CCP_form_tlc(CommonCmdPacket* packet, cycle_t ti, CMD_CODE cmd_id, const uint8_t* param, uint16_t len);
 
 /**
+ * @brief sub OBC のコマンドを MOBC の RT として生成
+ * @note  MOBC で RT として処理されたあと sub OBC に送られ RT として実行される
+ * @note  param チェックは未実装
+ * @param[in] apid: どの OBC かを指定する APID
+ * @param[in] cmd_id: CMD_CODE
+ * @param[in] param:  パラメタ
+ * @param[in] len:    パラメタ長
+ * @return CCP_UTIL_ACK
+ */
+CCP_UTIL_ACK CCP_form_sub_obc_rtc(CommonCmdPacket* packet, APID apid, CMD_CODE cmd_id, const uint8_t* param, uint16_t len);
+
+/**
+ * @brief sub OBC のコマンドを MOBC の TL として生成
+ * @note  MOBC で TL として処理されたあと sub OBC に送られ RT として実行される
+ * @note  param チェックは未実装
+ * @param[in] ti:     TI
+ * @param[in] apid:   どの OBC かを指定する APID
+ * @param[in] cmd_id: CMD_CODE
+ * @param[in] param:  パラメタ
+ * @param[in] len:    パラメタ長
+ * @return CCP_UTIL_ACK
+ */
+CCP_UTIL_ACK CCP_form_sub_obc_tlc(CommonCmdPacket* packet, cycle_t ti, APID apid, CMD_CODE cmd_id, const uint8_t* param, uint16_t len);
+
+/**
  * @brief BC展開 command を生成
  * @note  引数が不正なとき， packet は NOP RTC を返す
  * @param[in,out] packet:   CCP


### PR DESCRIPTION
## 概要
CCP UTIL と BCL で sub OBC のコマンドに対応

## Issue
N/A

## 詳細
sub OBC のコマンドをモード遷移のBC で打つ需要があったため実装した。APIDが異なるため現状のBCLでは sub OBC コマンドを登録できない。

## 検証結果
- BCL の pytest が通った
- 手元で別のC2A_userのSILSを回して sub OBC にコマンドが配送されるところまで確認した

## 影響範囲
小

## 補足
何かあれば