### PR TITLE
C2A標準CRCを CRC-16-IBM から CRC-16-CCITT に変える

### DIFF
--- a/Drivers/Protocol/eb90_frame_for_driver_super.c
+++ b/Drivers/Protocol/eb90_frame_for_driver_super.c
@@ -43,7 +43,7 @@ uint8_t EB90_FRAME_is_valid_crc_of_dssc(const DS_StreamConfig* p_stream_config)
 
 uint16_t EB90_FRAME_calc_crc(const uint8_t* data, size_t len)
 {
-  return CRC_calc_crc_16_ibm_right(0x0000, data, len, 0);
+  return CRC_calc_crc_16_ccitt_left(0xffff, data, len, 0);
 }
 
 #pragma section

--- a/Drivers/Protocol/eb90_frame_for_driver_super.c
+++ b/Drivers/Protocol/eb90_frame_for_driver_super.c
@@ -43,6 +43,8 @@ uint8_t EB90_FRAME_is_valid_crc_of_dssc(const DS_StreamConfig* p_stream_config)
 
 uint16_t EB90_FRAME_calc_crc(const uint8_t* data, size_t len)
 {
+  // CRC-16/CCITT-FALSE (CRC-16/AUTOSAR, CRC-16/IBM-3740 とも)
+  // https://reveng.sourceforge.io/crc-catalogue/16.htm
   return CRC_calc_crc_16_ccitt_left(0xffff, data, len, 0);
 }
 

--- a/Drivers/Protocol/eb90_frame_for_driver_super.h
+++ b/Drivers/Protocol/eb90_frame_for_driver_super.h
@@ -20,9 +20,14 @@
  *        |---------+-------+-------+------------------|
  *        | === Footer =============================== |
  *        |---------+-------+-------+------------------|
- *        |   N - 4 |     0 |    16 | CRC-16-CCITT     |
+ *        |   N - 4 |     0 |    16 | CRC              |
  *        |   N - 2 |     0 |    16 | ETX              |
  *        |---------+-------+-------+------------------|
+ *
+ *        CRC
+ *          CRC-16/CCITT-FALSE (CRC-16/AUTOSAR, CRC-16/IBM-3740 とも)
+ *          Packet Field の CRC
+ *          Header は含めない
  */
 #ifndef EB90_FRAME_FOR_DRIVER_SUPER_H_
 #define EB90_FRAME_FOR_DRIVER_SUPER_H_

--- a/Drivers/Protocol/eb90_frame_for_driver_super.h
+++ b/Drivers/Protocol/eb90_frame_for_driver_super.h
@@ -20,7 +20,7 @@
  *        |---------+-------+-------+------------------|
  *        | === Footer =============================== |
  *        |---------+-------+-------+------------------|
- *        |   N - 4 |     0 |    16 | CRC-16-IBM       |
+ *        |   N - 4 |     0 |    16 | CRC-16-CCITT     |
  *        |   N - 2 |     0 |    16 | ETX              |
  *        |---------+-------+-------+------------------|
  */
@@ -79,7 +79,7 @@ uint8_t EB90_FRAME_is_valid_crc_of_dssc(const DS_StreamConfig* p_stream_config);
 
 /**
  * @brief  EB90 Frame の CRC の計算
- * @note   CRC-16-IBM を使う
+ * @note   CRC-16-CCITT を使う
  * @param  data: CRC を計算するデータのポインタ
  * @param  len:  データ長
  * @return CRC


### PR DESCRIPTION
## 概要
C2A標準CRCを CRC-16-IBM から CRC-16-CCITT に変える

## Issue
- https://github.com/ut-issl/c2a-core/issues/390

## 詳細
See issue

## 検証結果
minimum_user と 2nd_obc_user のテストが全て通った

## 影響範囲
- [ ] 過去のC2A間通信のコンポーネントとの互換性がなくなるので pre release を打つ

