### PR TITLE
SCIDのデフォルト値を修正

### DIFF
--- a/Examples/minimum_user/src/src_user/TlmCmd/Ccsds/tc_transfer_frame.h
+++ b/Examples/minimum_user/src/src_user/TlmCmd/Ccsds/tc_transfer_frame.h
@@ -85,7 +85,7 @@ typedef enum
  */
 typedef enum
 {
-  TCTF_SCID_SAMPLE_SATELLITE = 0x35C, // SCID for command of sample satellite
+  TCTF_SCID_SAMPLE_SATELLITE = 0x157, // SCID for command of sample satellite
   TCTF_SCID_UNKNOWN
 } TCTF_SCID;
 


### PR DESCRIPTION
## 概要
SCIDのデフォルト値を修正

## 詳細
WINGSのデフォルト値が変わったため

## 検証結果
手元の最新WINGSで噛み合わせOK
