### PR TITLE
C2A間通信など， CTCP on EB90 frame のコンポ間通信の Driver を書きやすくする Util を整備

### DIFF
--- a/Drivers/Protocol/common_tlm_cmd_packet_for_driver_super.c
+++ b/Drivers/Protocol/common_tlm_cmd_packet_for_driver_super.c
@@ -53,4 +53,36 @@ DS_ERR_CODE CCP_get_ccp_from_dssc(const DS_StreamConfig* p_stream_config, Common
   return DS_ERR_CODE_OK;
 }
 
+
+DS_ERR_CODE CTCP_init_dssc(DS_StreamConfig* p_stream_config,
+                           uint8_t* tx_frame_buffer,
+                           int16_t tx_frame_buffer_size,
+                           DS_ERR_CODE (*data_analyzer)(DS_StreamConfig* p_stream_config, void* p_driver))
+{
+  if (tx_frame_buffer_size <= EB90_FRAME_HEADER_SIZE + CTCP_MAX_LEN + EB90_FRAME_FOOTER_SIZE)
+  {
+    return DS_ERR_CODE_ERR;
+  }
+
+  // 送信はする
+  DSSC_set_tx_frame(p_stream_config, tx_frame_buffer);  // 送る直前に中身を memcpy する
+  DSSC_set_tx_frame_buffer_size(p_stream_config, tx_frame_buffer_size);
+  DSSC_set_tx_frame_size(p_stream_config, 0);           // 送る直前に値をセットする
+
+  // 定期的な受信はする
+  DSSC_set_rx_header(p_stream_config, EB90_FRAME_kStx, EB90_FRAME_STX_SIZE);
+  DSSC_set_rx_footer(p_stream_config, EB90_FRAME_kEtx, EB90_FRAME_ETX_SIZE);
+  DSSC_set_rx_frame_size(p_stream_config, -1);          // 可変
+  DSSC_set_rx_framelength_pos(p_stream_config, EB90_FRAME_STX_SIZE);
+  DSSC_set_rx_framelength_type_size(p_stream_config, 2);
+  DSSC_set_rx_framelength_offset(p_stream_config,
+                                 EB90_FRAME_HEADER_SIZE + EB90_FRAME_FOOTER_SIZE);
+  DSSC_set_data_analyzer(p_stream_config, data_analyzer);
+
+  // 定期 TLM の監視機能の有効化はここではしないので， Driver 側でやる
+  // enable もここではしない
+
+  return DS_ERR_CODE_OK;
+}
+
 #pragma section

--- a/Drivers/Protocol/common_tlm_cmd_packet_for_driver_super.c
+++ b/Drivers/Protocol/common_tlm_cmd_packet_for_driver_super.c
@@ -59,7 +59,7 @@ DS_ERR_CODE CTCP_init_dssc(DS_StreamConfig* p_stream_config,
                            int16_t tx_frame_buffer_size,
                            DS_ERR_CODE (*data_analyzer)(DS_StreamConfig* p_stream_config, void* p_driver))
 {
-  if (tx_frame_buffer_size <= EB90_FRAME_HEADER_SIZE + CTCP_MAX_LEN + EB90_FRAME_FOOTER_SIZE)
+  if (tx_frame_buffer_size < EB90_FRAME_HEADER_SIZE + CTCP_MAX_LEN + EB90_FRAME_FOOTER_SIZE)
   {
     return DS_ERR_CODE_ERR;
   }

--- a/Drivers/Protocol/common_tlm_cmd_packet_for_driver_super.c
+++ b/Drivers/Protocol/common_tlm_cmd_packet_for_driver_super.c
@@ -86,7 +86,7 @@ DS_ERR_CODE CTCP_init_dssc(DS_StreamConfig* p_stream_config,
 }
 
 
-DS_ERR_CODE CTCP_set_tx_frane_to_dssc(DS_StreamConfig* p_stream_config,
+DS_ERR_CODE CTCP_set_tx_frame_to_dssc(DS_StreamConfig* p_stream_config,
                                       const CommonTlmCmdPacket* send_packet)
 {
   size_t pos;
@@ -123,21 +123,21 @@ DS_ERR_CODE CTCP_set_tx_frane_to_dssc(DS_StreamConfig* p_stream_config,
 }
 
 
-DS_ERR_CODE CTP_set_tx_frane_to_dssc(DS_StreamConfig* p_stream_config,
+DS_ERR_CODE CTP_set_tx_frame_to_dssc(DS_StreamConfig* p_stream_config,
                                      const CommonTlmPacket* send_packet)
 {
   const CommonTlmCmdPacket* ctcp = CTCP_convert_from_ctp(send_packet);
   if (ctcp == NULL) return DS_ERR_CODE_ERR;
-  return CTCP_set_tx_frane_to_dssc(p_stream_config, ctcp);
+  return CTCP_set_tx_frame_to_dssc(p_stream_config, ctcp);
 }
 
 
-DS_ERR_CODE CCP_set_tx_frane_to_dssc(DS_StreamConfig* p_stream_config,
+DS_ERR_CODE CCP_set_tx_frame_to_dssc(DS_StreamConfig* p_stream_config,
                                      const CommonCmdPacket* send_packet)
 {
   const CommonTlmCmdPacket* ctcp = CTCP_convert_from_ccp(send_packet);
   if (ctcp == NULL) return DS_ERR_CODE_ERR;
-  return CTCP_set_tx_frane_to_dssc(p_stream_config, ctcp);
+  return CTCP_set_tx_frame_to_dssc(p_stream_config, ctcp);
 }
 
 #pragma section

--- a/Drivers/Protocol/common_tlm_cmd_packet_for_driver_super.h
+++ b/Drivers/Protocol/common_tlm_cmd_packet_for_driver_super.h
@@ -59,8 +59,34 @@ DS_ERR_CODE CTCP_init_dssc(DS_StreamConfig* p_stream_config,
                            int16_t tx_frame_buffer_size,
                            DS_ERR_CODE (*data_analyzer)(DS_StreamConfig* p_stream_config, void* p_driver));
 
-// TODO: aobc.c の TODO 時に実装（標準処理の共通化）
-// DS_ERR_CODE CTCP_set_tx_frane_to_dssc(const DS_StreamConfig* p_stream_config,
-//                                       const CommonTlmCmdPacket* send_packet);
+/**
+ * @brief  C2A 間通信など， CTCP をコンポ間通信に用いるときの tx_frame のセット
+ * @param[in]  p_stream_config: DriverSuper 構造体の DS_StreamConfig
+ * @param[in]  send_packet: 送信するパケット
+ * @retval DS_ERR_CODE_OK:  正常終了
+ * @retval DS_ERR_CODE_ERR: DSSC 内部の設定不足などのエラー
+ */
+DS_ERR_CODE CTCP_set_tx_frane_to_dssc(DS_StreamConfig* p_stream_config,
+                                      const CommonTlmCmdPacket* send_packet);
+
+/**
+ * @brief  C2A 間通信など， CTP をコンポ間通信に用いるときの tx_frame のセット
+ * @param[in]  p_stream_config: DriverSuper 構造体の DS_StreamConfig
+ * @param[in]  send_packet: 送信するパケット
+ * @retval DS_ERR_CODE_OK:  正常終了
+ * @retval DS_ERR_CODE_ERR: DSSC 内部の設定不足などのエラー
+ */
+DS_ERR_CODE CTP_set_tx_frane_to_dssc(DS_StreamConfig* p_stream_config,
+                                     const CommonTlmPacket* send_packet);
+
+/**
+ * @brief  C2A 間通信など， CCP をコンポ間通信に用いるときの tx_frame のセット
+ * @param[in]  p_stream_config: DriverSuper 構造体の DS_StreamConfig
+ * @param[in]  send_packet: 送信するパケット
+ * @retval DS_ERR_CODE_OK:  正常終了
+ * @retval DS_ERR_CODE_ERR: DSSC 内部の設定不足などのエラー
+ */
+DS_ERR_CODE CCP_set_tx_frane_to_dssc(DS_StreamConfig* p_stream_config,
+                                     const CommonCmdPacket* send_packet);
 
 #endif

--- a/Drivers/Protocol/common_tlm_cmd_packet_for_driver_super.h
+++ b/Drivers/Protocol/common_tlm_cmd_packet_for_driver_super.h
@@ -42,6 +42,23 @@ DS_ERR_CODE CTP_get_ctp_from_dssc(const DS_StreamConfig* p_stream_config, Common
  */
 DS_ERR_CODE CCP_get_ccp_from_dssc(const DS_StreamConfig* p_stream_config, CommonCmdPacket* received_packet);
 
+/**
+ * @brief  C2A 間通信など， CTCP をコンポ間通信に用いるとき，DS_init で渡す初期化関数内部用の Init Util
+ *
+ *         これを呼び出すと，まるっと DSSC の初期設定ができる．
+ * @note   DSSC_enable は Driver 側でやること
+ * @param[in]  p_stream_config: DriverSuper 構造体の DS_StreamConfig
+ * @param[in]  tx_frame_buffer: コマンドフレーム（送信フレーム）のバッファ
+ * @param[in]  tx_frame_buffer_size: バッファサイズ
+ * @param[in]  data_analyzer: DSSC_set_data_analyzer で渡すための data_analyzer
+ * @retval DS_ERR_CODE_OK:  正常終了
+ * @retval DS_ERR_CODE_ERR: フレームバッファのサイズ不足などのエラー
+ */
+DS_ERR_CODE CTCP_init_dssc(DS_StreamConfig* p_stream_config,
+                           uint8_t* tx_frame_buffer,
+                           int16_t tx_frame_buffer_size,
+                           DS_ERR_CODE (*data_analyzer)(DS_StreamConfig* p_stream_config, void* p_driver));
+
 // TODO: aobc.c の TODO 時に実装（標準処理の共通化）
 // DS_ERR_CODE CTCP_set_tx_frane_to_dssc(const DS_StreamConfig* p_stream_config,
 //                                       const CommonTlmCmdPacket* send_packet);

--- a/Drivers/Protocol/common_tlm_cmd_packet_for_driver_super.h
+++ b/Drivers/Protocol/common_tlm_cmd_packet_for_driver_super.h
@@ -66,7 +66,7 @@ DS_ERR_CODE CTCP_init_dssc(DS_StreamConfig* p_stream_config,
  * @retval DS_ERR_CODE_OK:  正常終了
  * @retval DS_ERR_CODE_ERR: DSSC 内部の設定不足などのエラー
  */
-DS_ERR_CODE CTCP_set_tx_frane_to_dssc(DS_StreamConfig* p_stream_config,
+DS_ERR_CODE CTCP_set_tx_frame_to_dssc(DS_StreamConfig* p_stream_config,
                                       const CommonTlmCmdPacket* send_packet);
 
 /**
@@ -76,7 +76,7 @@ DS_ERR_CODE CTCP_set_tx_frane_to_dssc(DS_StreamConfig* p_stream_config,
  * @retval DS_ERR_CODE_OK:  正常終了
  * @retval DS_ERR_CODE_ERR: DSSC 内部の設定不足などのエラー
  */
-DS_ERR_CODE CTP_set_tx_frane_to_dssc(DS_StreamConfig* p_stream_config,
+DS_ERR_CODE CTP_set_tx_frame_to_dssc(DS_StreamConfig* p_stream_config,
                                      const CommonTlmPacket* send_packet);
 
 /**
@@ -86,7 +86,7 @@ DS_ERR_CODE CTP_set_tx_frane_to_dssc(DS_StreamConfig* p_stream_config,
  * @retval DS_ERR_CODE_OK:  正常終了
  * @retval DS_ERR_CODE_ERR: DSSC 内部の設定不足などのエラー
  */
-DS_ERR_CODE CCP_set_tx_frane_to_dssc(DS_StreamConfig* p_stream_config,
+DS_ERR_CODE CCP_set_tx_frame_to_dssc(DS_StreamConfig* p_stream_config,
                                      const CommonCmdPacket* send_packet);
 
 #endif

--- a/Drivers/Protocol/eb90_packet_for_driver_super.h
+++ b/Drivers/Protocol/eb90_packet_for_driver_super.h
@@ -68,6 +68,6 @@ uint32_t EB90_PACKET_get_id_from_dssc(const DS_StreamConfig* p_stream_config);
 const uint8_t* EB90_PACKET_get_user_data_head_from_dssc(const DS_StreamConfig* p_stream_config);
 
 // TODO: dssc の tx_frame に packet を EB90 frame につめてから挿入する関数を作る
-//       CTCP_set_tx_frane_to_dssc の EB90 packet 用
+//       CTCP_set_tx_frame_to_dssc の EB90 packet 用
 
 #endif

--- a/Drivers/Super/driver_super.c
+++ b/Drivers/Super/driver_super.c
@@ -1270,13 +1270,14 @@ static DS_ERR_CODE DS_reset_stream_config_(DS_StreamConfig* p_stream_config)
   p_stream_config->req_tlm_cmd_tx_time_ = TMGR_get_master_clock();
   p_stream_config->rx_frame_fix_time_   = TMGR_get_master_clock();
 
-  p_stream_config->tx_frame_       = NULL;
-  p_stream_config->tx_frame_size_  = 0;
-  p_stream_config->rx_header_      = NULL;
-  p_stream_config->rx_header_size_ = 0;
-  p_stream_config->rx_footer_      = NULL;
-  p_stream_config->rx_footer_size_ = 0;
-  p_stream_config->rx_frame_size_  = 0;
+  p_stream_config->tx_frame_             = NULL;
+  p_stream_config->tx_frame_size_        = 0;
+  p_stream_config->tx_frame_buffer_size_ = -1;
+  p_stream_config->rx_header_            = NULL;
+  p_stream_config->rx_header_size_       = 0;
+  p_stream_config->rx_footer_            = NULL;
+  p_stream_config->rx_footer_size_       = 0;
+  p_stream_config->rx_frame_size_        = 0;
 
   p_stream_config->rx_framelength_pos_       = -1;
   p_stream_config->rx_framelength_type_size_ = 0;
@@ -1524,6 +1525,16 @@ void DSSC_set_tx_frame(DS_StreamConfig* p_stream_config,
   p_stream_config->is_validation_needed_for_send_ = 1;
 }
 
+const uint8_t* DSSC_get_tx_frame(DS_StreamConfig* p_stream_config)
+{
+  return p_stream_config->tx_frame_;
+}
+
+uint8_t* DSSC_get_tx_frame_as_non_const_pointer(DS_StreamConfig* p_stream_config)
+{
+  return p_stream_config->tx_frame_;
+}
+
 void DSSC_set_tx_frame_size(DS_StreamConfig* p_stream_config,
                             const uint16_t tx_frame_size)
 {
@@ -1534,6 +1545,18 @@ void DSSC_set_tx_frame_size(DS_StreamConfig* p_stream_config,
 uint16_t DSSC_get_tx_frame_size(const DS_StreamConfig* p_stream_config)
 {
   return (uint16_t)p_stream_config->tx_frame_size_;
+}
+
+void DSSC_set_tx_frame_buffer_size(DS_StreamConfig* p_stream_config,
+                                   const int16_t tx_frame_buffer_size)
+{
+  p_stream_config->tx_frame_buffer_size_ = tx_frame_buffer_size;
+  p_stream_config->is_validation_needed_for_send_ = 1;
+}
+
+int16_t DSSC_get_tx_frame_buffer_size(DS_StreamConfig* p_stream_config)
+{
+  return (int16_t)p_stream_config->tx_frame_buffer_size_;
 }
 
 const uint8_t* DSSC_get_rx_frame(const DS_StreamConfig* p_stream_config)

--- a/Drivers/Super/driver_super.c
+++ b/Drivers/Super/driver_super.c
@@ -1330,6 +1330,11 @@ static DS_ERR_CODE DS_validate_stream_config_(DS_StreamConfig* p_stream_config)
 
   if (p_stream_config->rx_frame_size_ > DS_RX_FRAME_SIZE_MAX) return DS_ERR_CODE_ERR;   // [TODO] 現在はBigData未実装（詳細はヘッダファイル参照）のため，ここで弾く
 
+  if (p_stream_config->tx_frame_buffer_size_ >= 0)
+  {
+    if (p_stream_config->tx_frame_size_ > p_stream_config->tx_frame_buffer_size_) return DS_ERR_CODE_ERR;
+  }
+
   if (p_stream_config->rx_frame_size_ < 0)
   {
     // テレメトリ可変長

--- a/Drivers/Super/driver_super.h
+++ b/Drivers/Super/driver_super.h
@@ -262,9 +262,14 @@ struct DS_StreamConfig
   ObcTime  req_tlm_cmd_tx_time_;                            //!< テレメ要求コマンド最終送信時刻
   ObcTime  rx_frame_fix_time_;                              //!< フレーム確定時刻
 
-  uint8_t  *tx_frame_;                                      //!< コマンドフレーム
+  uint8_t* tx_frame_;                                       //!< コマンドフレーム
   uint16_t tx_frame_size_;                                  /*!< コマンドフレームサイズ
+                                                                 tx_frame_ のうち実際に送信するバイト数
                                                                  送信データがない場合は 0 */
+  int16_t  tx_frame_buffer_size_;                           /*!< 与えた tx_frame_ の最大サイズ
+                                                                 Drivers/Protocol などで， Util が tx_frame_ を使うときに使用
+                                                                 Protocol を使うときは設定しておくと良い（一部の関数は設定しないと使えない）
+                                                                 未指定の場合は負数とする */
 
   uint8_t  rx_frame_[DS_RX_FRAME_SIZE_MAX];                 /*!< データ受信フレームバッファ
                                                                  DS_RX_FRAME_SIZE_MAX を超えるような巨大なフレーム（ビッグデータ）には未対応（将来実装予定）
@@ -277,7 +282,7 @@ struct DS_StreamConfig
                                                                  ヘッダがなく，可変長の場合は，受信前（例えば DS_send_req_tlm_cmd 呼び出し前） に
                                                                  rx_frame_size_ を設定することで固定長のように扱うことで対応する．
                                                                  また，初期化時の Validation を通すためにも，初期値は適切な正数にしておくこと */
-  const uint8_t  *rx_footer_;                               //!< 受信データのフッタ
+  const uint8_t* rx_footer_;                                //!< 受信データのフッタ
   uint16_t rx_footer_size_;                                 /*!< 受信データのフッタサイズ
                                                                  ヘッダがない場合は0に設定 */
   int16_t  rx_frame_size_;                                  /*!< 受信データ（テレメトリ）フレームサイズ
@@ -339,7 +344,7 @@ struct DriverSuper
 {
   // 【継承先まで公開】
   IF_LIST_ENUM      interface;                              //!< 継承先の機器の使用IF
-  void              *if_config;                             //!< IF設定
+  void*             if_config;                              //!< IF設定
 
   DS_Config         config;                                 //!< DriverSuperの設定
 
@@ -485,10 +490,16 @@ const ObcTime* DSSC_get_general_cmd_tx_time(const DS_StreamConfig* p_stream_conf
 const ObcTime* DSSC_get_req_tlm_cmd_tx_time(const DS_StreamConfig* p_stream_config);
 const ObcTime* DSSC_get_rx_frame_fix_time(const DS_StreamConfig* p_stream_config);
 
-void DSSC_set_tx_frame(DS_StreamConfig* p_stream_config, uint8_t* tx_frame);
+void DSSC_set_tx_frame(DS_StreamConfig* p_stream_config,
+                       uint8_t* tx_frame);
+const uint8_t* DSSC_get_tx_frame(DS_StreamConfig* p_stream_config);
+uint8_t* DSSC_get_tx_frame_as_non_const_pointer(DS_StreamConfig* p_stream_config);
 void DSSC_set_tx_frame_size(DS_StreamConfig* p_stream_config,
                             const uint16_t tx_frame_size);
 uint16_t DSSC_get_tx_frame_size(const DS_StreamConfig* p_stream_config);
+void DSSC_set_tx_frame_buffer_size(DS_StreamConfig* p_stream_config,
+                                   const int16_t tx_frame_buffer_size);
+int16_t DSSC_get_tx_frame_buffer_size(DS_StreamConfig* p_stream_config);
 
 const uint8_t* DSSC_get_rx_frame(const DS_StreamConfig* p_stream_config);
 void DSSC_set_rx_header(DS_StreamConfig* p_stream_config,

--- a/Examples/2nd_obc_user/src/src_user/Drivers/Etc/mobc.c
+++ b/Examples/2nd_obc_user/src/src_user/Drivers/Etc/mobc.c
@@ -128,36 +128,11 @@ DS_CMD_ERR_CODE MOBC_send(MOBC_Driver* mobc_driver, const CommonTlmPacket* packe
 {
   DS_ERR_CODE ret;
   DS_StreamConfig* p_stream_config;
-  uint16_t    ctp_len;
-  uint16_t    crc;
-  size_t      pos;
-  size_t      size;
 
   p_stream_config = &(mobc_driver->driver.super.stream_config[MOBC_STREAM_TLM_CMD]);
 
-  // tx_frame の設定
-  ctp_len = CTP_get_packet_len(packet);
-  DSSC_set_tx_frame_size(p_stream_config,
-                         (uint16_t)(ctp_len + EB90_FRAME_HEADER_SIZE + EB90_FRAME_FOOTER_SIZE));
-
-  pos  = 0;
-  size = EB90_FRAME_STX_SIZE;
-  memcpy(&(MOBC_tx_frame_[pos]), EB90_FRAME_kStx, size);
-  pos += size;
-  size = EB90_FRAME_LEN_SIZE;
-  endian_memcpy(&(MOBC_tx_frame_[pos]), &ctp_len, size);       // ここはエンディアンを気にする！
-  pos += size;
-  size = (size_t)ctp_len;
-  memcpy(&(MOBC_tx_frame_[pos]), packet->packet, size);
-  pos += size;
-
-  crc = EB90_FRAME_calc_crc(MOBC_tx_frame_ + EB90_FRAME_HEADER_SIZE, pos - EB90_FRAME_HEADER_SIZE);
-
-  size = EB90_FRAME_CRC_SIZE;
-  endian_memcpy(&(MOBC_tx_frame_[pos]), &crc, size);       // ここはエンディアンを気にする！
-  pos += size;
-  size = EB90_FRAME_ETX_SIZE;
-  memcpy(&(MOBC_tx_frame_[pos]), EB90_FRAME_kEtx, size);
+  // tx_frameの設定
+  CTP_set_tx_frane_to_dssc(p_stream_config, packet);
 
   ret = DS_send_general_cmd(&(mobc_driver->driver.super), MOBC_STREAM_TLM_CMD);
 

--- a/Examples/2nd_obc_user/src/src_user/Drivers/Etc/mobc.c
+++ b/Examples/2nd_obc_user/src/src_user/Drivers/Etc/mobc.c
@@ -132,7 +132,7 @@ DS_CMD_ERR_CODE MOBC_send(MOBC_Driver* mobc_driver, const CommonTlmPacket* packe
   p_stream_config = &(mobc_driver->driver.super.stream_config[MOBC_STREAM_TLM_CMD]);
 
   // tx_frameの設定
-  CTP_set_tx_frane_to_dssc(p_stream_config, packet);
+  CTP_set_tx_frame_to_dssc(p_stream_config, packet);
 
   ret = DS_send_general_cmd(&(mobc_driver->driver.super), MOBC_STREAM_TLM_CMD);
 

--- a/Examples/2nd_obc_user/src/src_user/Drivers/Etc/mobc.c
+++ b/Examples/2nd_obc_user/src/src_user/Drivers/Etc/mobc.c
@@ -10,6 +10,7 @@
 #include <src_core/TlmCmd/common_tlm_cmd_packet.h>
 #include <src_core/Library/endian_memcpy.h>
 #include <src_core/Drivers/Protocol/eb90_frame_for_driver_super.h>
+#include <src_core/Drivers/Protocol/common_tlm_cmd_packet_for_driver_super.h>
 #include <string.h>
 
 #define MOBC_STREAM_TLM_CMD   (0)   //!< テレコマで使うストリーム
@@ -51,23 +52,12 @@ static DS_ERR_CODE MOBC_load_driver_super_init_settings_(DriverSuper* p_super)
 
   // stream は 0 のみ
   p_stream_config = &(p_super->stream_config[MOBC_STREAM_TLM_CMD]);
-  DSSC_enable(p_stream_config);
 
-  // 送信はする
-  DSSC_set_tx_frame(p_stream_config, MOBC_tx_frame_);  // 送る直前に中身を memcpy する
-  DSSC_set_tx_frame_size(p_stream_config, 0);          // 送る直前に値をセットする
-
-  // 定期的な受信はする
-  DSSC_set_rx_header(p_stream_config, EB90_FRAME_kStx, EB90_FRAME_STX_SIZE);
-  DSSC_set_rx_footer(p_stream_config, EB90_FRAME_kEtx, EB90_FRAME_ETX_SIZE);
-  DSSC_set_rx_frame_size(p_stream_config, -1);    // 可変
-  DSSC_set_rx_framelength_pos(p_stream_config, EB90_FRAME_STX_SIZE);
-  DSSC_set_rx_framelength_type_size(p_stream_config, 2);
-  DSSC_set_rx_framelength_offset(p_stream_config,
-                                 EB90_FRAME_HEADER_SIZE + EB90_FRAME_FOOTER_SIZE);
-  DSSC_set_data_analyzer(p_stream_config, MOBC_analyze_rec_data_);
+  CTCP_init_dssc(p_stream_config, MOBC_tx_frame_, sizeof(MOBC_tx_frame_), MOBC_analyze_rec_data_);
 
   // 定期 TLM の監視機能の有効化しない → ので設定上書きなし
+
+  DSSC_enable(p_stream_config);
 
   return DS_ERR_CODE_OK;
 }

--- a/Examples/2nd_obc_user/src/src_user/Drivers/Etc/mobc.h
+++ b/Examples/2nd_obc_user/src/src_user/Drivers/Etc/mobc.h
@@ -9,7 +9,6 @@
 #include <src_core/Drivers/Super/driver_super.h>
 #include <src_core/System/TimeManager/obc_time.h>
 #include <src_core/TlmCmd/common_tlm_packet.h>
-#include <src_core/Drivers/Protocol/common_tlm_cmd_packet_for_driver_super.h>
 #include <src_core/TlmCmd/packet_handler.h>
 
 /**

--- a/Examples/minimum_user/src/src_user/Drivers/Aocs/aobc.c
+++ b/Examples/minimum_user/src/src_user/Drivers/Aocs/aobc.c
@@ -131,37 +131,11 @@ DS_CMD_ERR_CODE AOBC_send_cmd(AOBC_Driver* aobc_driver, const CommonCmdPacket* p
   DS_ERR_CODE ret;
   DS_StreamConfig* p_stream_config;
   AOBC_CMD_CODE cmd_code;
-  uint16_t      ccp_len;
-  uint16_t      crc;
-  size_t        pos;
-  size_t        size;
 
   p_stream_config = &(aobc_driver->driver.super.stream_config[AOBC_STREAM_TLM_CMD]);
 
-  // TODO: 標準なので， Util を common_tlm_cmd_packet_for_driver_super.c で整備
   // tx_frameの設定
-  ccp_len = CCP_get_packet_len(packet);
-  DSSC_set_tx_frame_size(p_stream_config,
-                         (uint16_t)(ccp_len + EB90_FRAME_HEADER_SIZE + EB90_FRAME_FOOTER_SIZE));
-
-  pos  = 0;
-  size = EB90_FRAME_STX_SIZE;
-  memcpy(&(AOBC_tx_frame_[pos]), EB90_FRAME_kStx, size);
-  pos += size;
-  size = EB90_FRAME_LEN_SIZE;
-  endian_memcpy(&(AOBC_tx_frame_[pos]), &ccp_len, size);       // ここはエンディアンを気にする！
-  pos += size;
-  size = (size_t)ccp_len;
-  memcpy(&(AOBC_tx_frame_[pos]), packet->packet, size);
-  pos += size;
-
-  crc = EB90_FRAME_calc_crc(AOBC_tx_frame_ + EB90_FRAME_HEADER_SIZE, pos - EB90_FRAME_HEADER_SIZE);
-
-  size = EB90_FRAME_CRC_SIZE;
-  endian_memcpy(&(AOBC_tx_frame_[pos]), &crc, size);       // ここはエンディアンを気にする！
-  pos += size;
-  size = EB90_FRAME_ETX_SIZE;
-  memcpy(&(AOBC_tx_frame_[pos]), EB90_FRAME_kEtx, size);
+  CCP_set_tx_frane_to_dssc(p_stream_config, packet);
 
   cmd_code = (AOBC_CMD_CODE)CCP_get_id(packet);
 

--- a/Examples/minimum_user/src/src_user/Drivers/Aocs/aobc.c
+++ b/Examples/minimum_user/src/src_user/Drivers/Aocs/aobc.c
@@ -135,7 +135,7 @@ DS_CMD_ERR_CODE AOBC_send_cmd(AOBC_Driver* aobc_driver, const CommonCmdPacket* p
   p_stream_config = &(aobc_driver->driver.super.stream_config[AOBC_STREAM_TLM_CMD]);
 
   // tx_frameの設定
-  CCP_set_tx_frane_to_dssc(p_stream_config, packet);
+  CCP_set_tx_frame_to_dssc(p_stream_config, packet);
 
   cmd_code = (AOBC_CMD_CODE)CCP_get_id(packet);
 

--- a/Examples/minimum_user/src/src_user/Drivers/Aocs/aobc.c
+++ b/Examples/minimum_user/src/src_user/Drivers/Aocs/aobc.c
@@ -11,6 +11,7 @@
 #include <src_core/TlmCmd/common_cmd_packet.h>
 #include <src_core/Library/endian_memcpy.h>
 #include <src_core/Drivers/Protocol/eb90_frame_for_driver_super.h>
+#include <src_core/Drivers/Protocol/common_tlm_cmd_packet_for_driver_super.h>
 #include <string.h>
 
 #define AOBC_STREAM_TLM_CMD   (0)   //!< テレコマで使うストリーム
@@ -51,26 +52,14 @@ static DS_ERR_CODE AOBC_load_driver_super_init_settings_(DriverSuper* p_super)
 
   p_super->interface = UART;
 
-  // streamは0のみ
+  // stream は 0 のみ
   p_stream_config = &(p_super->stream_config[AOBC_STREAM_TLM_CMD]);
-  DSSC_enable(p_stream_config);
 
-  // 送信はする
-  DSSC_set_tx_frame(p_stream_config, AOBC_tx_frame_);  // 送る直前に中身を memcpy する
-  DSSC_set_tx_frame_size(p_stream_config, 0);          // 送る直前に値をセットする
-
-  // TODO: 標準なので， Util を common_tlm_cmd_packet_for_driver_super.c で整備
-  // 定期的な受信はする
-  DSSC_set_rx_header(p_stream_config, EB90_FRAME_kStx, EB90_FRAME_STX_SIZE);
-  DSSC_set_rx_footer(p_stream_config, EB90_FRAME_kEtx, EB90_FRAME_ETX_SIZE);
-  DSSC_set_rx_frame_size(p_stream_config, -1);    // 可変
-  DSSC_set_rx_framelength_pos(p_stream_config, EB90_FRAME_STX_SIZE);
-  DSSC_set_rx_framelength_type_size(p_stream_config, 2);
-  DSSC_set_rx_framelength_offset(p_stream_config,
-                                 EB90_FRAME_HEADER_SIZE + EB90_FRAME_FOOTER_SIZE);
-  DSSC_set_data_analyzer(p_stream_config, AOBC_analyze_rec_data_);
+  CTCP_init_dssc(p_stream_config, AOBC_tx_frame_, sizeof(AOBC_tx_frame_), AOBC_analyze_rec_data_);
 
   // 定期 TLM の監視機能の有効化しない → ので設定上書きなし
+
+  DSSC_enable(p_stream_config);
 
   return DS_ERR_CODE_OK;
 }


### PR DESCRIPTION
## 概要
C2A間通信など， CTCP on EB90 frame のコンポ間通信の Driver を書きやすくする Util を整備

## Issue
- https://github.com/ut-issl/c2a-core/issues/400

## 詳細
see diff

## 検証結果
minimum_user と 2nd_obc_user のテストが全て通った

