### PR TITLE
Fix set -rdynamic on link time only

### DIFF
--- a/common.cmake
+++ b/common.cmake
@@ -44,9 +44,7 @@ else()
 
   # debug
   target_compile_options(${PROJECT_NAME} PUBLIC "-g")
-  if (NOT CMAKE_C_COMPILER_ID STREQUAL "Clang")
-    target_compile_options(${PROJECT_NAME} PUBLIC "-rdynamic")
-  endif()
+  target_link_options(${PROJECT_NAME} PUBLIC "-rdynamic")
 
   # warning
   target_compile_options(${PROJECT_NAME} PUBLIC "-Wpedantic")


### PR DESCRIPTION
## 概要
SSIA

## Issue/PR
- https://github.com/ut-issl/s2e-core/pull/155

## 詳細
`-rdynamic` はそもそもリンク時のオプションで， gcc はコンパイルだけの時(`-c`の時)でもこのオプション渡されても何食わぬ顔だけど，clang は偉いので `-c` の時はなんやねんこれというワーニングを吐いてる(リンクする時に渡される分にはOK)，ということだったっぽい．

_Originally posted by @sksat in https://github.com/ut-issl/s2e-core/issues/155#issuecomment-1172161683_

