### PR TITLE
Examples/2nd_obc_user と Examples/minimum_user の同期スクリプトの微修正

### DIFF
--- a/Examples/2nd_obc_user/sync_with_minimum_user.bat
+++ b/Examples/2nd_obc_user/sync_with_minimum_user.bat
@@ -27,12 +27,9 @@ call :sync_file ".\src\src_user\TlmCmd\common_cmd_packet.c" "..\minimum_user\src
 call :sync_file ".\src\src_user\TlmCmd\common_tlm_cmd_packet.c" "..\minimum_user\src\src_user\TlmCmd\common_tlm_cmd_packet.c"
 call :sync_file ".\src\src_user\TlmCmd\common_tlm_packet.c" "..\minimum_user\src\src_user\TlmCmd\common_tlm_packet.c"
 
-call :sync_file ".\src\src_user\Test\test\conftest.py" "..\minimum_user\src\src_user\Test\test\conftest.py"
-call :sync_file ".\src\src_user\Test\utils\c2a_enum_utils.py" "..\minimum_user\src\src_user\Test\utils\c2a_enum_utils.py"
 call :sync_file ".\src\src_user\Test\utils\wings_utils.py" "..\minimum_user\src\src_user\Test\utils\wings_utils.py"
 call :sync_file ".\src\src_user\Test\authorization.json.temp" "..\minimum_user\src\src_user\Test\authorization.json.temp"
 call :sync_file ".\src\src_user\Test\pytest.ini" "..\minimum_user\src\src_user\Test\pytest.ini"
-call :sync_file ".\src\src_user\Test\settings.json" "..\minimum_user\src\src_user\Test\settings.json"
 
 
 echo.


### PR DESCRIPTION
## 概要
Examples/2nd_obc_user と Examples/minimum_user の同期スクリプトの微修正

## Issue
NA

## 詳細
- https://github.com/ut-issl/c2a-core/pull/386 での修正漏れ
- MOBC sample と AOBC (2nd OBC) sample でファイルが全く同じものを，暫定的にこのバッチファイルで同期しているが，上記PRで同一ではなくなったものを除外するのを忘れていた
