### PR TITLE
global time をユーザー定義に

### DIFF
--- a/Examples/minimum_user/src/src_user/TlmCmd/common_tlm_packet.c
+++ b/Examples/minimum_user/src/src_user/TlmCmd/common_tlm_packet.c
@@ -30,7 +30,7 @@ void CTP_set_apid(CommonTlmPacket* packet, APID apid)
 void CTP_set_global_time(CommonTlmPacket* packet)
 {
   // 何を設定するかはユーザー定義
-  // TMGR_get_curret_unixtime() で現在の unixtime を入れたり, gps_time を入れたり, など
+  // TMGR_get_curret_unixtime() で現在の unixtime を入れたり, gps 時刻 を入れたり, など
   TSP_set_global_time(packet, 0.0);
 }
 

--- a/Examples/minimum_user/src/src_user/TlmCmd/common_tlm_packet.c
+++ b/Examples/minimum_user/src/src_user/TlmCmd/common_tlm_packet.c
@@ -27,6 +27,13 @@ void CTP_set_apid(CommonTlmPacket* packet, APID apid)
   TSP_set_apid(packet, apid);
 }
 
+void CTP_set_global_time(CommonTlmPacket* packet)
+{
+  // 何を設定するかはユーザー定義
+  // TMGR_get_curret_unixtime() で現在の unixtime を入れたり, gps_time を入れたり, など
+  TSP_set_global_time(packet, 0.0);
+}
+
 ctp_dest_flags_t CTP_get_dest_flags(const CommonTlmPacket* packet)
 {
   return TSP_get_dest_flags(packet);

--- a/TlmCmd/common_tlm_packet.h
+++ b/TlmCmd/common_tlm_packet.h
@@ -63,8 +63,8 @@ APID CTP_get_apid(const CommonTlmPacket* packet);
 void CTP_set_apid(CommonTlmPacket* packet, APID apid);
 
 /**
- * @brief  global_time を設定
- * @note 何を設定するかは user 定義
+ * @brief  現在の global_time を設定
+ * @note   何を設定するかは user 定義
  * @param[in,out] packet: CTP
  * @return void
  */

--- a/TlmCmd/common_tlm_packet.h
+++ b/TlmCmd/common_tlm_packet.h
@@ -63,6 +63,14 @@ APID CTP_get_apid(const CommonTlmPacket* packet);
 void CTP_set_apid(CommonTlmPacket* packet, APID apid);
 
 /**
+ * @brief  global_time を設定
+ * @note 何を設定するかは user 定義
+ * @param[in,out] packet: CTP
+ * @return void
+ */
+void CTP_set_global_time(CommonTlmPacket* packet);
+
+/**
  * @brief  CTP_DEST_FLAG の & を取った flags を取得
  * @param  packet: CTP
  * @return Dest Flags

--- a/TlmCmd/telemetry_generator.c
+++ b/TlmCmd/telemetry_generator.c
@@ -71,7 +71,7 @@ CCP_EXEC_STS Cmd_GENERATE_TLM(const CommonCmdPacket* packet)
   }
 
   // FIXME: 他の時刻も入れる
-  TSP_set_global_time(&ctp_, 0.0);
+  CTP_set_global_time(&ctp_);
   TSP_set_on_board_subnet_time(&ctp_, (uint32_t)(TMGR_get_master_total_cycle()));   // FIXME: 暫定
 
   // FIXME: 他 OBC からのパケットは別処理する


### PR DESCRIPTION
## 概要
global time をユーザー定義できるようにした

## Issue
N/A

## 詳細
global_time が今までゼロ埋めされていたが、ユーザー定義で好きな値を設定できるようにした

## 検証結果
CIが通ればOK
