### PR TITLE
即時実行する CCP 作成関数の追加

### DIFF
--- a/Applications/anomaly_handler.c
+++ b/Applications/anomaly_handler.c
@@ -202,10 +202,8 @@ static void AH_respond_to_anomaly_(size_t id)
   // これが呼ばれてるには，anomaly_handler_.elements[].is_active == 1は保証されている．
 
   // 対応ブロックコマンドをリアルタイムコマンドで展開
-  CommonCmdPacket packet;
   // 通常BCなのでTLC1に展開
-  CCP_form_block_deploy_cmd(&packet, TLCD_ID_DEPLOY_BC, anomaly_handler_.elements[id].rule.bc_id);
-  PH_dispatch_command(&packet);
+  CCP_form_and_exec_block_deploy_cmd(TLCD_ID_DEPLOY_BC, anomaly_handler_.elements[id].rule.bc_id);
 
   // 実行したルールを記録し回数を更新
   anomaly_handler_.respond_at = TMGR_get_master_clock();

--- a/System/EventManager/event_handler.c
+++ b/System/EventManager/event_handler.c
@@ -648,34 +648,20 @@ static EH_CKECK_RULE_ACK EH_check_cumulative_rule_(EH_RULE_ID rule_id, const EL_
 static void EH_respond_(EH_RULE_ID rule_id)
 {
   EH_Rule* rule = &event_handler_.rule_table.rules[rule_id];
-  CommonCmdPacket packet;
-  CCP_UTIL_ACK form_cmd_ack;
-  CCP_EXEC_STS deploy_cmd_ack;
+  CCP_EXEC_STS ack;
 
-  form_cmd_ack = CCP_form_block_deploy_cmd(&packet, TLCD_ID_DEPLOY_BC, rule->settings.deploy_bct_id);
-  if (form_cmd_ack != CCP_UTIL_ACK_OK)
-  {
-    // BC 展開 Cmd の生成に失敗
-    // 正しく組んでいる場合，ここに来るはずはない
-    EL_record_event((EL_GROUP)EL_CORE_GROUP_EVENT_HANDLER,
-                    EH_EL_LOCAL_ID_FAIL_FORM_CTCP,
-                    EL_ERROR_LEVEL_HIGH,
-                    (uint32_t)rule_id);
-    return;
-  }
-
-  deploy_cmd_ack = PH_dispatch_command(&packet);
-  if (deploy_cmd_ack != CCP_EXEC_SUCCESS)
+  ack = CCP_form_and_exec_block_deploy_cmd(TLCD_ID_DEPLOY_BC, rule->settings.deploy_bct_id);
+  if (ack != CCP_EXEC_SUCCESS)
   {
     EL_record_event((EL_GROUP)EL_CORE_GROUP_EVENT_HANDLER,
                     EH_EL_LOCAL_ID_FAIL_FORM_CTCP,
                     EL_ERROR_LEVEL_HIGH,
-                    deploy_cmd_ack);
+                    ack);
   }
 
   EH_inactivate_rule_for_multi_level(rule_id);
 
-  EH_record_responded_log_(rule_id, deploy_cmd_ack);
+  EH_record_responded_log_(rule_id, ack);
 }
 
 

--- a/System/ModeManager/mode_manager.c
+++ b/System/ModeManager/mode_manager.c
@@ -309,11 +309,7 @@ static MM_ACK MM_finish_transition_(void)
 
 static void MM_deploy_block_cmd_(bct_id_t bc_index)
 {
-  CommonCmdPacket packet;
-
-  CCP_form_block_deploy_cmd(&packet, TLCD_ID_DEPLOY_BC, bc_index);
-
-  PH_dispatch_command(&packet);
+  CCP_form_and_exec_block_deploy_cmd(TLCD_ID_DEPLOY_BC, bc_index);
 }
 
 CCP_EXEC_STS Cmd_MM_UPDATE_TRANSITION_TABLE_FOR_TLM(const CommonCmdPacket* packet)

--- a/TlmCmd/common_cmd_packet.h
+++ b/TlmCmd/common_cmd_packet.h
@@ -45,7 +45,7 @@ typedef enum
   CCP_EXEC_ILLEGAL_CONTEXT,     //!< コマンド実行時のその他のエラー
   CCP_EXEC_CMD_NOT_DEFINED,     //!< cmdExec で用いる
   CCP_EXEC_ROUTING_FAILED,      //!< command router で用いる
-  CCP_EXEC_PACKET_FMT_ERR,      //!< packet handler で用いる
+  CCP_EXEC_PACKET_FMT_ERR,      //!< packet handler, ccp util で用いる
   CCP_EXEC_UNKNOWN              //!< 内部処理用．使わない．
 } CCP_EXEC_STS;
 

--- a/TlmCmd/common_cmd_packet_util.c
+++ b/TlmCmd/common_cmd_packet_util.c
@@ -44,6 +44,7 @@ void CCP_form_nop_rtc_(CommonCmdPacket* packet)
   CCP_form_rtc(packet, Cmd_CODE_NOP, NULL, 0);
 }
 
+
 void CCP_form_app_cmd(CommonCmdPacket* packet, cycle_t ti, AR_APP_ID id)
 {
   // FIXME: この4は環境依存なので，依存しないように直す
@@ -57,6 +58,7 @@ void CCP_form_app_cmd(CommonCmdPacket* packet, cycle_t ti, AR_APP_ID id)
 
   CCP_form_tlc(packet, ti, Cmd_CODE_AM_EXECUTE_APP, param, 4);
 }
+
 
 CCP_UTIL_ACK CCP_form_rtc(CommonCmdPacket* packet, CMD_CODE cmd_id, const uint8_t* param, uint16_t len)
 {
@@ -81,6 +83,7 @@ CCP_UTIL_ACK CCP_form_rtc(CommonCmdPacket* packet, CMD_CODE cmd_id, const uint8_
 
   return CCP_UTIL_ACK_OK;
 }
+
 
 CCP_UTIL_ACK CCP_form_tlc(CommonCmdPacket* packet, cycle_t ti, CMD_CODE cmd_id, const uint8_t* param, uint16_t len)
 {
@@ -109,6 +112,7 @@ CCP_UTIL_ACK CCP_form_tlc(CommonCmdPacket* packet, cycle_t ti, CMD_CODE cmd_id, 
   return CCP_UTIL_ACK_OK;
 }
 
+
 CCP_UTIL_ACK CCP_form_rtc_to_other_obc(CommonCmdPacket* packet, APID apid, CMD_CODE cmd_id, const uint8_t* param, uint16_t len)
 {
   if (packet == NULL)
@@ -129,6 +133,7 @@ CCP_UTIL_ACK CCP_form_rtc_to_other_obc(CommonCmdPacket* packet, APID apid, CMD_C
 
   return CCP_UTIL_ACK_OK;
 }
+
 
 CCP_UTIL_ACK CCP_form_tlc_to_other_obc(CommonCmdPacket* packet, cycle_t ti, APID apid, CMD_CODE cmd_id, const uint8_t* param, uint16_t len)
 {
@@ -153,6 +158,7 @@ CCP_UTIL_ACK CCP_form_tlc_to_other_obc(CommonCmdPacket* packet, cycle_t ti, APID
   return CCP_UTIL_ACK_OK;
 }
 
+
 CCP_UTIL_ACK CCP_form_block_deploy_cmd(CommonCmdPacket* packet, TLCD_ID tl_no, bct_id_t block_no)
 {
   uint8_t param[1 + SIZE_OF_BCT_ID_T];
@@ -175,6 +181,7 @@ CCP_UTIL_ACK CCP_form_block_deploy_cmd(CommonCmdPacket* packet, TLCD_ID tl_no, b
   return CCP_form_rtc(packet, Cmd_CODE_TLCD_DEPLOY_BLOCK, param, 1 + SIZE_OF_BCT_ID_T);
 }
 
+
 static void CCP_form_rtc_(CommonCmdPacket* packet, CMD_CODE cmd_id, const uint8_t* param, uint16_t len)
 {
   CCP_set_common_hdr(packet);
@@ -185,12 +192,14 @@ static void CCP_form_rtc_(CommonCmdPacket* packet, CMD_CODE cmd_id, const uint8_
   CCP_set_param(packet, param, len);
 }
 
+
 void CCP_convert_rtc_to_tlc(CommonCmdPacket* packet, cycle_t ti)
 {
   if (packet == NULL) return;
   CCP_set_exec_type(packet, CCP_EXEC_TYPE_TL_FROM_GS);  // TL なので，一旦仮で入れる
   CCP_set_ti(packet, ti);
 }
+
 
 PH_ACK CCP_register_rtc(CMD_CODE cmd_id, const uint8_t* param, uint16_t len)
 {
@@ -201,6 +210,7 @@ PH_ACK CCP_register_rtc(CMD_CODE cmd_id, const uint8_t* param, uint16_t len)
 
   return PH_analyze_cmd_packet(&CCP_util_packet_);
 }
+
 
 PH_ACK CCP_register_tlc(cycle_t ti, TLCD_ID tlcd_id, CMD_CODE cmd_id, const uint8_t* param, uint16_t len)
 {
@@ -219,6 +229,7 @@ PH_ACK CCP_register_tlc(cycle_t ti, TLCD_ID tlcd_id, CMD_CODE cmd_id, const uint
   CCP_set_exec_type(&CCP_util_packet_, type);
   return PH_analyze_cmd_packet(&CCP_util_packet_);
 }
+
 
 PH_ACK CCP_register_tlc_asap(cycle_t ti, TLCD_ID tlcd_id, CMD_CODE cmd_id, const uint8_t* param, uint16_t len)
 {
@@ -271,6 +282,27 @@ PH_ACK CCP_register_tlc_asap(cycle_t ti, TLCD_ID tlcd_id, CMD_CODE cmd_id, const
   return PH_analyze_cmd_packet(&CCP_util_packet_);
 }
 
+
+CCP_EXEC_STS CCP_form_and_exec_rtc(CMD_CODE cmd_id, const uint8_t* param, uint16_t len)
+{
+  CCP_UTIL_ACK ret;
+  ret = CCP_form_rtc(&CCP_util_packet_, cmd_id, param, len);
+  if (ret != CCP_UTIL_ACK_OK) return CCP_EXEC_PACKET_FMT_ERR;
+
+  return PH_dispatch_command(&CCP_util_packet_);
+}
+
+
+CCP_EXEC_STS CCP_form_and_exec_block_deploy_cmd(TLCD_ID tl_no, bct_id_t block_no)
+{
+  CCP_UTIL_ACK ret;
+  ret = CCP_form_block_deploy_cmd(&CCP_util_packet_, tl_no, block_no);
+  if (ret != CCP_UTIL_ACK_OK) return CCP_EXEC_PACKET_FMT_ERR;
+
+  return PH_dispatch_command(&CCP_util_packet_);
+}
+
+
 CCP_EXEC_TYPE CCP_get_exec_type_from_tlcd_id(TLCD_ID tlcd_id)
 {
   switch (tlcd_id)
@@ -294,6 +326,7 @@ CCP_EXEC_TYPE CCP_get_exec_type_from_tlcd_id(TLCD_ID tlcd_id)
   }
 }
 
+
 uint8_t* CCP_get_1byte_param_from_packet(const CommonCmdPacket* packet, uint8_t n)
 {
   static uint8_t ret;
@@ -312,6 +345,7 @@ uint8_t* CCP_get_1byte_param_from_packet(const CommonCmdPacket* packet, uint8_t 
   endian_memcpy(&ret, CCP_get_param_head(packet) + offset, (size_t)param_size);
   return &ret;
 }
+
 
 uint16_t* CCP_get_2byte_param_from_packet(const CommonCmdPacket* packet, uint8_t n)
 {
@@ -332,6 +366,7 @@ uint16_t* CCP_get_2byte_param_from_packet(const CommonCmdPacket* packet, uint8_t
   return &ret;
 }
 
+
 uint32_t* CCP_get_4byte_param_from_packet(const CommonCmdPacket* packet, uint8_t n)
 {
   static uint32_t ret;
@@ -351,6 +386,7 @@ uint32_t* CCP_get_4byte_param_from_packet(const CommonCmdPacket* packet, uint8_t
   return &ret;
 }
 
+
 uint64_t* CCP_get_8byte_param_from_packet(const CommonCmdPacket* packet, uint8_t n)
 {
   static uint64_t ret;
@@ -369,6 +405,7 @@ uint64_t* CCP_get_8byte_param_from_packet(const CommonCmdPacket* packet, uint8_t
   endian_memcpy(&ret, CCP_get_param_head(packet) + offset, (size_t)param_size);
   return &ret;
 }
+
 
 uint16_t CCP_get_raw_param_from_packet(const CommonCmdPacket* packet, void* dest, uint16_t max_copy_len)
 {
@@ -392,6 +429,7 @@ uint16_t CCP_get_raw_param_from_packet(const CommonCmdPacket* packet, void* dest
   memcpy(dest,  CCP_get_param_head(packet) + offset, (size_t)copy_len);
   return (uint16_t)copy_len;
 }
+
 
 CCP_UTIL_ACK CCP_calc_param_offset_(CMD_CODE cmd_id, uint8_t n, uint16_t* offset)
 {

--- a/TlmCmd/common_cmd_packet_util.h
+++ b/TlmCmd/common_cmd_packet_util.h
@@ -134,6 +134,26 @@ PH_ACK CCP_register_tlc(cycle_t ti, TLCD_ID tlcd_id, CMD_CODE cmd_id, const uint
 PH_ACK CCP_register_tlc_asap(cycle_t ti, TLCD_ID tlcd_id, CMD_CODE cmd_id, const uint8_t* param, uint16_t len);
 
 /**
+ * @brief Realtime command を生成し，即時実行する
+ * @note  RTC のキューに登録までする場合は `CCP_register_rtc` を使用
+ * @param[in]     cmd_id: CMD_CODE
+ * @param[in]     param:  パラメタ
+ * @param[in]     len:    パラメタ長
+ * @retval CCP_EXEC_PACKET_FMT_ERR: 引数が不正なとき
+ * @retval それ以外: PH_dispatch_command の返り値
+ */
+CCP_EXEC_STS CCP_form_and_exec_rtc(CMD_CODE cmd_id, const uint8_t* param, uint16_t len);
+
+/**
+ * @brief BC展開 command を生成し，即時実行する
+ * @param[in]     tl_no:    Timeline no
+ * @param[in]     block_no: BC ID
+ * @retval CCP_EXEC_PACKET_FMT_ERR: 引数が不正なとき
+ * @retval それ以外: PH_dispatch_command の返り値
+ */
+CCP_EXEC_STS CCP_form_and_exec_block_deploy_cmd(TLCD_ID tl_no, bct_id_t block_no);
+
+/**
  * @brief TLCD ID から CCP_EXEC_TYPE を取得する
  * @param[in] tlcd_id: tl id
  * @note 引数が不正な場合は CCP_EXEC_TYPE_UNKNOWN を返す

--- a/TlmCmd/common_cmd_packet_util.h
+++ b/TlmCmd/common_cmd_packet_util.h
@@ -82,7 +82,7 @@ CCP_UTIL_ACK CCP_form_rtc_to_other_obc(CommonCmdPacket* packet, APID apid, CMD_C
 CCP_UTIL_ACK CCP_form_tlc_to_other_obc(CommonCmdPacket* packet, cycle_t ti, APID apid, CMD_CODE cmd_id, const uint8_t* param, uint16_t len);
 
 /**
- * @brief BC展開 command を生成
+ * @brief BC展開 Realtime command を生成
  * @note  引数が不正なとき， packet は NOP RTC を返す
  * @param[in,out] packet:   CCP
  * @param[in]     tl_no:    Timeline no
@@ -135,7 +135,8 @@ PH_ACK CCP_register_tlc_asap(cycle_t ti, TLCD_ID tlcd_id, CMD_CODE cmd_id, const
 
 /**
  * @brief Realtime command を生成し，即時実行する
- * @note  RTC のキューに登録までする場合は `CCP_register_rtc` を使用
+ * @note  RTC のキューに登録する場合は `CCP_register_rtc` を使用
+ * @note  生成される command は RTC だが，キューイングされずに即時実行されるため RTC Dispatcher にはログは残らない
  * @param[in]     cmd_id: CMD_CODE
  * @param[in]     param:  パラメタ
  * @param[in]     len:    パラメタ長


### PR DESCRIPTION
## 概要
即時実行する CCP 作成関数の追加

## Issue
- https://github.com/ut-issl/c2a-core/issues/323

## 詳細
- see diff

## 検証結果
- 既存の部分を書き換えることで，既存のtestがすべて通ればOKということになる（にしてほしい．．．）

## 補足
こういう部分ってどうtest書けば良いんだろうね？