### PR TITLE
APIDのバリデーションをuser部に移動し， GENERATE_TLM で 2nd OBC の TI, Sequence counter を保存するようにした

### DIFF
--- a/Examples/minimum_user/src/src_user/Settings/CMakeLists.txt
+++ b/Examples/minimum_user/src/src_user/Settings/CMakeLists.txt
@@ -17,6 +17,7 @@ set(C2A_SRCS
   System/event_logger_settings.c
   System/EventHandlerRules/event_handler_rules.c
   System/EventHandlerRules/event_handler_rule_test.c
+  TlmCmd/Ccsds/apid_define.c
 )
 
 if(BUILD_C2A_AS_CXX)

--- a/Examples/minimum_user/src/src_user/Settings/TlmCmd/Ccsds/apid_define.c
+++ b/Examples/minimum_user/src/src_user/Settings/TlmCmd/Ccsds/apid_define.c
@@ -26,7 +26,7 @@ APID APID_get_apid_from_uint16(uint16_t apid)
   }
 }
 
-int APID_is_another_obc_tlm_apid(APID apid)
+int APID_is_other_obc_tlm_apid(APID apid)
 {
   switch (apid)
   {

--- a/Examples/minimum_user/src/src_user/Settings/TlmCmd/Ccsds/apid_define.c
+++ b/Examples/minimum_user/src/src_user/Settings/TlmCmd/Ccsds/apid_define.c
@@ -1,0 +1,42 @@
+#pragma section REPRO
+/**
+ * @file
+ * @brief CCSDS の APID を定義する
+ * @note  common_tlm_cmd_packet.h などから include されることを前提
+ */
+#include "apid_define.h"
+
+APID APID_get_apid_from_uint16(uint16_t apid)
+{
+  switch ((APID)apid)
+  {
+  case APID_MOBC_CMD:   // FALLTHROUGH
+  case APID_AOBC_CMD:   // FALLTHROUGH
+  case APID_TOBC_CMD:   // FALLTHROUGH
+  case APID_TCAL_TLM:   // FALLTHROUGH
+  case APID_MOBC_TLM:   // FALLTHROUGH
+  case APID_AOBC_TLM:   // FALLTHROUGH
+  case APID_TOBC_TLM:   // FALLTHROUGH
+  case APID_DUMP_TLM:   // FALLTHROUGH
+  case APID_FILL_PKT:
+    return (APID)apid;
+
+  default:
+    return APID_UNKNOWN;
+  }
+}
+
+int APID_is_another_obc_tlm_apid(APID apid)
+{
+  switch (apid)
+  {
+  case APID_AOBC_TLM:   // FALLTHROUGH
+  case APID_TOBC_TLM:
+    return 1;
+
+  default:
+    return 0;
+  }
+}
+
+#pragma section

--- a/Examples/minimum_user/src/src_user/Settings/TlmCmd/Ccsds/apid_define.h
+++ b/Examples/minimum_user/src/src_user/Settings/TlmCmd/Ccsds/apid_define.h
@@ -43,6 +43,6 @@ APID APID_get_apid_from_uint16(uint16_t apid);
  * @retval 1: 他 OBC で生成された TLM の APID
  * @retval 0: それ以外の APID
  */
-int APID_is_another_obc_tlm_apid(APID apid);
+int APID_is_other_obc_tlm_apid(APID apid);
 
 #endif

--- a/Examples/minimum_user/src/src_user/Settings/TlmCmd/Ccsds/apid_define.h
+++ b/Examples/minimum_user/src/src_user/Settings/TlmCmd/Ccsds/apid_define.h
@@ -6,6 +6,8 @@
 #ifndef APID_DEFINE_H_
 #define APID_DEFINE_H_
 
+#include "../../../Library/stdint.h"
+
 /**
  * @enum   APID
  * @brief  Application Process ID
@@ -13,14 +15,34 @@
  */
 typedef enum
 {
-  APID_MOBC_CMD = 0x210,    //!< 01000010000b:
-  APID_AOBC_CMD = 0x211,    //!< 01000010001b:
-  APID_TOBC_CMD = 0x212,    //!< 01000010010b:
-  APID_TCAL_TLM = 0x410,    //!< 10000010000b: APID for TIME CARIBLATION TLM
-  APID_MIS_TLM  = 0x510,    //!< 10100010000b: APID for MIS TLM
-  APID_DUMP_TLM = 0x710,    //!< 11100010000b: APID for DUMP TLM
+  APID_MOBC_CMD = 0x210,    //!< 01000010000b: APID for MOBC 宛の CMD
+  APID_AOBC_CMD = 0x211,    //!< 01000010001b: APID for AOBC 宛の CMD
+  APID_TOBC_CMD = 0x212,    //!< 01000010010b: APID for TOBC 宛の CMD
+  APID_TCAL_TLM = 0x410,    //!< 10000010000b: APID for TIME CARIBLATION TLM (FIXME: 現在まともに使ってない)
+  APID_MOBC_TLM = 0x510,    //!< 10100010000b: APID for MOBC で生成される TLM
+  APID_AOBC_TLM = 0x511,    //!< 10100010001b: APID for AOBC で生成される TLM
+  APID_TOBC_TLM = 0x512,    //!< 10100010002b: APID for TOBC で生成される TLM
+  APID_DUMP_TLM = 0x710,    //!< 11100010000b: APID for DUMP TLM (FIXME: 現在まともに使ってない)
   APID_FILL_PKT = 0x7ff,    //!< 11111111111b: APID for FILL PACKET
   APID_UNKNOWN
 } APID;
+
+
+/**
+ * @brief  バイト列から APID を取得
+ * @param  apid: APID 候補の uint16_t
+ * @note   不正な入力のときは APID_UNKNOWN を返す
+ * @return APID
+ */
+APID APID_get_apid_from_uint16(uint16_t apid);
+
+/**
+ * @brief  入力した APID が他の OBC で生成された TLM の APID かどうか
+ * @param  apid: APID
+ * @note   不正な APID は 0 を返す
+ * @retval 1: 他 OBC で生成された TLM の APID
+ * @retval 0: それ以外の APID
+ */
+int APID_is_another_obc_tlm_apid(APID apid);
 
 #endif

--- a/Examples/minimum_user/src/src_user/Settings/TlmCmd/common_cmd_packet_define.h
+++ b/Examples/minimum_user/src/src_user/Settings/TlmCmd/common_cmd_packet_define.h
@@ -6,6 +6,7 @@
 #define COMMON_CMD_PACKET_DEFINE_H_
 
 #include <src_core/TlmCmd/Ccsds/space_packet_typedef.h>
+#include "./Ccsds/apid_define.h"
 
 // CommonCmdPacket として CmdSpacePacket をつかう
 typedef CmdSpacePacket CommonCmdPacket;

--- a/Examples/minimum_user/src/src_user/Settings/TlmCmd/common_tlm_packet_define.h
+++ b/Examples/minimum_user/src/src_user/Settings/TlmCmd/common_tlm_packet_define.h
@@ -6,10 +6,15 @@
 #define COMMON_TLM_PACKET_DEFINE_H_
 
 #include <src_core/TlmCmd/Ccsds/space_packet_typedef.h>
+#include "./Ccsds/apid_define.h"
 
 // CommonTlmPacket として TlmSpacePacket をつかう
 typedef TlmSpacePacket CommonTlmPacket;
 
 #define CTP_MAX_LEN (TSP_MAX_LEN)
+
+// 自分で生成される TLM を示す AIPD を定義
+// FIXME: Space Packet が整備されたら直す
+#define CTP_APID_FROM_ME (APID_MOBC_TLM)
 
 #endif

--- a/TlmCmd/Ccsds/space_packet.c
+++ b/TlmCmd/Ccsds/space_packet.c
@@ -81,25 +81,9 @@ void SP_set_2nd_hdr_flag(SpacePacket* sp, SP_2ND_HDR_FLAG flag)
 
 APID SP_get_apid(const SpacePacket* sp)
 {
-  uint16_t tmp;
-  APID apid;
-
-  SP_extract_param_from_packet(sp, &SP_pei_apid_, &tmp);
-  apid = (APID)tmp;
-
-  // FIXME: ここはユーザー依存部分なので直す
-  switch (apid)
-  {
-  case APID_MOBC_CMD:         // FALLTHROUGH
-  case APID_AOBC_CMD:         // FALLTHROUGH
-  case APID_TOBC_CMD:         // FALLTHROUGH
-  case APID_MIS_TLM:          // FALLTHROUGH
-  case APID_DUMP_TLM:
-    return apid;
-
-  default:
-    return APID_UNKNOWN;
-  }
+  uint16_t apid;
+  SP_extract_param_from_packet(sp, &SP_pei_apid_, &apid);
+  return APID_get_apid_from_uint16(apid);
 }
 
 

--- a/TlmCmd/common_tlm_cmd_packet.h
+++ b/TlmCmd/common_tlm_cmd_packet.h
@@ -15,17 +15,21 @@
 #include "./common_cmd_packet.h"
 
 // ここで APID を定義する
+// APID_UNKNOWN, APID_FILL_PKT は必須
 /* 例
 // FIXME: CCSDS JAXA 標準になおす
 // FIXME: APID は Space Packet なので， CTCP にあるのは不適切？ 抽象化してもいいかも
 typedef enum
 {
-  APID_MOBC_CMD = 0x210,         // 01000010000b:
-  APID_AOBC_CMD = 0x211,         // 01000010001b:
-  APID_TCAL_TLM = 0x410,         // 10000010000b: APID for TIME CARIBLATION TLM
-  APID_MIS_TLM  = 0x510,         // 10100010000b: APID for MIS TLM
-  APID_DUMP_TLM = 0x710,         // 11100010000b: APID for DUMP TLM
-  APID_FILL_PKT = 0x7ff,         // 11111111111b: APID for FILL PACKET
+  APID_MOBC_CMD = 0x210,    //!< 01000010000b: APID for MOBC 宛の CMD
+  APID_AOBC_CMD = 0x211,    //!< 01000010001b: APID for AOBC 宛の CMD
+  APID_TOBC_CMD = 0x212,    //!< 01000010010b: APID for TOBC 宛の CMD
+  APID_TCAL_TLM = 0x410,    //!< 10000010000b: APID for TIME CARIBLATION TLM (FIXME: 現在まともに使ってない)
+  APID_MOBC_TLM = 0x510,    //!< 10100010000b: APID for MOBC で生成される TLM
+  APID_AOBC_TLM = 0x511,    //!< 10100010001b: APID for AOBC で生成される TLM
+  APID_TOBC_TLM = 0x512,    //!< 10100010002b: APID for TOBC で生成される TLM
+  APID_DUMP_TLM = 0x710,    //!< 11100010000b: APID for DUMP TLM (FIXME: 現在まともに使ってない)
+  APID_FILL_PKT = 0x7ff,    //!< 11111111111b: APID for FILL PACKET
   APID_UNKNOWN
 } APID;
 */

--- a/TlmCmd/common_tlm_packet.h
+++ b/TlmCmd/common_tlm_packet.h
@@ -9,7 +9,7 @@
 #include "../System/TimeManager/obc_time.h"
 #include <src_user/TlmCmd/telemetry_definitions.h>
 
-// ここで， CTP_MAX_LEN, CommonTlmPacket として使うパケット型を指定する
+// ここで， CTP_APID_FROM_ME, CTP_MAX_LEN, CommonTlmPacket として使うパケット型を指定する
 #include <src_user/Settings/TlmCmd/common_tlm_packet_define.h>
 
 // ここで APID を定義する

--- a/TlmCmd/telemetry_generator.c
+++ b/TlmCmd/telemetry_generator.c
@@ -39,7 +39,7 @@ CCP_EXEC_STS Cmd_GENERATE_TLM(const CommonCmdPacket* packet)
   }
 
   // ctp の ヘッダ部分の APID をクリア
-  // この後で， APID_is_another_obc_tlm_apid で配送元 OBC を割り出せるように
+  // この後で， APID_is_other_obc_tlm_apid で配送元 OBC を割り出せるように
   CTP_set_apid(&ctp_, APID_UNKNOWN);
 
   // ADU生成
@@ -55,7 +55,7 @@ CCP_EXEC_STS Cmd_GENERATE_TLM(const CommonCmdPacket* packet)
   if (ack != TF_TLM_FUNC_ACK_SUCCESS) return CCP_EXEC_ILLEGAL_CONTEXT;
 
   // Header
-  if (APID_is_another_obc_tlm_apid(CTP_get_apid(&ctp_)))
+  if (APID_is_other_obc_tlm_apid(CTP_get_apid(&ctp_)))
   {
     // 2nd OBC で生成された TLM の primary header, secondary header の board time はそのまま維持
   }

--- a/TlmCmd/telemetry_generator.c
+++ b/TlmCmd/telemetry_generator.c
@@ -54,27 +54,22 @@ CCP_EXEC_STS Cmd_GENERATE_TLM(const CommonCmdPacket* packet)
   if (ack == TF_TLM_FUNC_ACK_NOT_DEFINED) return CCP_EXEC_ILLEGAL_PARAMETER;
   if (ack != TF_TLM_FUNC_ACK_SUCCESS) return CCP_EXEC_ILLEGAL_CONTEXT;
 
-  // Primary Header
+  // Header
   if (APID_is_another_obc_tlm_apid(CTP_get_apid(&ctp_)))
   {
-    // 2nd OBC で生成された TLM の primary header はそのまま維持
+    // 2nd OBC で生成された TLM の primary header, secondary header の board time はそのまま維持
   }
   else
   {
+    // Primary Header
     // FIXME: Space Packet 依存を直す
     TSP_setup_primary_hdr(&ctp_, CTP_APID_FROM_ME, len);
     TSP_set_seq_count(&ctp_, TG_get_next_adu_counter_());
-  }
 
-  // Secondary Header
-  if (APID_is_another_obc_tlm_apid(CTP_get_apid(&ctp_)))
-  {
-    // 2nd OBC で生成された TLM の board time はそのまま維持
-  }
-  else
-  {
+    // Secondary Header
     TSP_set_board_time(&ctp_, (uint32_t)(TMGR_get_master_total_cycle()));
   }
+
   // FIXME: 他の時刻も入れる
   TSP_set_global_time(&ctp_, 0.0);
   TSP_set_on_board_subnet_time(&ctp_, (uint32_t)(TMGR_get_master_total_cycle()));   // FIXME: 暫定


### PR DESCRIPTION
## 概要
APIDのバリデーションをuser部に移動し， GENERATE_TLM で 2nd OBC の TI, Sequence counter を保存するようにした

## Issue
- https://github.com/ut-issl/c2a-core/issues/350
- https://github.com/ut-issl/c2a-core/issues/155

## 詳細
tlm id が全OBCでユニークであること，という仮定はまだ外せてない（ので暫定）

## 検証結果
既存のテストが全て通った

## 影響範囲
- APIDのバリデーションを各user で書く必要がある
- `CTP_APID_FROM_ME` を各userで定義する必要がある
- 各OBCのtlmで別のAPIDを割り振るようにする
- Sequence counterが，MOBCで統一ではなく，各APIDごとになる
- on board subnet timeはひとまずMOBCのTIを入れる（暫定処置）


