### PR TITLE
Remove unneeded CMake target_properties()

### DIFF
--- a/common.cmake
+++ b/common.cmake
@@ -1,7 +1,6 @@
 if(BUILD_C2A_AS_CXX)
   # memo: set_source_files_properties() must be set before add_library/add_executable on Visual Studio CMake
   set_source_files_properties(${C2A_SRCS} PROPERTIES LANGUAGE CXX)  # C++
-  set_target_properties(${PROJECT_NAME} PROPERTIES LANGUAGE CXX) # C++
 else()
   if (CMAKE_C_COMPILER_ID STREQUAL "Clang")
     # TODO: remove this!


### PR DESCRIPTION
## 概要
不要なCMake target propertyを消す

## Issue
NA

## 詳細
- そもそもtarget propertyに`LANGUAGE`は存在しないので，無意味な指定
  - ref: https://cmake.org/cmake/help/latest/manual/cmake-properties.7.html#target-properties
- Visual Studio 2019だとこれでコケてそう

## 検証結果
CIが通ればよし

## 影響範囲
CMakeの修正なのでSILS環境下のみ．無意味な設定を削るだけなので動作は変わらないはず．

