### PR TITLE
Pre Release (v3.7.0-beta.2): C2A間通信の実装例に CRC のチェックを入れ，テストを通す

### DIFF
--- a/Drivers/Protocol/eb90_frame_for_driver_super.c
+++ b/Drivers/Protocol/eb90_frame_for_driver_super.c
@@ -36,8 +36,9 @@ uint16_t EB90_FRAME_get_crc_from_dssc(const DS_StreamConfig* p_stream_config)
 
 uint8_t EB90_FRAME_is_valid_crc_of_dssc(const DS_StreamConfig* p_stream_config)
 {
-  // TODO: CRC を IBM から CCITT に変えてから実装する
-  return 1;
+  uint16_t len = EB90_FRAME_get_packet_length_from_dssc(p_stream_config);
+  const uint8_t* head = EB90_FRAME_get_packet_head_from_dssc(p_stream_config);
+  return (EB90_FRAME_calc_crc(head, len + EB90_FRAME_CRC_SIZE) == 0) ? 1 : 0;
 }
 
 

--- a/Drivers/Protocol/eb90_frame_for_driver_super.h
+++ b/Drivers/Protocol/eb90_frame_for_driver_super.h
@@ -24,6 +24,8 @@
  *        |   N - 2 |     0 |    16 | ETX              |
  *        |---------+-------+-------+------------------|
  *
+ *        Packet Length:
+ *          Packet Field の長さ
  *        CRC
  *          CRC-16/CCITT-FALSE (CRC-16/AUTOSAR, CRC-16/IBM-3740 とも)
  *          Packet Field の CRC

--- a/Examples/2nd_obc_user/src/src_user/Drivers/Etc/mobc.c
+++ b/Examples/2nd_obc_user/src/src_user/Drivers/Etc/mobc.c
@@ -108,8 +108,11 @@ static DS_ERR_CODE MOBC_analyze_rec_data_(DS_StreamConfig* p_stream_config, void
 
   mobc_driver->info.comm.rx_err_code = MOBC_RX_ERR_CODE_OK;
 
-  // TODO: ここに CRC チェックをいれる
-  // MOBC_RX_ERR_CODE_CRC_ERR を入れる
+  if (!EB90_FRAME_is_valid_crc_of_dssc(p_stream_config))
+  {
+    mobc_driver->info.comm.rx_err_code = MOBC_RX_ERR_CODE_CRC_ERR;
+    return DS_ERR_CODE_ERR;
+  }
 
   // MOBC からのコマンドは以下のパターン
   //  APID:

--- a/Examples/2nd_obc_user/src/src_user/Drivers/Etc/mobc.h
+++ b/Examples/2nd_obc_user/src/src_user/Drivers/Etc/mobc.h
@@ -19,7 +19,7 @@
  */
 typedef enum
 {
-  MOBC_TX_ERR_CODE_OK   = 0
+  MOBC_TX_ERR_CODE_OK = 0
   // MOBC_TX_ERR_CODE_CMD_NOT_FOUND,
 } MOBC_TX_ERR_CODE;
 
@@ -31,7 +31,7 @@ typedef enum
  */
 typedef enum
 {
-  MOBC_RX_ERR_CODE_OK   = 0,
+  MOBC_RX_ERR_CODE_OK = 0,
   // MOBC_RX_ERR_CODE_TLM_NOT_FOUND,
   MOBC_RX_ERR_CODE_CRC_ERR,
   MOBC_RX_ERR_CODE_INVALID_PACKET

--- a/Examples/minimum_user/src/src_user/Drivers/Aocs/aobc.c
+++ b/Examples/minimum_user/src/src_user/Drivers/Aocs/aobc.c
@@ -103,8 +103,11 @@ static DS_ERR_CODE AOBC_analyze_rec_data_(DS_StreamConfig* p_stream_config,
 
   aobc_driver->info.comm.rx_err_code = AOBC_RX_ERR_CODE_OK;
 
-  // [TODO] ここに CRC チェックをいれる
-  // AOBC_RX_ERR_CODE_CRC_ERR を入れる
+  if (!EB90_FRAME_is_valid_crc_of_dssc(p_stream_config))
+  {
+    aobc_driver->info.comm.rx_err_code = AOBC_RX_ERR_CODE_CRC_ERR;
+    return DS_ERR_CODE_ERR;
+  }
 
   return AOBC_buffer_tlm_packet(p_stream_config, aobc_driver);
 }

--- a/Examples/minimum_user/src/src_user/Drivers/Aocs/aobc.h
+++ b/Examples/minimum_user/src/src_user/Drivers/Aocs/aobc.h
@@ -19,7 +19,7 @@
  */
 typedef enum
 {
-  AOBC_TX_ERR_CODE_OK   = 0,
+  AOBC_TX_ERR_CODE_OK = 0,
   AOBC_TX_ERR_CODE_CMD_NOT_FOUND
 } AOBC_TX_ERR_CODE;
 
@@ -30,7 +30,7 @@ typedef enum
  */
 typedef enum
 {
-  AOBC_RX_ERR_CODE_OK   = 0,
+  AOBC_RX_ERR_CODE_OK = 0,
   AOBC_RX_ERR_CODE_TLM_NOT_FOUND,
   AOBC_RX_ERR_CODE_CRC_ERR
 } AOBC_RX_ERR_CODE;

--- a/c2a_core_main.h
+++ b/c2a_core_main.h
@@ -10,6 +10,6 @@ void C2A_core_main(void);
 #define C2A_CORE_VER_MAJOR (3)
 #define C2A_CORE_VER_MINOR (7)
 #define C2A_CORE_VER_PATCH (0)
-#define C2A_CORE_VER_PRE   ("beta.1")
+#define C2A_CORE_VER_PRE   ("beta.2")
 
 #endif


### PR DESCRIPTION
## 概要
Pre Release (v3.7.0-beta.2): C2A間通信の実装例に CRC のチェックを入れ，テストを通す

## Issue
- https://github.com/ut-issl/c2a-core/issues/395

## 詳細
see issue

## 検証結果
minimum_user と 2nd_obc_user のテストが全て通った

## 補足
- https://github.com/ut-issl/c2a-core/pull/403 でCRCが変わってることに注意
- https://github.com/ut-issl/c2a-core/pull/403 とあわせて，コンポ間通信が非互換になるので pre release を打つ
