### PR TITLE
Fix CMake option typo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ option(USE_ALL_C2A_CORE_APPS    "use C2A-core all Applications" ON)
 option(USE_ALL_C2A_CORE_LIB     "use C2A-core all Library" ON)
 option(USE_32BIT_COMPILER       "use 32bit compiler" OFF)
 
-option(BUULD_C2A_AS_SILS_FW     "build C2A as SILS firmware" ON)
+option(BUILD_C2A_AS_SILS_FW     "build C2A as SILS firmware" ON)
 option(BUILD_C2A_AS_CXX         "build C2A as C++" OFF)
 option(BUILD_C2A_AS_UTF8        "build C2A as UTF-8" ON)
 

--- a/common.cmake
+++ b/common.cmake
@@ -17,7 +17,7 @@ else()
   endif()
 endif()
 
-if(BUULD_C2A_AS_SILS_FW)
+if(BUILD_C2A_AS_SILS_FW)
   target_compile_definitions(${PROJECT_NAME} PUBLIC SILS_FW)
 endif()
 


### PR DESCRIPTION
## 概要
Fix #357 

## Issue
- #357 

## 詳細
CMakeのオプション名をtypoしていたので修正

## 検証結果
test へのリンクや，検証結果へのリンク

## 影響範囲
default ONのオプションであり，つい最近追加したということもありそもそもあまり使われておらず，現状ほぼ影響は無い

## 補足
何かあれば

## 注意
- 関連する Projects が存在する場合，それの紐付けを行うこと
- Assignees を設定すること
- 可能ならば Reviewers を設定すること
- 可能ならば `priority` ラベルを付けること
