### PR TITLE
Cmd の返り値を CCP_EXEC_STS から CCP_CmdRet に

### DIFF
--- a/Applications/TestApp/test_ccp_util.c
+++ b/Applications/TestApp/test_ccp_util.c
@@ -8,7 +8,7 @@
 #include "../../TlmCmd/common_cmd_packet_util.h"
 #include <src_user/TlmCmd/command_definitions.h>
 
-CCP_EXEC_STS Cmd_TEST_CCP_REGISTER_TLC_ASAP(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_TEST_CCP_REGISTER_TLC_ASAP(const CommonCmdPacket* packet)
 {
   cycle_t ti = CCP_get_param_from_packet(packet, 0, cycle_t);
   PH_ACK ack = CCP_register_tlc_asap(ti, TLCD_ID_FROM_GS, Cmd_CODE_NOP, NULL, 0);
@@ -17,7 +17,7 @@ CCP_EXEC_STS Cmd_TEST_CCP_REGISTER_TLC_ASAP(const CommonCmdPacket* packet)
   return CCP_EXEC_SUCCESS;
 }
 
-CCP_EXEC_STS Cmd_TEST_CCP_GET_RAW_PARAM_INFO(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_TEST_CCP_GET_RAW_PARAM_INFO(const CommonCmdPacket* packet)
 {
   uint16_t len = CCP_get_param_from_packet(packet, 0, uint16_t);
   uint8_t first_data = CCP_get_param_from_packet(packet, 1, uint8_t);

--- a/Applications/TestApp/test_ccp_util.c
+++ b/Applications/TestApp/test_ccp_util.c
@@ -14,7 +14,7 @@ CCP_CmdRet Cmd_TEST_CCP_REGISTER_TLC_ASAP(const CommonCmdPacket* packet)
   PH_ACK ack = CCP_register_tlc_asap(ti, TLCD_ID_FROM_GS, Cmd_CODE_NOP, NULL, 0);
   if (ack != PH_ACK_TLC_SUCCESS) return CCP_EXEC_ILLEGAL_CONTEXT;
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 CCP_CmdRet Cmd_TEST_CCP_GET_RAW_PARAM_INFO(const CommonCmdPacket* packet)
@@ -38,7 +38,7 @@ CCP_CmdRet Cmd_TEST_CCP_GET_RAW_PARAM_INFO(const CommonCmdPacket* packet)
   if (len == 0)
   {
     // raw param なし
-    return CCP_EXEC_SUCCESS;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   }
 
   data = CCP_get_raw_param_head(packet);
@@ -47,7 +47,7 @@ CCP_CmdRet Cmd_TEST_CCP_GET_RAW_PARAM_INFO(const CommonCmdPacket* packet)
     return CCP_EXEC_ILLEGAL_CONTEXT;
   }
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 #pragma section

--- a/Applications/TestApp/test_ccp_util.c
+++ b/Applications/TestApp/test_ccp_util.c
@@ -12,7 +12,7 @@ CCP_CmdRet Cmd_TEST_CCP_REGISTER_TLC_ASAP(const CommonCmdPacket* packet)
 {
   cycle_t ti = CCP_get_param_from_packet(packet, 0, cycle_t);
   PH_ACK ack = CCP_register_tlc_asap(ti, TLCD_ID_FROM_GS, Cmd_CODE_NOP, NULL, 0);
-  if (ack != PH_ACK_TLC_SUCCESS) return CCP_EXEC_ILLEGAL_CONTEXT;
+  if (ack != PH_ACK_TLC_SUCCESS) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
 
   return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
@@ -26,13 +26,13 @@ CCP_CmdRet Cmd_TEST_CCP_GET_RAW_PARAM_INFO(const CommonCmdPacket* packet)
   // CCP_get_raw_param_head の test
   if (CCP_get_raw_param_head(packet) != CCP_get_param_head(packet) + sizeof(uint16_t) + sizeof(uint8_t))
   {
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   }
 
   // len チェック
   if (CCP_get_raw_param_len(packet) != len)
   {
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   }
 
   if (len == 0)
@@ -44,7 +44,7 @@ CCP_CmdRet Cmd_TEST_CCP_GET_RAW_PARAM_INFO(const CommonCmdPacket* packet)
   data = CCP_get_raw_param_head(packet);
   if (data[0] != first_data)
   {
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   }
 
   return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);

--- a/Applications/TestApp/test_ccp_util.h
+++ b/Applications/TestApp/test_ccp_util.h
@@ -7,7 +7,7 @@
 
 #include "../../TlmCmd/common_cmd_packet.h"
 
-CCP_EXEC_STS Cmd_TEST_CCP_REGISTER_TLC_ASAP(const CommonCmdPacket* packet);
-CCP_EXEC_STS Cmd_TEST_CCP_GET_RAW_PARAM_INFO(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_TEST_CCP_REGISTER_TLC_ASAP(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_TEST_CCP_GET_RAW_PARAM_INFO(const CommonCmdPacket* packet);
 
 #endif

--- a/Applications/anomaly_handler.c
+++ b/Applications/anomaly_handler.c
@@ -264,7 +264,7 @@ CCP_CmdRet Cmd_AH_REGISTER_RULE(const CommonCmdPacket* packet)
   if (CCP_get_param_len(packet) != (5 + SIZE_OF_BCT_ID_T))
   {
     // パラメータ長確認(6Bytes)
-    return CCP_EXEC_ILLEGAL_LENGTH;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_LENGTH);
   }
   else if (param[ID] >= AH_MAX_RULES)
   {

--- a/Applications/anomaly_handler.c
+++ b/Applications/anomaly_handler.c
@@ -252,7 +252,7 @@ static void AH_print_ah_status_(void)
 }
 
 
-CCP_EXEC_STS Cmd_AH_REGISTER_RULE(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_AH_REGISTER_RULE(const CommonCmdPacket* packet)
 {
   enum
   {
@@ -297,7 +297,7 @@ static void AH_add_rule_(size_t id, const AH_Rule* ahr)
 }
 
 
-CCP_EXEC_STS Cmd_AH_ACTIVATE_RULE(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_AH_ACTIVATE_RULE(const CommonCmdPacket* packet)
 {
   const uint8_t* param = CCP_get_param_head(packet);
   size_t id;
@@ -321,7 +321,7 @@ void AH_activate_rule(size_t id)
 }
 
 
-CCP_EXEC_STS Cmd_AH_INACTIVATE_RULE(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_AH_INACTIVATE_RULE(const CommonCmdPacket* packet)
 {
   const uint8_t* param = CCP_get_param_head(packet);
   size_t id;
@@ -344,7 +344,7 @@ void AH_inactivate_rule(size_t id)
 }
 
 
-CCP_EXEC_STS Cmd_AH_CLEAR_LOG(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_AH_CLEAR_LOG(const CommonCmdPacket* packet)
 {
   (void)packet;
   AH_clear_log_();
@@ -366,7 +366,7 @@ static void AH_clear_log_(void)
 }
 
 
-CCP_EXEC_STS Cmd_AH_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_AH_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet)
 {
   uint8_t page;
 
@@ -395,7 +395,7 @@ static void AH_respond_log_clear(void)
 }
 
 
-CCP_EXEC_STS Cmd_AHRES_LOG_CLEAR(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_AHRES_LOG_CLEAR(const CommonCmdPacket* packet)
 {
   (void)packet;
   AH_respond_log_clear();
@@ -403,7 +403,7 @@ CCP_EXEC_STS Cmd_AHRES_LOG_CLEAR(const CommonCmdPacket* packet)
 }
 
 
-CCP_EXEC_STS Cmd_AHRES_LOG_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_AHRES_LOG_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet)
 {
   uint8_t page;
 

--- a/Applications/anomaly_handler.c
+++ b/Applications/anomaly_handler.c
@@ -269,12 +269,12 @@ CCP_CmdRet Cmd_AH_REGISTER_RULE(const CommonCmdPacket* packet)
   else if (param[ID] >= AH_MAX_RULES)
   {
     // 登録指定位置が許容範囲外
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   }
   else if (param[COND] > AH_CUMULATE)
   {
     // 判定条件が定義されたものと一致しない
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   }
 
   ahr.code.group = (uint32_t)param[GROUP];
@@ -306,7 +306,7 @@ CCP_CmdRet Cmd_AH_ACTIVATE_RULE(const CommonCmdPacket* packet)
   if (id >= AH_MAX_RULES)
   {
     // 指定位置が範囲外
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   }
 
   AH_activate_rule(id);
@@ -330,7 +330,7 @@ CCP_CmdRet Cmd_AH_INACTIVATE_RULE(const CommonCmdPacket* packet)
   if (id >= AH_MAX_RULES)
   {
     // 指定位置が範囲外
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   }
 
   AH_inactivate_rule(id);
@@ -375,7 +375,7 @@ CCP_CmdRet Cmd_AH_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet)
   if (page >= AH_TLM_PAGE_MAX)
   {
     // ページ番号がコマンドテーブル範囲外
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   }
 
   anomaly_handler_.page_no = page;
@@ -412,7 +412,7 @@ CCP_CmdRet Cmd_AHRES_LOG_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet)
   if (page >= AH_LOG_TLM_PAGE_MAX)
   {
     // ページ番号がコマンドテーブル範囲外
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   }
 
   AH_respond_log_.page_no = page;

--- a/Applications/anomaly_handler.c
+++ b/Applications/anomaly_handler.c
@@ -285,7 +285,7 @@ CCP_CmdRet Cmd_AH_REGISTER_RULE(const CommonCmdPacket* packet)
 
   AH_add_rule_((size_t)param[ID], &ahr);
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
@@ -310,7 +310,7 @@ CCP_CmdRet Cmd_AH_ACTIVATE_RULE(const CommonCmdPacket* packet)
   }
 
   AH_activate_rule(id);
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
@@ -334,7 +334,7 @@ CCP_CmdRet Cmd_AH_INACTIVATE_RULE(const CommonCmdPacket* packet)
   }
 
   AH_inactivate_rule(id);
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
@@ -348,7 +348,7 @@ CCP_CmdRet Cmd_AH_CLEAR_LOG(const CommonCmdPacket* packet)
 {
   (void)packet;
   AH_clear_log_();
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
@@ -379,7 +379,7 @@ CCP_CmdRet Cmd_AH_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet)
   }
 
   anomaly_handler_.page_no = page;
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
@@ -399,7 +399,7 @@ CCP_CmdRet Cmd_AHRES_LOG_CLEAR(const CommonCmdPacket* packet)
 {
   (void)packet;
   AH_respond_log_clear();
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
@@ -416,7 +416,7 @@ CCP_CmdRet Cmd_AHRES_LOG_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet)
   }
 
   AH_respond_log_.page_no = page;
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 

--- a/Applications/anomaly_handler.h
+++ b/Applications/anomaly_handler.h
@@ -95,19 +95,19 @@ void AH_inactivate_rule(size_t id);
 // こいつは初期化時に使われるので，選択制にした
 void AH_add_rule(size_t id, const AH_Rule* ahr, uint8_t is_active);
 
-CCP_EXEC_STS Cmd_AH_REGISTER_RULE(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_AH_REGISTER_RULE(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_AH_ACTIVATE_RULE(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_AH_ACTIVATE_RULE(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_AH_INACTIVATE_RULE(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_AH_INACTIVATE_RULE(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_AH_CLEAR_LOG(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_AH_CLEAR_LOG(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_AH_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_AH_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_AHRES_LOG_CLEAR(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_AHRES_LOG_CLEAR(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_AHRES_LOG_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_AHRES_LOG_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet);
 
 #endif
 #endif

--- a/Applications/divided_cmd_utility.c
+++ b/Applications/divided_cmd_utility.c
@@ -291,7 +291,7 @@ CCP_CmdRet Cmd_DCU_ABORT_CMD(const CommonCmdPacket* packet)
 
   DCU_abort_cmd(target_cmd);
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
@@ -302,7 +302,7 @@ CCP_CmdRet Cmd_DCU_DOWN_ABORT_FLAG(const CommonCmdPacket* packet)
 
   DCU_donw_abort_flag(target_cmd);
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
@@ -312,7 +312,7 @@ CCP_CmdRet Cmd_DCU_CLEAR_LOG(const CommonCmdPacket* packet)
 
   DCU_clear_log_();
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 #pragma section

--- a/Applications/divided_cmd_utility.c
+++ b/Applications/divided_cmd_utility.c
@@ -284,7 +284,7 @@ DCU_LOG_ACK DCU_search_and_get_log(CMD_CODE cmd_code, const DCU_ExecStatus* exec
 }
 
 
-CCP_EXEC_STS Cmd_DCU_ABORT_CMD(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_DCU_ABORT_CMD(const CommonCmdPacket* packet)
 {
   // CMD_CODE は u16 と想定する
   CMD_CODE target_cmd = (CMD_CODE)CCP_get_param_from_packet(packet, 0, uint16_t);
@@ -295,7 +295,7 @@ CCP_EXEC_STS Cmd_DCU_ABORT_CMD(const CommonCmdPacket* packet)
 }
 
 
-CCP_EXEC_STS Cmd_DCU_DOWN_ABORT_FLAG(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_DCU_DOWN_ABORT_FLAG(const CommonCmdPacket* packet)
 {
   // CMD_CODE は u16 と想定する
   CMD_CODE target_cmd = (CMD_CODE)CCP_get_param_from_packet(packet, 0, uint16_t);
@@ -306,7 +306,7 @@ CCP_EXEC_STS Cmd_DCU_DOWN_ABORT_FLAG(const CommonCmdPacket* packet)
 }
 
 
-CCP_EXEC_STS Cmd_DCU_CLEAR_LOG(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_DCU_CLEAR_LOG(const CommonCmdPacket* packet)
 {
   (void)packet;
 

--- a/Applications/divided_cmd_utility.h
+++ b/Applications/divided_cmd_utility.h
@@ -161,17 +161,17 @@ DCU_LOG_ACK DCU_search_and_get_log(CMD_CODE cmd_code, const DCU_ExecStatus* exec
  * @brief 実行中の分割コマンドを停止する
  * @note  もし，指定した Cmd が実行中ではなくても CCP_EXEC_SUCCESS を返す
  */
-CCP_EXEC_STS Cmd_DCU_ABORT_CMD(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_DCU_ABORT_CMD(const CommonCmdPacket* packet);
 
 /**
  * @brief エラー，またはコマンドによって中断ステータスとなっているコマンドを，実行可能状態に戻す
  * @note  もし，指定した Cmd が中断ステータスではなくても CCP_EXEC_SUCCESS を返す
  */
-CCP_EXEC_STS Cmd_DCU_DOWN_ABORT_FLAG(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_DCU_DOWN_ABORT_FLAG(const CommonCmdPacket* packet);
 
 /**
  * @brief ログをクリアする
  */
-CCP_EXEC_STS Cmd_DCU_CLEAR_LOG(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_DCU_CLEAR_LOG(const CommonCmdPacket* packet);
 
 #endif

--- a/Applications/event_utility.c
+++ b/Applications/event_utility.c
@@ -37,21 +37,21 @@ CCP_CmdRet Cmd_EVENT_UTIL_ENABLE_EH_EXEC(const CommonCmdPacket* packet)
 {
   (void)packet;
   event_utility_.is_enabled_eh_execution = 1;
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 CCP_CmdRet Cmd_EVENT_UTIL_DISABLE_EH_EXEC(const CommonCmdPacket* packet)
 {
   (void)packet;
   event_utility_.is_enabled_eh_execution = 0;
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 CCP_CmdRet Cmd_EVENT_UTIL_EXEC_EH(const CommonCmdPacket* packet)
 {
   (void)packet;
   EH_execute();
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 #pragma section

--- a/Applications/event_utility.c
+++ b/Applications/event_utility.c
@@ -33,21 +33,21 @@ static void EVENT_UTIL_update_()
   }
 }
 
-CCP_EXEC_STS Cmd_EVENT_UTIL_ENABLE_EH_EXEC(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EVENT_UTIL_ENABLE_EH_EXEC(const CommonCmdPacket* packet)
 {
   (void)packet;
   event_utility_.is_enabled_eh_execution = 1;
   return CCP_EXEC_SUCCESS;
 }
 
-CCP_EXEC_STS Cmd_EVENT_UTIL_DISABLE_EH_EXEC(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EVENT_UTIL_DISABLE_EH_EXEC(const CommonCmdPacket* packet)
 {
   (void)packet;
   event_utility_.is_enabled_eh_execution = 0;
   return CCP_EXEC_SUCCESS;
 }
 
-CCP_EXEC_STS Cmd_EVENT_UTIL_EXEC_EH(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EVENT_UTIL_EXEC_EH(const CommonCmdPacket* packet)
 {
   (void)packet;
   EH_execute();

--- a/Applications/event_utility.c
+++ b/Applications/event_utility.c
@@ -6,6 +6,7 @@
  */
 #include "event_utility.h"
 #include "../System/EventManager/event_handler.h"
+#include "../TlmCmd/common_cmd_packet_util.h"
 
 #include <stddef.h> // for NULL
 

--- a/Applications/event_utility.h
+++ b/Applications/event_utility.h
@@ -22,8 +22,8 @@ typedef struct
 
 extern const EventUtility* const event_utility;
 
-CCP_EXEC_STS Cmd_EVENT_UTIL_ENABLE_EH_EXEC(const CommonCmdPacket* packet);
-CCP_EXEC_STS Cmd_EVENT_UTIL_DISABLE_EH_EXEC(const CommonCmdPacket* packet);
-CCP_EXEC_STS Cmd_EVENT_UTIL_EXEC_EH(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EVENT_UTIL_ENABLE_EH_EXEC(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EVENT_UTIL_DISABLE_EH_EXEC(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EVENT_UTIL_EXEC_EH(const CommonCmdPacket* packet);
 
 #endif

--- a/Applications/gs_command_dispatcher.c
+++ b/Applications/gs_command_dispatcher.c
@@ -6,6 +6,7 @@
 
 #include "gs_command_dispatcher.h"
 #include "../TlmCmd/packet_handler.h"
+#include "../TlmCmd/common_cmd_packet_util.h"
 
 static CommandDispatcher gs_command_dispatcher_;
 const CommandDispatcher* const gs_command_dispatcher = &gs_command_dispatcher_;

--- a/Applications/gs_command_dispatcher.c
+++ b/Applications/gs_command_dispatcher.c
@@ -49,7 +49,7 @@ CCP_CmdRet Cmd_GSCD_CLEAR_ERR_LOG(const CommonCmdPacket* packet)
 
   // 記録されたエラー情報をクリア
   CDIS_clear_error_status(&gs_command_dispatcher_);
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 #pragma section

--- a/Applications/gs_command_dispatcher.c
+++ b/Applications/gs_command_dispatcher.c
@@ -43,7 +43,7 @@ static void GSCD_dispatch_(void)
   CDIS_dispatch_command(&gs_command_dispatcher_);
 }
 
-CCP_EXEC_STS Cmd_GSCD_CLEAR_ERR_LOG(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_GSCD_CLEAR_ERR_LOG(const CommonCmdPacket* packet)
 {
   (void)packet;
 

--- a/Applications/gs_command_dispatcher.h
+++ b/Applications/gs_command_dispatcher.h
@@ -17,6 +17,6 @@ extern const CommandDispatcher* const gs_command_dispatcher;
  */
 AppInfo GSCD_create_app(void);
 
-CCP_EXEC_STS Cmd_GSCD_CLEAR_ERR_LOG(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_GSCD_CLEAR_ERR_LOG(const CommonCmdPacket* packet);
 
 #endif

--- a/Applications/memory_dump.c
+++ b/Applications/memory_dump.c
@@ -78,7 +78,7 @@ CCP_CmdRet Cmd_MEM_SET_REGION(const CommonCmdPacket* packet)
   if (span > MEM_MAX_SPAN)
   {
     // 指定ダンプ幅が最大量を超えている場合は異常終了。
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   }
 
   memory_dump_.begin = begin;
@@ -109,7 +109,7 @@ CCP_CmdRet Cmd_MEM_DUMP_REGION_SEQ(const CommonCmdPacket* packet)
     // パケット生成回数の上限は8回とする。
     // 32kbpsでのDL時に8VCDU/secで1秒分の通信量。
     // これを超える場合は複数回コマンドを送信して対応する。
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   }
 
   return MEM_dump_region_(category, num_dumps);
@@ -131,7 +131,7 @@ CCP_CmdRet Cmd_MEM_DUMP_REGION_RND(const CommonCmdPacket* packet)
     // パケット生成回数の上限は8回とする。
     // 32kbpsでのDL時に8VCDU/secで1秒分の通信量。
     // これを超える場合は複数回コマンドを送信して対応する。
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   }
 
   endian_memcpy(&adu_seq, param + 2, 2);
@@ -169,7 +169,7 @@ CCP_CmdRet Cmd_MEM_DUMP_SINGLE(const CommonCmdPacket* packet)
     // パケット生成回数の上限は8回とする。
     // 32kbpsでのDL時に8VCDU/secで1秒分の通信量。
     // これを超える場合は複数回コマンドを送信して対応する。
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   }
 
   endian_memcpy(&start_addr, param + 2, 4);
@@ -231,7 +231,7 @@ CCP_CmdRet Cmd_MEM_SET_DESTINATION(const CommonCmdPacket* packet)
   {
     // 宛先アドレスが領域内部に含まれる場合。
     // これを認めると処理が複雑になるので禁止する。
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   }
 
   // 宛先アドレスを設定し、RPを領域先頭に合わせる。

--- a/Applications/memory_dump.c
+++ b/Applications/memory_dump.c
@@ -58,7 +58,7 @@ static void MEM_init_(void)
   memory_dump_.adu_counter = 0;
 }
 
-CCP_EXEC_STS Cmd_MEM_SET_REGION(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_MEM_SET_REGION(const CommonCmdPacket* packet)
 {
   const uint8_t* param = CCP_get_param_head(packet);
   uint32_t begin, end, span;
@@ -95,7 +95,7 @@ CCP_EXEC_STS Cmd_MEM_SET_REGION(const CommonCmdPacket* packet)
 // FIXME: CTCP 大改修が終わったら直す
 // https://github.com/ut-issl/c2a-core/pull/217
 #if 0
-CCP_EXEC_STS Cmd_MEM_DUMP_REGION_SEQ(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_MEM_DUMP_REGION_SEQ(const CommonCmdPacket* packet)
 {
   const uint8_t* param = CCP_get_param_head(packet);
   uint8_t category, num_dumps;
@@ -115,7 +115,7 @@ CCP_EXEC_STS Cmd_MEM_DUMP_REGION_SEQ(const CommonCmdPacket* packet)
   return MEM_dump_region_(category, num_dumps);
 }
 
-CCP_EXEC_STS Cmd_MEM_DUMP_REGION_RND(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_MEM_DUMP_REGION_RND(const CommonCmdPacket* packet)
 {
   const uint8_t* param = CCP_get_param_head(packet);
   uint8_t category, num_dumps;
@@ -153,7 +153,7 @@ CCP_EXEC_STS Cmd_MEM_DUMP_REGION_RND(const CommonCmdPacket* packet)
   }
 }
 
-CCP_EXEC_STS Cmd_MEM_DUMP_SINGLE(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_MEM_DUMP_SINGLE(const CommonCmdPacket* packet)
 {
   const uint8_t* param = CCP_get_param_head(packet);
   uint8_t category, num_dumps;
@@ -201,7 +201,7 @@ CCP_EXEC_STS Cmd_MEM_DUMP_SINGLE(const CommonCmdPacket* packet)
 }
 #endif
 
-CCP_EXEC_STS Cmd_MEM_LOAD(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_MEM_LOAD(const CommonCmdPacket* packet)
 {
   const uint8_t* param = CCP_get_param_head(packet);
   size_t param_len = CCP_get_param_len(packet);
@@ -220,7 +220,7 @@ CCP_EXEC_STS Cmd_MEM_LOAD(const CommonCmdPacket* packet)
   return CCP_EXEC_SUCCESS;
 }
 
-CCP_EXEC_STS Cmd_MEM_SET_DESTINATION(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_MEM_SET_DESTINATION(const CommonCmdPacket* packet)
 {
   const uint8_t* param = CCP_get_param_head(packet);
   uint32_t dest;
@@ -240,7 +240,7 @@ CCP_EXEC_STS Cmd_MEM_SET_DESTINATION(const CommonCmdPacket* packet)
   return CCP_EXEC_SUCCESS;
 }
 
-CCP_EXEC_STS Cmd_MEM_COPY_REGION_SEQ(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_MEM_COPY_REGION_SEQ(const CommonCmdPacket* packet)
 {
   const uint8_t* param = CCP_get_param_head(packet);
   uint32_t copy_width, wp;

--- a/Applications/memory_dump.c
+++ b/Applications/memory_dump.c
@@ -70,7 +70,7 @@ CCP_CmdRet Cmd_MEM_SET_REGION(const CommonCmdPacket* packet)
   if (begin > end)
   {
     // 領域の開始と終了の大小関係が逆の場合は異常終了
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   }
 
   span = end - begin;
@@ -149,7 +149,7 @@ CCP_CmdRet Cmd_MEM_DUMP_REGION_RND(const CommonCmdPacket* packet)
   else
   {
     // 指定されたADU Sequence Counterが領域外であれば異常終了
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   }
 }
 

--- a/Applications/memory_dump.c
+++ b/Applications/memory_dump.c
@@ -89,7 +89,7 @@ CCP_CmdRet Cmd_MEM_SET_REGION(const CommonCmdPacket* packet)
   // 領域設定1回毎に独立したADUカウント値を割り当てる。
   memory_dump_.adu_counter = MEM_get_next_adu_counter_();
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 // FIXME: CTCP 大改修が終わったら直す
@@ -197,7 +197,7 @@ CCP_CmdRet Cmd_MEM_DUMP_SINGLE(const CommonCmdPacket* packet)
   // 生成したパケットを送出
   MEM_send_packet_(&MEM_ctp_, num_dumps);
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 #endif
 
@@ -217,7 +217,7 @@ CCP_CmdRet Cmd_MEM_LOAD(const CommonCmdPacket* packet)
 
   // 指定した開始アドレスから始まる領域にデータを書き込み
   memcpy((void*)start_addr, &(param[4]), data_len);
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 CCP_CmdRet Cmd_MEM_SET_DESTINATION(const CommonCmdPacket* packet)
@@ -237,7 +237,7 @@ CCP_CmdRet Cmd_MEM_SET_DESTINATION(const CommonCmdPacket* packet)
   // 宛先アドレスを設定し、RPを領域先頭に合わせる。
   memory_dump_.dest = dest;
   memory_dump_.rp = memory_dump_.begin;
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 CCP_CmdRet Cmd_MEM_COPY_REGION_SEQ(const CommonCmdPacket* packet)
@@ -249,7 +249,7 @@ CCP_CmdRet Cmd_MEM_COPY_REGION_SEQ(const CommonCmdPacket* packet)
   {
     // 既に領域全体の読み出しが完了している場合。
     // 処理は行わず正常終了する。
-    return CCP_EXEC_SUCCESS;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   }
 
   // パラメータ読み出し。
@@ -268,7 +268,7 @@ CCP_CmdRet Cmd_MEM_COPY_REGION_SEQ(const CommonCmdPacket* packet)
   // 指定されたコピー幅だけ領域をコピーし、RPを更新。
   memcpy((uint8_t*)wp, (const uint8_t*)memory_dump_.rp, copy_width);
   memory_dump_.rp += copy_width;
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 static uint8_t MEM_get_next_adu_counter_(void)
@@ -295,11 +295,11 @@ static CCP_EXEC_STS MEM_dump_region_(uint8_t category,
     // 生成したパケットを送出し、ADU Sequence Counterの値を更新
     MEM_send_packet_(&MEM_ctp_, num_dumps);
     ++memory_dump_.adu_seq;
-    return CCP_EXEC_SUCCESS;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 
   case MEM_NO_DATA:
     // すでに全領域ダンプ済みなら何もせず終了
-    return CCP_EXEC_SUCCESS;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 
   default:
     // それ以外のエラーはないはず

--- a/Applications/memory_dump.c
+++ b/Applications/memory_dump.c
@@ -6,6 +6,7 @@
 #include "../System/TimeManager/time_manager.h"
 #include "../TlmCmd/packet_handler.h"
 #include "../Library/endian_memcpy.h"
+#include "../TlmCmd/common_cmd_packet_util.h"
 
 static MemoryDump memory_dump_;
 const MemoryDump* const memory_dump = &memory_dump_;

--- a/Applications/memory_dump.c
+++ b/Applications/memory_dump.c
@@ -304,7 +304,7 @@ static CCP_EXEC_STS MEM_dump_region_(uint8_t category,
 
   default:
     // それ以外のエラーはないはず
-    return CCP_EXEC_UNKNOWN;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_UNKNOWN);
   }
 }
 

--- a/Applications/memory_dump.h
+++ b/Applications/memory_dump.h
@@ -32,31 +32,31 @@ AppInfo MEM_create_app(void);
 
 // 2018/08/24
 // 自分の解釈をコメントとして追加
-CCP_EXEC_STS Cmd_MEM_SET_REGION(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_MEM_SET_REGION(const CommonCmdPacket* packet);
 
 // FIXME: CTCP 大改修が終わったら直す
 // https://github.com/ut-issl/c2a-core/pull/217
 #if 0
-CCP_EXEC_STS Cmd_MEM_DUMP_REGION_SEQ(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_MEM_DUMP_REGION_SEQ(const CommonCmdPacket* packet);
 // 1パケットに入り切らない場合は，最初のADU分割された最初のパケットのみダンプ
 // もう一度送ると，その次のパケットがダンプ
 // 最後はちゃんと止まる
 
-CCP_EXEC_STS Cmd_MEM_DUMP_REGION_RND(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_MEM_DUMP_REGION_RND(const CommonCmdPacket* packet);
 // ADU分割された場合，その途中のパケットからダンプ
 
-CCP_EXEC_STS Cmd_MEM_DUMP_SINGLE(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_MEM_DUMP_SINGLE(const CommonCmdPacket* packet);
 // アドレスを指定して，ダンプ？
 // Cmd_MEM_SET_REGION は無視？
 #endif
 
-CCP_EXEC_STS Cmd_MEM_LOAD(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_MEM_LOAD(const CommonCmdPacket* packet);
 // MEMにアップリンクして書き込み
 
-CCP_EXEC_STS Cmd_MEM_SET_DESTINATION(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_MEM_SET_DESTINATION(const CommonCmdPacket* packet);
 // Cmd_MEM_COPY_REGION_SEQのコピー先を指定
 
-CCP_EXEC_STS Cmd_MEM_COPY_REGION_SEQ(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_MEM_COPY_REGION_SEQ(const CommonCmdPacket* packet);
 // destにrpを指定幅だけコピーしていく
 // これもCmd_MEM_DUMP_REGION_SEQと同様に，何度も繰り返し発行して使う．
 

--- a/Applications/nop.c
+++ b/Applications/nop.c
@@ -22,7 +22,7 @@ static void NOP_nop_() {
 CCP_CmdRet Cmd_NOP(const CommonCmdPacket* packet)
 {
   (void)packet;
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 #pragma section

--- a/Applications/nop.c
+++ b/Applications/nop.c
@@ -19,7 +19,7 @@ static void NOP_nop_() {
   // no operation
 }
 
-CCP_EXEC_STS Cmd_NOP(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_NOP(const CommonCmdPacket* packet)
 {
   (void)packet;
   return CCP_EXEC_SUCCESS;

--- a/Applications/nop.c
+++ b/Applications/nop.c
@@ -7,6 +7,7 @@
  */
 #include "nop.h"
 #include <stddef.h>
+#include "../TlmCmd/common_cmd_packet_util.h"
 
 static void NOP_nop_(void);
 

--- a/Applications/nop.h
+++ b/Applications/nop.h
@@ -12,6 +12,6 @@
 
 AppInfo NOP_create_app(void);
 
-CCP_EXEC_STS Cmd_NOP(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_NOP(const CommonCmdPacket* packet);
 
 #endif

--- a/Applications/realtime_command_dispatcher.c
+++ b/Applications/realtime_command_dispatcher.c
@@ -29,7 +29,7 @@ CCP_CmdRet Cmd_RTCD_CLEAR_ALL_REALTIME(const CommonCmdPacket* packet)
   (void)packet;
 
   CDIS_clear_command_list(&realtime_command_dispatcher_);
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 CCP_CmdRet Cmd_RTCD_CLEAR_ERR_LOG(const CommonCmdPacket* packet)
@@ -38,6 +38,6 @@ CCP_CmdRet Cmd_RTCD_CLEAR_ERR_LOG(const CommonCmdPacket* packet)
 
   // 記録されたエラー情報を解除。
   CDIS_clear_error_status(&realtime_command_dispatcher_);
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 #pragma section

--- a/Applications/realtime_command_dispatcher.c
+++ b/Applications/realtime_command_dispatcher.c
@@ -1,7 +1,7 @@
 #pragma section REPRO
 #include "realtime_command_dispatcher.h"
-
 #include "../TlmCmd/packet_handler.h"
+#include "../TlmCmd/common_cmd_packet_util.h"
 
 static CommandDispatcher realtime_command_dispatcher_;
 const CommandDispatcher* const realtime_command_dispatcher = &realtime_command_dispatcher_;

--- a/Applications/realtime_command_dispatcher.c
+++ b/Applications/realtime_command_dispatcher.c
@@ -24,7 +24,7 @@ static void RTCD_dispatch_(void)
   CDIS_dispatch_command(&realtime_command_dispatcher_);
 }
 
-CCP_EXEC_STS Cmd_RTCD_CLEAR_ALL_REALTIME(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_RTCD_CLEAR_ALL_REALTIME(const CommonCmdPacket* packet)
 {
   (void)packet;
 
@@ -32,7 +32,7 @@ CCP_EXEC_STS Cmd_RTCD_CLEAR_ALL_REALTIME(const CommonCmdPacket* packet)
   return CCP_EXEC_SUCCESS;
 }
 
-CCP_EXEC_STS Cmd_RTCD_CLEAR_ERR_LOG(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_RTCD_CLEAR_ERR_LOG(const CommonCmdPacket* packet)
 {
   (void)packet;
 

--- a/Applications/realtime_command_dispatcher.h
+++ b/Applications/realtime_command_dispatcher.h
@@ -9,8 +9,8 @@ extern const CommandDispatcher* const realtime_command_dispatcher;
 
 AppInfo RTCD_create_app(void);
 
-CCP_EXEC_STS Cmd_RTCD_CLEAR_ALL_REALTIME(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_RTCD_CLEAR_ALL_REALTIME(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_RTCD_CLEAR_ERR_LOG(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_RTCD_CLEAR_ERR_LOG(const CommonCmdPacket* packet);
 
 #endif

--- a/Applications/telemetry_manager.c
+++ b/Applications/telemetry_manager.c
@@ -434,7 +434,7 @@ CCP_CmdRet Cmd_TLM_MGR_INIT(const CommonCmdPacket* packet)
   if (exec_counter == 3)
   {
     DCU_report_finish(Cmd_CODE_TLM_MGR_INIT, CCP_EXEC_SUCCESS);
-    return CCP_EXEC_SUCCESS;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   }
 
   // 再帰実行
@@ -444,7 +444,7 @@ CCP_CmdRet Cmd_TLM_MGR_INIT(const CommonCmdPacket* packet)
     return CCP_EXEC_ILLEGAL_CONTEXT;
   }
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
@@ -459,7 +459,7 @@ CCP_CmdRet Cmd_TLM_MGR_INIT_MASTER_BC(const CommonCmdPacket* packet)
 
   BCL_load_bc(telemetry_manager_.master_bc_id, TLM_MGR_load_master_bc_);
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
@@ -471,7 +471,7 @@ CCP_CmdRet Cmd_TLM_MGR_CLEAR_HK_TLM(const CommonCmdPacket* packet)
 
   TLM_MGR_clear_bc_of_register_info_(&telemetry_manager_.register_info.hk_tlm);
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
@@ -483,7 +483,7 @@ CCP_CmdRet Cmd_TLM_MGR_CLEAR_SYSTEM_TLM(const CommonCmdPacket* packet)
 
   TLM_MGR_clear_bc_of_register_info_(&telemetry_manager_.register_info.system_tlm);
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
@@ -519,7 +519,7 @@ CCP_CmdRet Cmd_TLM_MGR_CLEAR_USER_TLM(const CommonCmdPacket* packet)
   default:
     TLM_MGR_clear_bc_of_register_info_(&telemetry_manager_.register_info.reserve);     // 便宜上ここで
     DCU_report_finish(Cmd_CODE_TLM_MGR_CLEAR_USER_TLM, CCP_EXEC_SUCCESS);
-    return CCP_EXEC_SUCCESS;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   }
 
   // 再帰実行
@@ -529,7 +529,7 @@ CCP_CmdRet Cmd_TLM_MGR_CLEAR_USER_TLM(const CommonCmdPacket* packet)
     return CCP_EXEC_ILLEGAL_CONTEXT;
   }
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
@@ -569,7 +569,7 @@ CCP_CmdRet Cmd_TLM_MGR_START_TLM(const CommonCmdPacket* packet)
   CCP_form_block_deploy_cmd(&TLM_MGR_packet_, TLCD_ID_DEPLOY_TLM, master_bc_id);
   PH_analyze_cmd_packet(&TLM_MGR_packet_);
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
@@ -601,7 +601,7 @@ CCP_CmdRet Cmd_TLM_MGR_STOP_TLM(const CommonCmdPacket* packet)
                0);
   BCT_overwrite_cmd(&bc_register_pos, &TLM_MGR_packet_);
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 CCP_CmdRet Cmd_TLM_MGR_CLEAR_TLM_TL(const CommonCmdPacket* packet)
@@ -616,7 +616,7 @@ CCP_CmdRet Cmd_TLM_MGR_CLEAR_TLM_TL(const CommonCmdPacket* packet)
   CCP_form_rtc(&TLM_MGR_packet_, Cmd_CODE_TLCD_CLEAR_ALL_TIMELINE, param, 1);
   PH_analyze_cmd_packet(&TLM_MGR_packet_);
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
@@ -635,7 +635,7 @@ CCP_CmdRet Cmd_TLM_MGR_REGISTER_HK_TLM(const CommonCmdPacket* packet)
   ret = TLM_MGR_register_generate_tlm_(&telemetry_manager_.register_info.hk_tlm, param);
   if (ret != TLM_MGR_ERR_CODE_OK) return CCP_EXEC_ILLEGAL_CONTEXT;
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
@@ -654,7 +654,7 @@ CCP_CmdRet Cmd_TLM_MGR_REGISTER_SYSTEM_TLM(const CommonCmdPacket* packet)
   ret = TLM_MGR_register_generate_tlm_(&telemetry_manager_.register_info.system_tlm, param);
   if (ret != TLM_MGR_ERR_CODE_OK) return CCP_EXEC_ILLEGAL_CONTEXT;
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
@@ -673,7 +673,7 @@ CCP_CmdRet Cmd_TLM_MGR_REGISTER_HIGH_FREQ_TLM(const CommonCmdPacket* packet)
   ret = TLM_MGR_register_generate_tlm_(&telemetry_manager_.register_info.high_freq_tlm, param);
   if (ret != TLM_MGR_ERR_CODE_OK) return CCP_EXEC_ILLEGAL_CONTEXT;
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
@@ -692,7 +692,7 @@ CCP_CmdRet Cmd_TLM_MGR_REGISTER_LOW_FREQ_TLM(const CommonCmdPacket* packet)
   ret = TLM_MGR_register_generate_tlm_(&telemetry_manager_.register_info.low_freq_tlm, param);
   if (ret != TLM_MGR_ERR_CODE_OK) return CCP_EXEC_ILLEGAL_CONTEXT;
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 #pragma section

--- a/Applications/telemetry_manager.c
+++ b/Applications/telemetry_manager.c
@@ -17,6 +17,7 @@
 #include "../System/WatchdogTimer/watchdog_timer.h"
 #include <src_user/TlmCmd/block_command_definitions.h>
 #include <src_user/TlmCmd/command_definitions.h>
+#include "../TlmCmd/common_cmd_packet_util.h"
 
 /**
  * @brief  App初期化関数

--- a/Applications/telemetry_manager.c
+++ b/Applications/telemetry_manager.c
@@ -389,7 +389,7 @@ static void TLM_MGR_load_nop_bc_(void)
 
 // FIXME: 実行時間やばい： 21ms
 // 適当に分割しないと
-CCP_EXEC_STS Cmd_TLM_MGR_INIT(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_TLM_MGR_INIT(const CommonCmdPacket* packet)
 {
   uint8_t ret;
   uint16_t exec_counter;
@@ -448,7 +448,7 @@ CCP_EXEC_STS Cmd_TLM_MGR_INIT(const CommonCmdPacket* packet)
 }
 
 
-CCP_EXEC_STS Cmd_TLM_MGR_INIT_MASTER_BC(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_TLM_MGR_INIT_MASTER_BC(const CommonCmdPacket* packet)
 {
   (void)packet;
 
@@ -463,7 +463,7 @@ CCP_EXEC_STS Cmd_TLM_MGR_INIT_MASTER_BC(const CommonCmdPacket* packet)
 }
 
 
-CCP_EXEC_STS Cmd_TLM_MGR_CLEAR_HK_TLM(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_TLM_MGR_CLEAR_HK_TLM(const CommonCmdPacket* packet)
 {
   (void)packet;
 
@@ -475,7 +475,7 @@ CCP_EXEC_STS Cmd_TLM_MGR_CLEAR_HK_TLM(const CommonCmdPacket* packet)
 }
 
 
-CCP_EXEC_STS Cmd_TLM_MGR_CLEAR_SYSTEM_TLM(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_TLM_MGR_CLEAR_SYSTEM_TLM(const CommonCmdPacket* packet)
 {
   (void)packet;
 
@@ -489,7 +489,7 @@ CCP_EXEC_STS Cmd_TLM_MGR_CLEAR_SYSTEM_TLM(const CommonCmdPacket* packet)
 
 // FIXME: 実行時間チェック :9ms
 // 結局，NOP BC作るのが重い
-CCP_EXEC_STS Cmd_TLM_MGR_CLEAR_USER_TLM(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_TLM_MGR_CLEAR_USER_TLM(const CommonCmdPacket* packet)
 {
   uint16_t exec_counter;
   (void)packet;
@@ -533,7 +533,7 @@ CCP_EXEC_STS Cmd_TLM_MGR_CLEAR_USER_TLM(const CommonCmdPacket* packet)
 }
 
 
-CCP_EXEC_STS Cmd_TLM_MGR_START_TLM(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_TLM_MGR_START_TLM(const CommonCmdPacket* packet)
 {
   BCT_Pos  bc_register_pos;
   bct_id_t master_bc_id;
@@ -573,7 +573,7 @@ CCP_EXEC_STS Cmd_TLM_MGR_START_TLM(const CommonCmdPacket* packet)
 }
 
 
-CCP_EXEC_STS Cmd_TLM_MGR_STOP_TLM(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_TLM_MGR_STOP_TLM(const CommonCmdPacket* packet)
 {
   BCT_Pos  bc_register_pos;
   bct_id_t master_bc_id;
@@ -604,7 +604,7 @@ CCP_EXEC_STS Cmd_TLM_MGR_STOP_TLM(const CommonCmdPacket* packet)
   return CCP_EXEC_SUCCESS;
 }
 
-CCP_EXEC_STS Cmd_TLM_MGR_CLEAR_TLM_TL(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_TLM_MGR_CLEAR_TLM_TL(const CommonCmdPacket* packet)
 {
   uint8_t param[1];
 
@@ -620,7 +620,7 @@ CCP_EXEC_STS Cmd_TLM_MGR_CLEAR_TLM_TL(const CommonCmdPacket* packet)
 }
 
 
-CCP_EXEC_STS Cmd_TLM_MGR_REGISTER_HK_TLM(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_TLM_MGR_REGISTER_HK_TLM(const CommonCmdPacket* packet)
 {
   const uint8_t* param = CCP_get_param_head(packet);
   TLM_MGR_ERR_CODE ret;
@@ -639,7 +639,7 @@ CCP_EXEC_STS Cmd_TLM_MGR_REGISTER_HK_TLM(const CommonCmdPacket* packet)
 }
 
 
-CCP_EXEC_STS Cmd_TLM_MGR_REGISTER_SYSTEM_TLM(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_TLM_MGR_REGISTER_SYSTEM_TLM(const CommonCmdPacket* packet)
 {
   const uint8_t* param = CCP_get_param_head(packet);
   TLM_MGR_ERR_CODE ret;
@@ -658,7 +658,7 @@ CCP_EXEC_STS Cmd_TLM_MGR_REGISTER_SYSTEM_TLM(const CommonCmdPacket* packet)
 }
 
 
-CCP_EXEC_STS Cmd_TLM_MGR_REGISTER_HIGH_FREQ_TLM(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_TLM_MGR_REGISTER_HIGH_FREQ_TLM(const CommonCmdPacket* packet)
 {
   const uint8_t* param = CCP_get_param_head(packet);
   TLM_MGR_ERR_CODE ret;
@@ -677,7 +677,7 @@ CCP_EXEC_STS Cmd_TLM_MGR_REGISTER_HIGH_FREQ_TLM(const CommonCmdPacket* packet)
 }
 
 
-CCP_EXEC_STS Cmd_TLM_MGR_REGISTER_LOW_FREQ_TLM(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_TLM_MGR_REGISTER_LOW_FREQ_TLM(const CommonCmdPacket* packet)
 {
   const uint8_t* param = CCP_get_param_head(packet);
   TLM_MGR_ERR_CODE ret;

--- a/Applications/telemetry_manager.c
+++ b/Applications/telemetry_manager.c
@@ -404,7 +404,7 @@ CCP_CmdRet Cmd_TLM_MGR_INIT(const CommonCmdPacket* packet)
     // DCU_STATUS_ABORTED_BY_ERR
     // DCU_STATUS_ABORTED_BY_CMD
     // がここに
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   }
 
   switch (exec_counter)
@@ -422,13 +422,13 @@ CCP_CmdRet Cmd_TLM_MGR_INIT(const CommonCmdPacket* packet)
     ret = TLM_MGR_init_4_();
     break;
   default:
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   }
 
   if (ret != 0)
   {
     DCU_report_err(Cmd_CODE_TLM_MGR_INIT, CCP_EXEC_ILLEGAL_CONTEXT);
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   }
 
   if (exec_counter == 3)
@@ -441,7 +441,7 @@ CCP_CmdRet Cmd_TLM_MGR_INIT(const CommonCmdPacket* packet)
   if (DCU_register_next(Cmd_CODE_TLM_MGR_INIT, NULL, 0) != DCU_ACK_OK)
   {
     DCU_report_err(Cmd_CODE_TLM_MGR_INIT, CCP_EXEC_ILLEGAL_CONTEXT);
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   }
 
   return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
@@ -452,7 +452,7 @@ CCP_CmdRet Cmd_TLM_MGR_INIT_MASTER_BC(const CommonCmdPacket* packet)
 {
   (void)packet;
 
-  if (telemetry_manager_.is_inited == 0) return CCP_EXEC_ILLEGAL_CONTEXT;
+  if (telemetry_manager_.is_inited == 0) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
 
   // TODO: TLM_MGR_calc_register_info_from_bc_info_ は入れなくていいか検討する
   //       とりあえずはなくていい気がする
@@ -467,7 +467,7 @@ CCP_CmdRet Cmd_TLM_MGR_CLEAR_HK_TLM(const CommonCmdPacket* packet)
 {
   (void)packet;
 
-  if (telemetry_manager_.is_inited == 0) return CCP_EXEC_ILLEGAL_CONTEXT;
+  if (telemetry_manager_.is_inited == 0) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
 
   TLM_MGR_clear_bc_of_register_info_(&telemetry_manager_.register_info.hk_tlm);
 
@@ -479,7 +479,7 @@ CCP_CmdRet Cmd_TLM_MGR_CLEAR_SYSTEM_TLM(const CommonCmdPacket* packet)
 {
   (void)packet;
 
-  if (telemetry_manager_.is_inited == 0) return CCP_EXEC_ILLEGAL_CONTEXT;
+  if (telemetry_manager_.is_inited == 0) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
 
   TLM_MGR_clear_bc_of_register_info_(&telemetry_manager_.register_info.system_tlm);
 
@@ -494,7 +494,7 @@ CCP_CmdRet Cmd_TLM_MGR_CLEAR_USER_TLM(const CommonCmdPacket* packet)
   uint16_t exec_counter;
   (void)packet;
 
-  if (telemetry_manager_.is_inited == 0) return CCP_EXEC_ILLEGAL_CONTEXT;
+  if (telemetry_manager_.is_inited == 0) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
 
   switch (DCU_check_in(Cmd_CODE_TLM_MGR_CLEAR_USER_TLM, &exec_counter))
   {
@@ -505,7 +505,7 @@ CCP_CmdRet Cmd_TLM_MGR_CLEAR_USER_TLM(const CommonCmdPacket* packet)
     // DCU_STATUS_ABORTED_BY_ERR
     // DCU_STATUS_ABORTED_BY_CMD
     // がここに
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   }
 
   switch (exec_counter)
@@ -526,7 +526,7 @@ CCP_CmdRet Cmd_TLM_MGR_CLEAR_USER_TLM(const CommonCmdPacket* packet)
   if (DCU_register_next(Cmd_CODE_TLM_MGR_CLEAR_USER_TLM, NULL, 0) != DCU_ACK_OK)
   {
     DCU_report_err(Cmd_CODE_TLM_MGR_CLEAR_USER_TLM, CCP_EXEC_ILLEGAL_CONTEXT);
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   }
 
   return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
@@ -542,12 +542,12 @@ CCP_CmdRet Cmd_TLM_MGR_START_TLM(const CommonCmdPacket* packet)
 
   (void)packet;
 
-  if (telemetry_manager_.is_inited == 0) return CCP_EXEC_ILLEGAL_CONTEXT;
+  if (telemetry_manager_.is_inited == 0) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
 
   // master BC が 1つでないのは何かがおかしい
   if (telemetry_manager_.register_info.master.bc_info_idx_used_num != 1)
   {
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   }
 
   // master bc の末尾の nop を deploy に差し替える
@@ -581,12 +581,12 @@ CCP_CmdRet Cmd_TLM_MGR_STOP_TLM(const CommonCmdPacket* packet)
 
   (void)packet;
 
-  if (telemetry_manager_.is_inited == 0) return CCP_EXEC_ILLEGAL_CONTEXT;
+  if (telemetry_manager_.is_inited == 0) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
 
   // master BC が 1つでないのは何かがおかしい
   if (telemetry_manager_.register_info.master.bc_info_idx_used_num != 1)
   {
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   }
 
   // master bc の末尾の deploy を nop に差し替えることで止める
@@ -610,7 +610,7 @@ CCP_CmdRet Cmd_TLM_MGR_CLEAR_TLM_TL(const CommonCmdPacket* packet)
 
   (void)packet;
 
-  if (telemetry_manager_.is_inited == 0) return CCP_EXEC_ILLEGAL_CONTEXT;
+  if (telemetry_manager_.is_inited == 0) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
 
   param[0] = TLCD_ID_DEPLOY_TLM;
   CCP_form_rtc(&TLM_MGR_packet_, Cmd_CODE_TLCD_CLEAR_ALL_TIMELINE, param, 1);
@@ -625,7 +625,7 @@ CCP_CmdRet Cmd_TLM_MGR_REGISTER_HK_TLM(const CommonCmdPacket* packet)
   const uint8_t* param = CCP_get_param_head(packet);
   TLM_MGR_ERR_CODE ret;
 
-  if (telemetry_manager_.is_inited == 0) return CCP_EXEC_ILLEGAL_CONTEXT;
+  if (telemetry_manager_.is_inited == 0) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
 
   if (CA_ckeck_cmd_param_len(Cmd_CODE_GENERATE_TLM, CCP_get_param_len(packet)) != CA_ACK_OK)
   {
@@ -633,7 +633,7 @@ CCP_CmdRet Cmd_TLM_MGR_REGISTER_HK_TLM(const CommonCmdPacket* packet)
   }
 
   ret = TLM_MGR_register_generate_tlm_(&telemetry_manager_.register_info.hk_tlm, param);
-  if (ret != TLM_MGR_ERR_CODE_OK) return CCP_EXEC_ILLEGAL_CONTEXT;
+  if (ret != TLM_MGR_ERR_CODE_OK) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
 
   return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
@@ -644,7 +644,7 @@ CCP_CmdRet Cmd_TLM_MGR_REGISTER_SYSTEM_TLM(const CommonCmdPacket* packet)
   const uint8_t* param = CCP_get_param_head(packet);
   TLM_MGR_ERR_CODE ret;
 
-  if (telemetry_manager_.is_inited == 0) return CCP_EXEC_ILLEGAL_CONTEXT;
+  if (telemetry_manager_.is_inited == 0) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
 
   if (CA_ckeck_cmd_param_len(Cmd_CODE_GENERATE_TLM, CCP_get_param_len(packet)) != CA_ACK_OK)
   {
@@ -652,7 +652,7 @@ CCP_CmdRet Cmd_TLM_MGR_REGISTER_SYSTEM_TLM(const CommonCmdPacket* packet)
   }
 
   ret = TLM_MGR_register_generate_tlm_(&telemetry_manager_.register_info.system_tlm, param);
-  if (ret != TLM_MGR_ERR_CODE_OK) return CCP_EXEC_ILLEGAL_CONTEXT;
+  if (ret != TLM_MGR_ERR_CODE_OK) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
 
   return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
@@ -663,7 +663,7 @@ CCP_CmdRet Cmd_TLM_MGR_REGISTER_HIGH_FREQ_TLM(const CommonCmdPacket* packet)
   const uint8_t* param = CCP_get_param_head(packet);
   TLM_MGR_ERR_CODE ret;
 
-  if (telemetry_manager_.is_inited == 0) return CCP_EXEC_ILLEGAL_CONTEXT;
+  if (telemetry_manager_.is_inited == 0) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
 
   if (CA_ckeck_cmd_param_len(Cmd_CODE_GENERATE_TLM, CCP_get_param_len(packet)) != CA_ACK_OK)
   {
@@ -671,7 +671,7 @@ CCP_CmdRet Cmd_TLM_MGR_REGISTER_HIGH_FREQ_TLM(const CommonCmdPacket* packet)
   }
 
   ret = TLM_MGR_register_generate_tlm_(&telemetry_manager_.register_info.high_freq_tlm, param);
-  if (ret != TLM_MGR_ERR_CODE_OK) return CCP_EXEC_ILLEGAL_CONTEXT;
+  if (ret != TLM_MGR_ERR_CODE_OK) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
 
   return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
@@ -682,7 +682,7 @@ CCP_CmdRet Cmd_TLM_MGR_REGISTER_LOW_FREQ_TLM(const CommonCmdPacket* packet)
   const uint8_t* param = CCP_get_param_head(packet);
   TLM_MGR_ERR_CODE ret;
 
-  if (telemetry_manager_.is_inited == 0) return CCP_EXEC_ILLEGAL_CONTEXT;
+  if (telemetry_manager_.is_inited == 0) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
 
   if (CA_ckeck_cmd_param_len(Cmd_CODE_GENERATE_TLM, CCP_get_param_len(packet)) != CA_ACK_OK)
   {
@@ -690,7 +690,7 @@ CCP_CmdRet Cmd_TLM_MGR_REGISTER_LOW_FREQ_TLM(const CommonCmdPacket* packet)
   }
 
   ret = TLM_MGR_register_generate_tlm_(&telemetry_manager_.register_info.low_freq_tlm, param);
-  if (ret != TLM_MGR_ERR_CODE_OK) return CCP_EXEC_ILLEGAL_CONTEXT;
+  if (ret != TLM_MGR_ERR_CODE_OK) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
 
   return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }

--- a/Applications/telemetry_manager.c
+++ b/Applications/telemetry_manager.c
@@ -630,7 +630,7 @@ CCP_CmdRet Cmd_TLM_MGR_REGISTER_HK_TLM(const CommonCmdPacket* packet)
 
   if (CA_ckeck_cmd_param_len(Cmd_CODE_GENERATE_TLM, CCP_get_param_len(packet)) != CA_ACK_OK)
   {
-    return CCP_EXEC_ILLEGAL_LENGTH;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_LENGTH);
   }
 
   ret = TLM_MGR_register_generate_tlm_(&telemetry_manager_.register_info.hk_tlm, param);
@@ -649,7 +649,7 @@ CCP_CmdRet Cmd_TLM_MGR_REGISTER_SYSTEM_TLM(const CommonCmdPacket* packet)
 
   if (CA_ckeck_cmd_param_len(Cmd_CODE_GENERATE_TLM, CCP_get_param_len(packet)) != CA_ACK_OK)
   {
-    return CCP_EXEC_ILLEGAL_LENGTH;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_LENGTH);
   }
 
   ret = TLM_MGR_register_generate_tlm_(&telemetry_manager_.register_info.system_tlm, param);
@@ -668,7 +668,7 @@ CCP_CmdRet Cmd_TLM_MGR_REGISTER_HIGH_FREQ_TLM(const CommonCmdPacket* packet)
 
   if (CA_ckeck_cmd_param_len(Cmd_CODE_GENERATE_TLM, CCP_get_param_len(packet)) != CA_ACK_OK)
   {
-    return CCP_EXEC_ILLEGAL_LENGTH;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_LENGTH);
   }
 
   ret = TLM_MGR_register_generate_tlm_(&telemetry_manager_.register_info.high_freq_tlm, param);
@@ -687,7 +687,7 @@ CCP_CmdRet Cmd_TLM_MGR_REGISTER_LOW_FREQ_TLM(const CommonCmdPacket* packet)
 
   if (CA_ckeck_cmd_param_len(Cmd_CODE_GENERATE_TLM, CCP_get_param_len(packet)) != CA_ACK_OK)
   {
-    return CCP_EXEC_ILLEGAL_LENGTH;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_LENGTH);
   }
 
   ret = TLM_MGR_register_generate_tlm_(&telemetry_manager_.register_info.low_freq_tlm, param);

--- a/Applications/telemetry_manager.h
+++ b/Applications/telemetry_manager.h
@@ -109,34 +109,34 @@ AppInfo TLM_MGR_create_app(void);
 /**
  * @brief 初期化
  */
-CCP_EXEC_STS Cmd_TLM_MGR_INIT(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_TLM_MGR_INIT(const CommonCmdPacket* packet);
 
 /**
  * @brief master bc の初期化
  */
-CCP_EXEC_STS Cmd_TLM_MGR_INIT_MASTER_BC(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_TLM_MGR_INIT_MASTER_BC(const CommonCmdPacket* packet);
 
 /**
  * @brief HKテレメを初期化
  */
-CCP_EXEC_STS Cmd_TLM_MGR_CLEAR_HK_TLM(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_TLM_MGR_CLEAR_HK_TLM(const CommonCmdPacket* packet);
 
 /**
  * @brief systemテレメを初期化
  */
-CCP_EXEC_STS Cmd_TLM_MGR_CLEAR_SYSTEM_TLM(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_TLM_MGR_CLEAR_SYSTEM_TLM(const CommonCmdPacket* packet);
 
 /**
  * @brief high_freq_tlm, low_freq_tlm を初期化
  * @note  便宜上 TLM_MGR_BC_TYPE_RESERVE の BC も初期化してしまう
  */
-CCP_EXEC_STS Cmd_TLM_MGR_CLEAR_USER_TLM(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_TLM_MGR_CLEAR_USER_TLM(const CommonCmdPacket* packet);
 
 /**
  * @brief TLM送出開始
  * @note  master bc の末尾を Cmd_TLCD_DEPLOY_BLOCK にして deploy block しているだけ
  */
-CCP_EXEC_STS Cmd_TLM_MGR_START_TLM(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_TLM_MGR_START_TLM(const CommonCmdPacket* packet);
 
 /**
  * @brief TLM送出一時停止
@@ -144,38 +144,38 @@ CCP_EXEC_STS Cmd_TLM_MGR_START_TLM(const CommonCmdPacket* packet);
  * @note  Cmd_TLCD_CLEAR_ALL_TIMELINE / Cmd_TLM_MGR_CLEAR_TLM_TL だと他のものも消えてしまう
  * @note  Cmd_TLCD_CLEAR_ALL_TIMELINE / Cmd_TLM_MGR_CLEAR_TLM_TL のほうが適切な場合もあるのでよく考えること
  */
-CCP_EXEC_STS Cmd_TLM_MGR_STOP_TLM(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_TLM_MGR_STOP_TLM(const CommonCmdPacket* packet);
 
 /**
  * @brief TLM送出用TLをクリア
  * @note  Cmd_TLCD_CLEAR_ALL_TIMELINE しているだけ
  * @note  Cmd_TLCD_CLEAR_ALL_TIMELINE をGSから送ってもいいが， TL No がマジックナンバーになるので．
  */
-CCP_EXEC_STS Cmd_TLM_MGR_CLEAR_TLM_TL(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_TLM_MGR_CLEAR_TLM_TL(const CommonCmdPacket* packet);
 
 /**
  * @brief HKテレメを登録
  */
-CCP_EXEC_STS Cmd_TLM_MGR_REGISTER_HK_TLM(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_TLM_MGR_REGISTER_HK_TLM(const CommonCmdPacket* packet);
 
 /**
  * @brief systemテレメを登録
  */
-CCP_EXEC_STS Cmd_TLM_MGR_REGISTER_SYSTEM_TLM(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_TLM_MGR_REGISTER_SYSTEM_TLM(const CommonCmdPacket* packet);
 
 /**
  * @brief high_freq_tlm を登録
  */
-CCP_EXEC_STS Cmd_TLM_MGR_REGISTER_HIGH_FREQ_TLM(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_TLM_MGR_REGISTER_HIGH_FREQ_TLM(const CommonCmdPacket* packet);
 
 /**
  * @brief low_freq_tlm を登録
  */
-CCP_EXEC_STS Cmd_TLM_MGR_REGISTER_LOW_FREQ_TLM(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_TLM_MGR_REGISTER_LOW_FREQ_TLM(const CommonCmdPacket* packet);
 
 
 // TODO: いきなり設定が変わるのではなく，設定変更 → 反映，にしたい．
-// CCP_EXEC_STS Cmd_TLM_MGR_APPLY(const CommonCmdPacket* packet);
+// CCP_CmdRet Cmd_TLM_MGR_APPLY(const CommonCmdPacket* packet);
 
 
 // *** HOW TO USE ***

--- a/Applications/timeline_command_dispatcher.c
+++ b/Applications/timeline_command_dispatcher.c
@@ -193,7 +193,7 @@ CCP_CmdRet Cmd_TLCD_CLEAR_ALL_TIMELINE(const CommonCmdPacket* packet)
   if (id >= TLCD_ID_MAX)
   {
     // 指定されたライン番号が存在しない場合は異常判定
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   }
 
   CDIS_clear_command_list(&timeline_command_dispatcher_.dispatcher[id]);
@@ -208,7 +208,7 @@ CCP_CmdRet Cmd_TLCD_CLEAR_TIMELINE_AT(const CommonCmdPacket* packet)
   if (id >= TLCD_ID_MAX)
   {
     // 指定されたライン番号が存在しない場合は異常判定
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   }
 
   if (TLCD_drop_tl_cmd_at_(id, time) == PH_ACK_SUCCESS)
@@ -217,7 +217,7 @@ CCP_CmdRet Cmd_TLCD_CLEAR_TIMELINE_AT(const CommonCmdPacket* packet)
   }
   else
   {
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   }
 }
 
@@ -263,13 +263,13 @@ CCP_CmdRet Cmd_TLCD_DEPLOY_BLOCK(const CommonCmdPacket* packet)
   if (id >= TLCD_ID_MAX)
   {
     // 指定されたライン番号が存在しない場合は異常判定
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   }
 
   if (block_no >= BCT_MAX_BLOCKS)
   {
     // 指定されたブロック番号が存在しない場合は異常判定
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   }
 
   ack = PL_deploy_block_cmd(&(PH_tl_cmd_list[id]), block_no, TMGR_get_master_total_cycle());
@@ -293,7 +293,7 @@ CCP_CmdRet Cmd_TLCD_CLEAR_ERR_LOG(const CommonCmdPacket* packet)
   if (id >= TLCD_ID_MAX)
   {
     // ライン番号が不正。
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   }
 
   // 当該コマンド処理機能のエラー記録を解除。
@@ -309,13 +309,13 @@ CCP_CmdRet Cmd_TLCD_SET_SOE_FLAG(const CommonCmdPacket* packet)
   if (id >= TLCD_ID_MAX)
   {
     // 指定されたライン番号が存在しない場合は異常判定
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   }
 
   if ((flag != 0) && (flag != 1))
   {
     // フラグ内容が0/1でないなら異常判定。
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   }
 
   // 異常時実行中断フラグを設定
@@ -331,13 +331,13 @@ CCP_CmdRet Cmd_TLCD_SET_LOUT_FLAG(const CommonCmdPacket* packet)
   if (id >= TLCD_ID_MAX)
   {
     // 指定されたライン番号が存在しない場合は異常判定
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   }
 
   if ((flag != 0) && (flag != 1))
   {
     // フラグ情報が0/1でない場合は異常判定。
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   }
 
   // コマンド実行フラグを設定。
@@ -352,7 +352,7 @@ CCP_CmdRet Cmd_TLCD_SET_ID_FOR_TLM(const CommonCmdPacket* packet)
   if (id >= TLCD_ID_MAX)
   {
     // 指定されたライン番号が存在しない場合は異常判定
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   }
 
   timeline_command_dispatcher_.tlm_info_.id = id;
@@ -367,7 +367,7 @@ CCP_CmdRet Cmd_TLCD_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet)
   if (page >= TL_TLM_PAGE_MAX)
   {
     // ページ番号がコマンドテーブル範囲外
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   }
 
   timeline_command_dispatcher_.tlm_info_.page_no = page;

--- a/Applications/timeline_command_dispatcher.c
+++ b/Applications/timeline_command_dispatcher.c
@@ -280,7 +280,7 @@ CCP_CmdRet Cmd_TLCD_DEPLOY_BLOCK(const CommonCmdPacket* packet)
                     (uint32_t)ack,
                     EL_ERROR_LEVEL_LOW,
                     (uint32_t)id);
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   }
 
   return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);

--- a/Applications/timeline_command_dispatcher.c
+++ b/Applications/timeline_command_dispatcher.c
@@ -197,7 +197,7 @@ CCP_CmdRet Cmd_TLCD_CLEAR_ALL_TIMELINE(const CommonCmdPacket* packet)
   }
 
   CDIS_clear_command_list(&timeline_command_dispatcher_.dispatcher[id]);
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 CCP_CmdRet Cmd_TLCD_CLEAR_TIMELINE_AT(const CommonCmdPacket* packet)
@@ -213,7 +213,7 @@ CCP_CmdRet Cmd_TLCD_CLEAR_TIMELINE_AT(const CommonCmdPacket* packet)
 
   if (TLCD_drop_tl_cmd_at_(id, time) == PH_ACK_SUCCESS)
   {
-    return CCP_EXEC_SUCCESS;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   }
   else
   {
@@ -283,7 +283,7 @@ CCP_CmdRet Cmd_TLCD_DEPLOY_BLOCK(const CommonCmdPacket* packet)
     return CCP_EXEC_ILLEGAL_CONTEXT;
   }
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 CCP_CmdRet Cmd_TLCD_CLEAR_ERR_LOG(const CommonCmdPacket* packet)
@@ -298,7 +298,7 @@ CCP_CmdRet Cmd_TLCD_CLEAR_ERR_LOG(const CommonCmdPacket* packet)
 
   // 当該コマンド処理機能のエラー記録を解除。
   CDIS_clear_error_status(&timeline_command_dispatcher_.dispatcher[id]);
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 CCP_CmdRet Cmd_TLCD_SET_SOE_FLAG(const CommonCmdPacket* packet)
@@ -320,7 +320,7 @@ CCP_CmdRet Cmd_TLCD_SET_SOE_FLAG(const CommonCmdPacket* packet)
 
   // 異常時実行中断フラグを設定
   timeline_command_dispatcher_.dispatcher[id].stop_on_error = flag;
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 CCP_CmdRet Cmd_TLCD_SET_LOUT_FLAG(const CommonCmdPacket* packet)
@@ -342,7 +342,7 @@ CCP_CmdRet Cmd_TLCD_SET_LOUT_FLAG(const CommonCmdPacket* packet)
 
   // コマンド実行フラグを設定。
   timeline_command_dispatcher_.dispatcher[id].lockout = flag;
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 CCP_CmdRet Cmd_TLCD_SET_ID_FOR_TLM(const CommonCmdPacket* packet)
@@ -357,7 +357,7 @@ CCP_CmdRet Cmd_TLCD_SET_ID_FOR_TLM(const CommonCmdPacket* packet)
 
   timeline_command_dispatcher_.tlm_info_.id = id;
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 CCP_CmdRet Cmd_TLCD_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet)
@@ -371,7 +371,7 @@ CCP_CmdRet Cmd_TLCD_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet)
   }
 
   timeline_command_dispatcher_.tlm_info_.page_no = page;
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 #pragma section

--- a/Applications/timeline_command_dispatcher.c
+++ b/Applications/timeline_command_dispatcher.c
@@ -258,7 +258,7 @@ CCP_CmdRet Cmd_TLCD_DEPLOY_BLOCK(const CommonCmdPacket* packet)
   {
     // パラメータはTLライン番号(1Byte)とブロック番号。
     // 一致しない場合は異常判定。
-    return CCP_EXEC_ILLEGAL_LENGTH;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_LENGTH);
   }
 
   if (id >= TLCD_ID_MAX)

--- a/Applications/timeline_command_dispatcher.c
+++ b/Applications/timeline_command_dispatcher.c
@@ -186,7 +186,7 @@ TLCD_ID TLCD_update_tl_list_for_tlm(TLCD_ID id)
   return id;
 }
 
-CCP_EXEC_STS Cmd_TLCD_CLEAR_ALL_TIMELINE(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_TLCD_CLEAR_ALL_TIMELINE(const CommonCmdPacket* packet)
 {
   TLCD_ID id = (TLCD_ID)CCP_get_param_from_packet(packet, 0, uint8_t);
 
@@ -200,7 +200,7 @@ CCP_EXEC_STS Cmd_TLCD_CLEAR_ALL_TIMELINE(const CommonCmdPacket* packet)
   return CCP_EXEC_SUCCESS;
 }
 
-CCP_EXEC_STS Cmd_TLCD_CLEAR_TIMELINE_AT(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_TLCD_CLEAR_TIMELINE_AT(const CommonCmdPacket* packet)
 {
   TLCD_ID id = (TLCD_ID)CCP_get_param_from_packet(packet, 0, uint8_t);
   cycle_t time = CCP_get_param_from_packet(packet, 1, cycle_t);
@@ -247,7 +247,7 @@ static PH_ACK TLCD_drop_tl_cmd_at_(TLCD_ID id, cycle_t time)
   return PH_ACK_SUCCESS;
 }
 
-CCP_EXEC_STS Cmd_TLCD_DEPLOY_BLOCK(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_TLCD_DEPLOY_BLOCK(const CommonCmdPacket* packet)
 {
   TLCD_ID id = (TLCD_ID)CCP_get_param_from_packet(packet, 0, uint8_t);
   bct_id_t block_no = CCP_get_param_from_packet(packet, 1, bct_id_t);
@@ -286,7 +286,7 @@ CCP_EXEC_STS Cmd_TLCD_DEPLOY_BLOCK(const CommonCmdPacket* packet)
   return CCP_EXEC_SUCCESS;
 }
 
-CCP_EXEC_STS Cmd_TLCD_CLEAR_ERR_LOG(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_TLCD_CLEAR_ERR_LOG(const CommonCmdPacket* packet)
 {
   TLCD_ID id = (TLCD_ID)CCP_get_param_from_packet(packet, 0, uint8_t);
 
@@ -301,7 +301,7 @@ CCP_EXEC_STS Cmd_TLCD_CLEAR_ERR_LOG(const CommonCmdPacket* packet)
   return CCP_EXEC_SUCCESS;
 }
 
-CCP_EXEC_STS Cmd_TLCD_SET_SOE_FLAG(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_TLCD_SET_SOE_FLAG(const CommonCmdPacket* packet)
 {
   TLCD_ID id = (TLCD_ID)CCP_get_param_from_packet(packet, 0, uint8_t);
   uint8_t flag = CCP_get_param_from_packet(packet, 1, uint8_t);
@@ -323,7 +323,7 @@ CCP_EXEC_STS Cmd_TLCD_SET_SOE_FLAG(const CommonCmdPacket* packet)
   return CCP_EXEC_SUCCESS;
 }
 
-CCP_EXEC_STS Cmd_TLCD_SET_LOUT_FLAG(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_TLCD_SET_LOUT_FLAG(const CommonCmdPacket* packet)
 {
   TLCD_ID id = (TLCD_ID)CCP_get_param_from_packet(packet, 0, uint8_t);
   uint8_t flag = CCP_get_param_from_packet(packet, 1, uint8_t);
@@ -345,7 +345,7 @@ CCP_EXEC_STS Cmd_TLCD_SET_LOUT_FLAG(const CommonCmdPacket* packet)
   return CCP_EXEC_SUCCESS;
 }
 
-CCP_EXEC_STS Cmd_TLCD_SET_ID_FOR_TLM(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_TLCD_SET_ID_FOR_TLM(const CommonCmdPacket* packet)
 {
   TLCD_ID id = (TLCD_ID)CCP_get_param_from_packet(packet, 0, uint8_t);
 
@@ -360,7 +360,7 @@ CCP_EXEC_STS Cmd_TLCD_SET_ID_FOR_TLM(const CommonCmdPacket* packet)
   return CCP_EXEC_SUCCESS;
 }
 
-CCP_EXEC_STS Cmd_TLCD_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_TLCD_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet)
 {
   uint8_t page = CCP_get_param_from_packet(packet, 0, uint8_t);
 

--- a/Applications/timeline_command_dispatcher.c
+++ b/Applications/timeline_command_dispatcher.c
@@ -5,6 +5,7 @@
 #include "../System/AnomalyLogger/anomaly_logger.h"
 #include "../System/EventManager/event_logger.h"
 #include "../TlmCmd/common_cmd_packet_util.h"
+#include "../TlmCmd/common_cmd_packet_util.h"
 
 #include <string.h> // for memset
 

--- a/Applications/timeline_command_dispatcher.h
+++ b/Applications/timeline_command_dispatcher.h
@@ -82,13 +82,13 @@ AppInfo TLCD_mis_create_app(void);
  */
 TLCD_ID TLCD_update_tl_list_for_tlm(TLCD_ID id);
 
-CCP_EXEC_STS Cmd_TLCD_CLEAR_ALL_TIMELINE(const CommonCmdPacket* packet);
-CCP_EXEC_STS Cmd_TLCD_CLEAR_TIMELINE_AT(const CommonCmdPacket* packet);
-CCP_EXEC_STS Cmd_TLCD_DEPLOY_BLOCK(const CommonCmdPacket* packet);
-CCP_EXEC_STS Cmd_TLCD_CLEAR_ERR_LOG(const CommonCmdPacket* packet);
-CCP_EXEC_STS Cmd_TLCD_SET_SOE_FLAG(const CommonCmdPacket* packet);
-CCP_EXEC_STS Cmd_TLCD_SET_LOUT_FLAG(const CommonCmdPacket* packet);
-CCP_EXEC_STS Cmd_TLCD_SET_ID_FOR_TLM(const CommonCmdPacket* packet);
-CCP_EXEC_STS Cmd_TLCD_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_TLCD_CLEAR_ALL_TIMELINE(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_TLCD_CLEAR_TIMELINE_AT(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_TLCD_DEPLOY_BLOCK(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_TLCD_CLEAR_ERR_LOG(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_TLCD_SET_SOE_FLAG(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_TLCD_SET_LOUT_FLAG(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_TLCD_SET_ID_FOR_TLM(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_TLCD_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet);
 
 #endif

--- a/Applications/utility_command.c
+++ b/Applications/utility_command.c
@@ -77,7 +77,7 @@ static int UTIL_CMD_send_(unsigned char ch)
   return ret;
 }
 
-CCP_EXEC_STS Cmd_UTIL_CMD_ADD(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_UTIL_CMD_ADD(const CommonCmdPacket* packet)
 {
   unsigned char size = CCP_get_param_head(packet)[0];
   if (CCP_get_param_len(packet) != 21)
@@ -104,7 +104,7 @@ CCP_EXEC_STS Cmd_UTIL_CMD_ADD(const CommonCmdPacket* packet)
   return CCP_EXEC_SUCCESS;
 }
 
-CCP_EXEC_STS Cmd_UTIL_CMD_SEND(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_UTIL_CMD_SEND(const CommonCmdPacket* packet)
 {
   unsigned char uart_ch = CCP_get_param_head(packet)[0];
   int ret;
@@ -125,7 +125,7 @@ CCP_EXEC_STS Cmd_UTIL_CMD_SEND(const CommonCmdPacket* packet)
   return CCP_EXEC_SUCCESS;
 }
 
-CCP_EXEC_STS Cmd_UTIL_CMD_RESET(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_UTIL_CMD_RESET(const CommonCmdPacket* packet)
 {
   (void)packet;
   UTIL_CMD_reset_();

--- a/Applications/utility_command.c
+++ b/Applications/utility_command.c
@@ -115,7 +115,7 @@ CCP_CmdRet Cmd_UTIL_CMD_SEND(const CommonCmdPacket* packet)
     ret = UTIL_CMD_send_(uart_ch);
     if (ret != 0)
     {
-      return CCP_EXEC_ILLEGAL_CONTEXT;
+      return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
     }
   }
   else

--- a/Applications/utility_command.c
+++ b/Applications/utility_command.c
@@ -94,12 +94,12 @@ CCP_CmdRet Cmd_UTIL_CMD_ADD(const CommonCmdPacket* packet)
     }
      else
       {
-        return CCP_EXEC_ILLEGAL_PARAMETER;
+        return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
       }
   }
   else
   {
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   }
   return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
@@ -120,7 +120,7 @@ CCP_CmdRet Cmd_UTIL_CMD_SEND(const CommonCmdPacket* packet)
   }
   else
   {
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   }
   return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }

--- a/Applications/utility_command.c
+++ b/Applications/utility_command.c
@@ -84,7 +84,7 @@ CCP_CmdRet Cmd_UTIL_CMD_ADD(const CommonCmdPacket* packet)
   if (CCP_get_param_len(packet) != 21)
   {
     // パラメータ長確認(21Bytes)
-    return CCP_EXEC_ILLEGAL_LENGTH;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_LENGTH);
   }
   if (size <= 20)
   {

--- a/Applications/utility_command.c
+++ b/Applications/utility_command.c
@@ -101,7 +101,7 @@ CCP_CmdRet Cmd_UTIL_CMD_ADD(const CommonCmdPacket* packet)
   {
     return CCP_EXEC_ILLEGAL_PARAMETER;
   }
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 CCP_CmdRet Cmd_UTIL_CMD_SEND(const CommonCmdPacket* packet)
@@ -122,14 +122,14 @@ CCP_CmdRet Cmd_UTIL_CMD_SEND(const CommonCmdPacket* packet)
   {
     return CCP_EXEC_ILLEGAL_PARAMETER;
   }
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 CCP_CmdRet Cmd_UTIL_CMD_RESET(const CommonCmdPacket* packet)
 {
   (void)packet;
   UTIL_CMD_reset_();
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 #pragma section

--- a/Applications/utility_command.c
+++ b/Applications/utility_command.c
@@ -4,6 +4,7 @@
 #include "../IfWrapper/uart.h"
 #include <src_user/Settings/port_config.h>
 #include <string.h>                     // for memcpy
+#include "../TlmCmd/common_cmd_packet_util.h"
 
 
 static UtilityCommand utility_command_;

--- a/Applications/utility_command.h
+++ b/Applications/utility_command.h
@@ -24,8 +24,8 @@ extern const UtilityCommand* const utility_command;
 AppInfo UTIL_CMD_create_app(void);
 
 // コマンド
-CCP_EXEC_STS Cmd_UTIL_CMD_ADD(const CommonCmdPacket* packet);
-CCP_EXEC_STS Cmd_UTIL_CMD_SEND(const CommonCmdPacket* packet);
-CCP_EXEC_STS Cmd_UTIL_CMD_RESET(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_UTIL_CMD_ADD(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_UTIL_CMD_SEND(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_UTIL_CMD_RESET(const CommonCmdPacket* packet);
 
 #endif

--- a/Applications/utility_counter.c
+++ b/Applications/utility_counter.c
@@ -5,6 +5,7 @@
 #include "../TlmCmd/packet_handler.h"
 #include "../System/AnomalyLogger/anomaly_logger.h"
 #include <string.h>   // for memcpy
+#include "../TlmCmd/common_cmd_packet_util.h"
 
 static UtilityCounter utility_counter_;
 const UtilityCounter* const utility_counter = &utility_counter_;

--- a/Applications/utility_counter.c
+++ b/Applications/utility_counter.c
@@ -76,7 +76,7 @@ CCP_CmdRet Cmd_UTIL_COUNTER_INCREMENT(const CommonCmdPacket* packet)
   {
     return CCP_EXEC_ILLEGAL_PARAMETER;
   }
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 
 }
 
@@ -102,7 +102,7 @@ CCP_CmdRet Cmd_UTIL_COUNTER_RESET(const CommonCmdPacket* packet)
   {
     return CCP_EXEC_ILLEGAL_PARAMETER;
   }
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 CCP_CmdRet Cmd_UTIL_COUNTER_SET_PARAM(const CommonCmdPacket* packet)
@@ -127,7 +127,7 @@ CCP_CmdRet Cmd_UTIL_COUNTER_SET_PARAM(const CommonCmdPacket* packet)
   {
     return CCP_EXEC_ILLEGAL_PARAMETER;
   }
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 #endif

--- a/Applications/utility_counter.c
+++ b/Applications/utility_counter.c
@@ -59,7 +59,7 @@ static void UTIL_COUNTER_incl_(UTIL_COUNTER_NAME num)
 
 }
 
-CCP_EXEC_STS Cmd_UTIL_COUNTER_INCREMENT(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_UTIL_COUNTER_INCREMENT(const CommonCmdPacket* packet)
 {
   UTIL_COUNTER_NAME index;
 
@@ -80,7 +80,7 @@ CCP_EXEC_STS Cmd_UTIL_COUNTER_INCREMENT(const CommonCmdPacket* packet)
 
 }
 
-CCP_EXEC_STS Cmd_UTIL_COUNTER_RESET(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_UTIL_COUNTER_RESET(const CommonCmdPacket* packet)
 {
   UTIL_COUNTER_NAME index;
 
@@ -105,7 +105,7 @@ CCP_EXEC_STS Cmd_UTIL_COUNTER_RESET(const CommonCmdPacket* packet)
   return CCP_EXEC_SUCCESS;
 }
 
-CCP_EXEC_STS Cmd_UTIL_COUNTER_SET_PARAM(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_UTIL_COUNTER_SET_PARAM(const CommonCmdPacket* packet)
 {
   UTIL_COUNTER_NAME index;
 

--- a/Applications/utility_counter.c
+++ b/Applications/utility_counter.c
@@ -74,7 +74,7 @@ CCP_CmdRet Cmd_UTIL_COUNTER_INCREMENT(const CommonCmdPacket* packet)
   }
   else
   {
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   }
   return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 
@@ -100,7 +100,7 @@ CCP_CmdRet Cmd_UTIL_COUNTER_RESET(const CommonCmdPacket* packet)
   }
   else
   {
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   }
   return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
@@ -120,12 +120,12 @@ CCP_CmdRet Cmd_UTIL_COUNTER_SET_PARAM(const CommonCmdPacket* packet)
     if (utility_counter_.cnt[index].anomaly_active > 1)
     {
       utility_counter_.cnt[index].anomaly_active = 0;
-      return CCP_EXEC_ILLEGAL_PARAMETER;
+      return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
     }
   }
   else
   {
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   }
   return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }

--- a/Applications/utility_counter.h
+++ b/Applications/utility_counter.h
@@ -66,9 +66,9 @@ extern const UtilityCounter* const utility_counter;
 AppInfo UTIL_COUNTER_create_app(void);
 
 // コマンド
-CCP_EXEC_STS Cmd_UTIL_COUNTER_INCREMENT(const CommonCmdPacket* packet);
-CCP_EXEC_STS Cmd_UTIL_COUNTER_RESET(const CommonCmdPacket* packet);
-CCP_EXEC_STS Cmd_UTIL_COUNTER_SET_PARAM(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_UTIL_COUNTER_INCREMENT(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_UTIL_COUNTER_RESET(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_UTIL_COUNTER_SET_PARAM(const CommonCmdPacket* packet);
 
 #endif
 #endif

--- a/Drivers/Super/driver_super.c
+++ b/Drivers/Super/driver_super.c
@@ -1694,7 +1694,7 @@ CCP_EXEC_STS DS_conv_driver_err_to_ccp_exec_sts(DS_DRIVER_ERR_CODE code)
   default:
     // ここに来るのは以下
     // DS_DRIVER_ERR_CODE_OK
-    return CCP_EXEC_SUCCESS;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   }
 }
 
@@ -1716,7 +1716,7 @@ CCP_EXEC_STS DS_conv_cmd_err_to_ccp_exec_sts(DS_CMD_ERR_CODE code)
     // DS_CMD_UNKNOWN_ERR
     // 下２つのエラーはDriver側の問題で，そちらでエラー情報を持つべき
     // ここでは SUCCESSを返す
-    return CCP_EXEC_SUCCESS;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   }
 }
 

--- a/Drivers/Super/driver_super.c
+++ b/Drivers/Super/driver_super.c
@@ -1688,7 +1688,7 @@ CCP_EXEC_STS DS_conv_driver_err_to_ccp_exec_sts(DS_DRIVER_ERR_CODE code)
     // 全てこれでいいのかは，要検討
     return CCP_EXEC_ILLEGAL_CONTEXT;
   case DS_DRIVER_ERR_CODE_ILLEGAL_PARAMETER:
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   case DS_DRIVER_ERR_CODE_ILLEGAL_LENGTH:
     return CCP_EXEC_ILLEGAL_LENGTH;
   default:
@@ -1706,7 +1706,7 @@ CCP_EXEC_STS DS_conv_cmd_err_to_ccp_exec_sts(DS_CMD_ERR_CODE code)
   case DS_CMD_ILLEGAL_CONTEXT:
     return CCP_EXEC_ILLEGAL_CONTEXT;
   case DS_CMD_ILLEGAL_PARAMETER:
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   case DS_CMD_ILLEGAL_LENGTH:
     return CCP_EXEC_ILLEGAL_LENGTH;
   default:

--- a/Drivers/Super/driver_super.c
+++ b/Drivers/Super/driver_super.c
@@ -1686,7 +1686,7 @@ CCP_EXEC_STS DS_conv_driver_err_to_ccp_exec_sts(DS_DRIVER_ERR_CODE code)
   case DS_DRIVER_ERR_CODE_ILLEGAL_CONTEXT:
   case DS_DRIVER_ERR_CODE_UNKNOWN_ERR:
     // 全てこれでいいのかは，要検討
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   case DS_DRIVER_ERR_CODE_ILLEGAL_PARAMETER:
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   case DS_DRIVER_ERR_CODE_ILLEGAL_LENGTH:
@@ -1704,7 +1704,7 @@ CCP_EXEC_STS DS_conv_cmd_err_to_ccp_exec_sts(DS_CMD_ERR_CODE code)
   switch (code)
   {
   case DS_CMD_ILLEGAL_CONTEXT:
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   case DS_CMD_ILLEGAL_PARAMETER:
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   case DS_CMD_ILLEGAL_LENGTH:

--- a/Drivers/Super/driver_super.c
+++ b/Drivers/Super/driver_super.c
@@ -1690,7 +1690,7 @@ CCP_EXEC_STS DS_conv_driver_err_to_ccp_exec_sts(DS_DRIVER_ERR_CODE code)
   case DS_DRIVER_ERR_CODE_ILLEGAL_PARAMETER:
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   case DS_DRIVER_ERR_CODE_ILLEGAL_LENGTH:
-    return CCP_EXEC_ILLEGAL_LENGTH;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_LENGTH);
   default:
     // ここに来るのは以下
     // DS_DRIVER_ERR_CODE_OK
@@ -1708,7 +1708,7 @@ CCP_EXEC_STS DS_conv_cmd_err_to_ccp_exec_sts(DS_CMD_ERR_CODE code)
   case DS_CMD_ILLEGAL_PARAMETER:
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   case DS_CMD_ILLEGAL_LENGTH:
-    return CCP_EXEC_ILLEGAL_LENGTH;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_LENGTH);
   default:
     // ここに来るのは以下の３つ
     // DS_CMD_OK

--- a/Drivers/Super/driver_super.c
+++ b/Drivers/Super/driver_super.c
@@ -1680,7 +1680,7 @@ DS_ERR_CODE DSSC_get_ret_from_data_analyzer(const DS_StreamConfig* p_stream_conf
 
 // ###### Driver汎用Util関数 ######
 
-CCP_EXEC_STS DS_conv_driver_err_to_ccp_exec_sts(DS_DRIVER_ERR_CODE code)
+CCP_CmdRet DS_conv_driver_err_to_ccp_cmd_ret(DS_DRIVER_ERR_CODE code)
 {
   switch (code)
   {
@@ -1700,7 +1700,7 @@ CCP_EXEC_STS DS_conv_driver_err_to_ccp_exec_sts(DS_DRIVER_ERR_CODE code)
 }
 
 
-CCP_EXEC_STS DS_conv_cmd_err_to_ccp_exec_sts(DS_CMD_ERR_CODE code)
+CCP_CmdRet DS_conv_cmd_err_to_ccp_cmd_ret(DS_CMD_ERR_CODE code)
 {
   switch (code)
   {

--- a/Drivers/Super/driver_super.c
+++ b/Drivers/Super/driver_super.c
@@ -13,6 +13,7 @@
 #include "../../Library/print.h"
 #include <string.h>     // for memsetなどのmem系
 #include <stddef.h>     // for NULL
+#include "../../TlmCmd/common_cmd_packet_util.h"
 
 // #define DS_DEBUG                       // 適切なときにコメントアウトする
 // #define DS_DEBUG_SHOW_REC_DATA         // 適切なときにコメントアウトする

--- a/Drivers/Super/driver_super.h
+++ b/Drivers/Super/driver_super.h
@@ -35,7 +35,7 @@ typedef struct DS_StreamConfig DS_StreamConfig;
  * @note   受信関数呼び出し時については， DS_REC_ERR_CODE を用いること
  * @note   接続先機器へ送るCmd呼び出し時については， DS_CMD_ERR_CODE を用いること
  * @note   DI の Cmd の返り値である CCP_EXEC_STS との整合性を多少意識している
- * @note   CCP_EXEC_STS への変換は DS_conv_driver_err_to_ccp_exec_sts を用いる
+ * @note   CCP_EXEC_STS への変換は DS_conv_driver_err_to_ccp_cmd_ret を用いる
  * @note   より詳細なエラー情報を返したい場合は， Driver ごとに独自 enum を定義して良い
  */
 typedef enum
@@ -80,7 +80,7 @@ typedef enum
  * @brief  各DIが Driver にコマンドを送るときに，統一的に使うコード
  * @note   uint8_t を想定
  * @note   DI の Cmd の返り値である CCP_EXEC_STS との整合性を多少意識している
- * @note   CCP_EXEC_STS への変換は DS_conv_cmd_err_to_ccp_exec_sts を用いる
+ * @note   CCP_EXEC_STS への変換は DS_conv_cmd_err_to_ccp_cmd_ret を用いる
  */
 typedef enum
 {
@@ -537,23 +537,23 @@ DS_ERR_CODE DSSC_get_ret_from_data_analyzer(const DS_StreamConfig* p_stream_conf
 // ###### Driver汎用Util関数 ######
 
 /**
- * @brief  DS_DRIVER_ERR_CODE から CCP_EXEC_STS への変換関数
+ * @brief  DS_DRIVER_ERR_CODE から CCP_CmdRet への変換関数
  *
  *         DI から Driver の関数を呼び出したときのエラーコードの変換に用いる
  * @note   汎用Util関数
  * @param  DS_DRIVER_ERR_CODE
- * @return CCP_EXEC_STS
+ * @return CCP_CmdRet
  */
-CCP_EXEC_STS DS_conv_driver_err_to_ccp_exec_sts(DS_DRIVER_ERR_CODE code);
+CCP_CmdRet DS_conv_driver_err_to_ccp_cmd_ret(DS_DRIVER_ERR_CODE code);
 
 /**
- * @brief  DS_CMD_ERR_CODE から CCP_EXEC_STS への変換関数
+ * @brief  DS_CMD_ERR_CODE から CCP_CmdRet への変換関数
  *
  *         DI から Driver の関数を呼び出したときのエラーコードの変換に用いる
  * @note   汎用Util関数
  * @param  DS_CMD_ERR_CODE
- * @return CCP_EXEC_STS
+ * @return CCP_CmdRet
  */
-CCP_EXEC_STS DS_conv_cmd_err_to_ccp_exec_sts(DS_CMD_ERR_CODE code);
+CCP_CmdRet DS_conv_cmd_err_to_ccp_cmd_ret(DS_CMD_ERR_CODE code);
 
 #endif

--- a/Examples/minimum_user/src/src_user/Applications/DriverInstances/di_aobc.c
+++ b/Examples/minimum_user/src/src_user/Applications/DriverInstances/di_aobc.c
@@ -96,7 +96,8 @@ CCP_EXEC_STS DI_AOBC_dispatch_command(const CommonCmdPacket* packet)
   CCP_set_dest_type(pckt, CCP_DEST_TYPE_TO_ME);
 
   ret = AOBC_send_cmd(&aobc_driver_, pckt);
-  return DS_conv_cmd_err_to_ccp_cmd_ret(ret);
+  // FIXME: ここも一旦握りつぶす（後で直す）
+  return DS_conv_cmd_err_to_ccp_cmd_ret(ret).exec_sts;
 }
 
 

--- a/Examples/minimum_user/src/src_user/Applications/DriverInstances/di_aobc.c
+++ b/Examples/minimum_user/src/src_user/Applications/DriverInstances/di_aobc.c
@@ -99,7 +99,7 @@ CCP_EXEC_STS DI_AOBC_dispatch_command(const CommonCmdPacket* packet)
 }
 
 
-CCP_EXEC_STS Cmd_DI_AOBC_CDIS_CLEAR_ALL_REALTIME(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_DI_AOBC_CDIS_CLEAR_ALL_REALTIME(const CommonCmdPacket* packet)
 {
   (void)packet;
 
@@ -108,7 +108,7 @@ CCP_EXEC_STS Cmd_DI_AOBC_CDIS_CLEAR_ALL_REALTIME(const CommonCmdPacket* packet)
 }
 
 
-CCP_EXEC_STS Cmd_DI_AOBC_CDIS_CLEAR_ERR_LOG(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_DI_AOBC_CDIS_CLEAR_ERR_LOG(const CommonCmdPacket* packet)
 {
   (void)packet;
 

--- a/Examples/minimum_user/src/src_user/Applications/DriverInstances/di_aobc.c
+++ b/Examples/minimum_user/src/src_user/Applications/DriverInstances/di_aobc.c
@@ -96,7 +96,7 @@ CCP_EXEC_STS DI_AOBC_dispatch_command(const CommonCmdPacket* packet)
   CCP_set_dest_type(pckt, CCP_DEST_TYPE_TO_ME);
 
   ret = AOBC_send_cmd(&aobc_driver_, pckt);
-  return DS_conv_cmd_err_to_ccp_exec_sts(ret);
+  return DS_conv_cmd_err_to_ccp_cmd_ret(ret);
 }
 
 

--- a/Examples/minimum_user/src/src_user/Applications/DriverInstances/di_aobc.c
+++ b/Examples/minimum_user/src/src_user/Applications/DriverInstances/di_aobc.c
@@ -104,7 +104,7 @@ CCP_CmdRet Cmd_DI_AOBC_CDIS_CLEAR_ALL_REALTIME(const CommonCmdPacket* packet)
   (void)packet;
 
   CDIS_clear_command_list(&DI_AOBC_cdis_);
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
@@ -114,7 +114,7 @@ CCP_CmdRet Cmd_DI_AOBC_CDIS_CLEAR_ERR_LOG(const CommonCmdPacket* packet)
 
   // 記録されたエラー情報を解除
   CDIS_clear_error_status(&DI_AOBC_cdis_);
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 #pragma section

--- a/Examples/minimum_user/src/src_user/Applications/DriverInstances/di_aobc.c
+++ b/Examples/minimum_user/src/src_user/Applications/DriverInstances/di_aobc.c
@@ -9,6 +9,7 @@
 #include "../../Drivers/Aocs/aobc.h"
 #include "../../TlmCmd/user_packet_handler.h"
 #include <src_core/Library/print.h>
+#include <src_core/TlmCmd/common_cmd_packet_util.h>
 #include "../../Settings/port_config.h"
 
 

--- a/Examples/minimum_user/src/src_user/Applications/DriverInstances/di_aobc.h
+++ b/Examples/minimum_user/src/src_user/Applications/DriverInstances/di_aobc.h
@@ -40,8 +40,8 @@ AppInfo DI_AOBC_cmd_dispatcher(void);
  */
 CCP_EXEC_STS DI_AOBC_dispatch_command(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_DI_AOBC_CDIS_CLEAR_ALL_REALTIME(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_DI_AOBC_CDIS_CLEAR_ALL_REALTIME(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_DI_AOBC_CDIS_CLEAR_ERR_LOG(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_DI_AOBC_CDIS_CLEAR_ERR_LOG(const CommonCmdPacket* packet);
 
 #endif

--- a/Examples/minimum_user/src/src_user/Applications/DriverInstances/di_gs.c
+++ b/Examples/minimum_user/src/src_user/Applications/DriverInstances/di_gs.c
@@ -177,7 +177,7 @@ CCP_CmdRet Cmd_DI_GS_SET_RP_FLUSH_INTERVAL(const CommonCmdPacket* packet)
 CCP_CmdRet Cmd_DI_GS_SET_FARM_PW(const CommonCmdPacket* packet)
 {
   uint8_t pw = CCP_get_param_head(packet)[0];
-  if (pw < 1 || pw > 127) return CCP_EXEC_ILLEGAL_PARAMETER;
+  if (pw < 1 || pw > 127) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   GS_set_farm_pw(pw);
 
   return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
@@ -186,7 +186,7 @@ CCP_CmdRet Cmd_DI_GS_SET_FARM_PW(const CommonCmdPacket* packet)
 CCP_CmdRet Cmd_DI_GS_SET_INFO(const CommonCmdPacket* packet)
 {
   uint8_t which = CCP_get_param_head(packet)[0];
-  if (which >= GS_PORT_TYPE_NUM) return CCP_EXEC_ILLEGAL_PARAMETER;
+  if (which >= GS_PORT_TYPE_NUM) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   gs_driver_.latest_info = &gs_driver_.info[(GS_PORT_TYPE)which];
   gs_driver_.tlm_tx_port_type = (GS_PORT_TYPE)which;
 
@@ -204,7 +204,7 @@ CCP_CmdRet Cmd_DI_GS_CCSDS_GET_BUFFER(const CommonCmdPacket* packet)
 CCP_CmdRet Cmd_DI_GS_CCSDS_SET_RATE(const CommonCmdPacket* packet)
 {
   uint32_t ui_rate = (uint32_t)CCP_get_param_head(packet)[0];
-  if (ui_rate == 0) return CCP_EXEC_ILLEGAL_PARAMETER;
+  if (ui_rate == 0) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
 
   CCSDS_set_rate(ui_rate, &gs_driver_.driver_ccsds.ccsds_config);
 

--- a/Examples/minimum_user/src/src_user/Applications/DriverInstances/di_gs.c
+++ b/Examples/minimum_user/src/src_user/Applications/DriverInstances/di_gs.c
@@ -149,7 +149,7 @@ CCP_CmdRet Cmd_DI_GS_CCSDS_TX_STOP(const CommonCmdPacket* packet)
 CCP_CmdRet Cmd_DI_GS_DRIVER_RESET(const CommonCmdPacket* packet)
 {
   (void)packet;
-  if (GS_init(&gs_driver_, PORT_CH_RS422_MOBC_EXT)) return CCP_EXEC_ILLEGAL_CONTEXT;
+  if (GS_init(&gs_driver_, PORT_CH_RS422_MOBC_EXT)) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
 
   return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }

--- a/Examples/minimum_user/src/src_user/Applications/DriverInstances/di_gs.c
+++ b/Examples/minimum_user/src/src_user/Applications/DriverInstances/di_gs.c
@@ -7,6 +7,7 @@
 #include "di_gs.h"
 
 #include <src_core/TlmCmd/packet_handler.h>
+#include <src_core/TlmCmd/common_cmd_packet_util.h>
 #include <src_core/Library/print.h>
 #include "../../Drivers/Com/gs_validate.h"
 #include "../../Settings/port_config.h"

--- a/Examples/minimum_user/src/src_user/Applications/DriverInstances/di_gs.c
+++ b/Examples/minimum_user/src/src_user/Applications/DriverInstances/di_gs.c
@@ -135,7 +135,7 @@ CCP_CmdRet Cmd_DI_GS_CCSDS_TX_START(const CommonCmdPacket* packet)
   (void)packet;
   gs_driver_.is_ccsds_tx_valid = 1;
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 CCP_CmdRet Cmd_DI_GS_CCSDS_TX_STOP(const CommonCmdPacket* packet)
@@ -143,7 +143,7 @@ CCP_CmdRet Cmd_DI_GS_CCSDS_TX_STOP(const CommonCmdPacket* packet)
   (void)packet;
   gs_driver_.is_ccsds_tx_valid = 0;
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 CCP_CmdRet Cmd_DI_GS_DRIVER_RESET(const CommonCmdPacket* packet)
@@ -151,7 +151,7 @@ CCP_CmdRet Cmd_DI_GS_DRIVER_RESET(const CommonCmdPacket* packet)
   (void)packet;
   if (GS_init(&gs_driver_, PORT_CH_RS422_MOBC_EXT)) return CCP_EXEC_ILLEGAL_CONTEXT;
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 CCP_CmdRet Cmd_DI_GS_SET_MS_FLUSH_INTERVAL(const CommonCmdPacket* packet)
@@ -161,7 +161,7 @@ CCP_CmdRet Cmd_DI_GS_SET_MS_FLUSH_INTERVAL(const CommonCmdPacket* packet)
 
   DI_GS_set_t2m_flush_interval_(flush_interval, &DI_GS_ms_tlm_packet_handler_);
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 CCP_CmdRet Cmd_DI_GS_SET_RP_FLUSH_INTERVAL(const CommonCmdPacket* packet)
@@ -171,7 +171,7 @@ CCP_CmdRet Cmd_DI_GS_SET_RP_FLUSH_INTERVAL(const CommonCmdPacket* packet)
 
   DI_GS_set_t2m_flush_interval_(flush_interval, &DI_GS_rp_tlm_packet_handler_);
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 CCP_CmdRet Cmd_DI_GS_SET_FARM_PW(const CommonCmdPacket* packet)
@@ -180,7 +180,7 @@ CCP_CmdRet Cmd_DI_GS_SET_FARM_PW(const CommonCmdPacket* packet)
   if (pw < 1 || pw > 127) return CCP_EXEC_ILLEGAL_PARAMETER;
   GS_set_farm_pw(pw);
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 CCP_CmdRet Cmd_DI_GS_SET_INFO(const CommonCmdPacket* packet)
@@ -190,7 +190,7 @@ CCP_CmdRet Cmd_DI_GS_SET_INFO(const CommonCmdPacket* packet)
   gs_driver_.latest_info = &gs_driver_.info[(GS_PORT_TYPE)which];
   gs_driver_.tlm_tx_port_type = (GS_PORT_TYPE)which;
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 CCP_CmdRet Cmd_DI_GS_CCSDS_GET_BUFFER(const CommonCmdPacket* packet)
@@ -198,7 +198,7 @@ CCP_CmdRet Cmd_DI_GS_CCSDS_GET_BUFFER(const CommonCmdPacket* packet)
   (void)packet;
   gs_driver_.ccsds_info.buffer_num = CCSDS_get_buffer_num();
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 CCP_CmdRet Cmd_DI_GS_CCSDS_SET_RATE(const CommonCmdPacket* packet)
@@ -208,7 +208,7 @@ CCP_CmdRet Cmd_DI_GS_CCSDS_SET_RATE(const CommonCmdPacket* packet)
 
   CCSDS_set_rate(ui_rate, &gs_driver_.driver_ccsds.ccsds_config);
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 #pragma section

--- a/Examples/minimum_user/src/src_user/Applications/DriverInstances/di_gs.c
+++ b/Examples/minimum_user/src/src_user/Applications/DriverInstances/di_gs.c
@@ -130,7 +130,7 @@ static void DI_GS_set_t2m_flush_interval_(cycle_t flush_interval, DI_GS_TlmPacke
   gs_tlm_packet_handler->tc_packet_to_m_pdu.flush_interval = flush_interval;
 }
 
-CCP_EXEC_STS Cmd_DI_GS_CCSDS_TX_START(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_DI_GS_CCSDS_TX_START(const CommonCmdPacket* packet)
 {
   (void)packet;
   gs_driver_.is_ccsds_tx_valid = 1;
@@ -138,7 +138,7 @@ CCP_EXEC_STS Cmd_DI_GS_CCSDS_TX_START(const CommonCmdPacket* packet)
   return CCP_EXEC_SUCCESS;
 }
 
-CCP_EXEC_STS Cmd_DI_GS_CCSDS_TX_STOP(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_DI_GS_CCSDS_TX_STOP(const CommonCmdPacket* packet)
 {
   (void)packet;
   gs_driver_.is_ccsds_tx_valid = 0;
@@ -146,7 +146,7 @@ CCP_EXEC_STS Cmd_DI_GS_CCSDS_TX_STOP(const CommonCmdPacket* packet)
   return CCP_EXEC_SUCCESS;
 }
 
-CCP_EXEC_STS Cmd_DI_GS_DRIVER_RESET(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_DI_GS_DRIVER_RESET(const CommonCmdPacket* packet)
 {
   (void)packet;
   if (GS_init(&gs_driver_, PORT_CH_RS422_MOBC_EXT)) return CCP_EXEC_ILLEGAL_CONTEXT;
@@ -154,7 +154,7 @@ CCP_EXEC_STS Cmd_DI_GS_DRIVER_RESET(const CommonCmdPacket* packet)
   return CCP_EXEC_SUCCESS;
 }
 
-CCP_EXEC_STS Cmd_DI_GS_SET_MS_FLUSH_INTERVAL(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_DI_GS_SET_MS_FLUSH_INTERVAL(const CommonCmdPacket* packet)
 {
   cycle_t flush_interval;
   endian_memcpy(&flush_interval, CCP_get_param_head(packet), sizeof(cycle_t));
@@ -164,7 +164,7 @@ CCP_EXEC_STS Cmd_DI_GS_SET_MS_FLUSH_INTERVAL(const CommonCmdPacket* packet)
   return CCP_EXEC_SUCCESS;
 }
 
-CCP_EXEC_STS Cmd_DI_GS_SET_RP_FLUSH_INTERVAL(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_DI_GS_SET_RP_FLUSH_INTERVAL(const CommonCmdPacket* packet)
 {
   cycle_t flush_interval;
   endian_memcpy(&flush_interval, CCP_get_param_head(packet), sizeof(cycle_t));
@@ -174,7 +174,7 @@ CCP_EXEC_STS Cmd_DI_GS_SET_RP_FLUSH_INTERVAL(const CommonCmdPacket* packet)
   return CCP_EXEC_SUCCESS;
 }
 
-CCP_EXEC_STS Cmd_DI_GS_SET_FARM_PW(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_DI_GS_SET_FARM_PW(const CommonCmdPacket* packet)
 {
   uint8_t pw = CCP_get_param_head(packet)[0];
   if (pw < 1 || pw > 127) return CCP_EXEC_ILLEGAL_PARAMETER;
@@ -183,7 +183,7 @@ CCP_EXEC_STS Cmd_DI_GS_SET_FARM_PW(const CommonCmdPacket* packet)
   return CCP_EXEC_SUCCESS;
 }
 
-CCP_EXEC_STS Cmd_DI_GS_SET_INFO(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_DI_GS_SET_INFO(const CommonCmdPacket* packet)
 {
   uint8_t which = CCP_get_param_head(packet)[0];
   if (which >= GS_PORT_TYPE_NUM) return CCP_EXEC_ILLEGAL_PARAMETER;
@@ -193,7 +193,7 @@ CCP_EXEC_STS Cmd_DI_GS_SET_INFO(const CommonCmdPacket* packet)
   return CCP_EXEC_SUCCESS;
 }
 
-CCP_EXEC_STS Cmd_DI_GS_CCSDS_GET_BUFFER(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_DI_GS_CCSDS_GET_BUFFER(const CommonCmdPacket* packet)
 {
   (void)packet;
   gs_driver_.ccsds_info.buffer_num = CCSDS_get_buffer_num();
@@ -201,7 +201,7 @@ CCP_EXEC_STS Cmd_DI_GS_CCSDS_GET_BUFFER(const CommonCmdPacket* packet)
   return CCP_EXEC_SUCCESS;
 }
 
-CCP_EXEC_STS Cmd_DI_GS_CCSDS_SET_RATE(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_DI_GS_CCSDS_SET_RATE(const CommonCmdPacket* packet)
 {
   uint32_t ui_rate = (uint32_t)CCP_get_param_head(packet)[0];
   if (ui_rate == 0) return CCP_EXEC_ILLEGAL_PARAMETER;

--- a/Examples/minimum_user/src/src_user/Applications/DriverInstances/di_gs.h
+++ b/Examples/minimum_user/src/src_user/Applications/DriverInstances/di_gs.h
@@ -32,15 +32,15 @@ AppInfo DI_GS_cmd_packet_handler(void);
 AppInfo DI_GS_mst_packet_handler(void);
 AppInfo DI_GS_rpt_packet_handler(void);
 
-CCP_EXEC_STS Cmd_DI_GS_CCSDS_TX_START(const CommonCmdPacket* packet);
-CCP_EXEC_STS Cmd_DI_GS_CCSDS_TX_STOP(const CommonCmdPacket* packet);
-CCP_EXEC_STS Cmd_DI_GS_DRIVER_RESET(const CommonCmdPacket* packet);
-CCP_EXEC_STS Cmd_DI_GS_SET_MS_FLUSH_INTERVAL(const CommonCmdPacket* packet);
-CCP_EXEC_STS Cmd_DI_GS_SET_RP_FLUSH_INTERVAL(const CommonCmdPacket* packet);
-CCP_EXEC_STS Cmd_DI_GS_SET_FARM_PW(const CommonCmdPacket* packet);
-CCP_EXEC_STS Cmd_DI_GS_SET_INFO(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_DI_GS_CCSDS_TX_START(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_DI_GS_CCSDS_TX_STOP(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_DI_GS_DRIVER_RESET(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_DI_GS_SET_MS_FLUSH_INTERVAL(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_DI_GS_SET_RP_FLUSH_INTERVAL(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_DI_GS_SET_FARM_PW(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_DI_GS_SET_INFO(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_DI_GS_CCSDS_GET_BUFFER(const CommonCmdPacket* packet);
-CCP_EXEC_STS Cmd_DI_GS_CCSDS_SET_RATE(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_DI_GS_CCSDS_GET_BUFFER(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_DI_GS_CCSDS_SET_RATE(const CommonCmdPacket* packet);
 
 #endif

--- a/Examples/minimum_user/src/src_user/Applications/DriverInstances/di_uart_test.c
+++ b/Examples/minimum_user/src/src_user/Applications/DriverInstances/di_uart_test.c
@@ -8,6 +8,7 @@
 #include <stddef.h> // for NULL
 
 #include <src_core/Library/print.h>
+#include <src_core/TlmCmd/common_cmd_packet_util.h>
 #include "../../Settings/port_config.h"
 
 

--- a/Examples/minimum_user/src/src_user/Applications/DriverInstances/di_uart_test.c
+++ b/Examples/minimum_user/src/src_user/Applications/DriverInstances/di_uart_test.c
@@ -68,7 +68,7 @@ static void UART_TEST_update_(void)
 }
 
 
-CCP_EXEC_STS Cmd_UART_TEST_INIT_DI(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_UART_TEST_INIT_DI(const CommonCmdPacket* packet)
 {
   (void)packet;
 
@@ -78,7 +78,7 @@ CCP_EXEC_STS Cmd_UART_TEST_INIT_DI(const CommonCmdPacket* packet)
 }
 
 
-CCP_EXEC_STS Cmd_UART_TEST_UPDATE(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_UART_TEST_UPDATE(const CommonCmdPacket* packet)
 {
   (void)packet;
 
@@ -88,7 +88,7 @@ CCP_EXEC_STS Cmd_UART_TEST_UPDATE(const CommonCmdPacket* packet)
 }
 
 
-CCP_EXEC_STS Cmd_UART_TEST_SEND_TEST(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_UART_TEST_SEND_TEST(const CommonCmdPacket* packet)
 {
   const uint8_t* param = CCP_get_param_head(packet);
   uint8_t id;

--- a/Examples/minimum_user/src/src_user/Applications/DriverInstances/di_uart_test.c
+++ b/Examples/minimum_user/src/src_user/Applications/DriverInstances/di_uart_test.c
@@ -74,7 +74,7 @@ CCP_CmdRet Cmd_UART_TEST_INIT_DI(const CommonCmdPacket* packet)
 
   UART_TEST_init_();
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
@@ -84,7 +84,7 @@ CCP_CmdRet Cmd_UART_TEST_UPDATE(const CommonCmdPacket* packet)
 
   UART_TEST_update_();
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 

--- a/Examples/minimum_user/src/src_user/Applications/DriverInstances/di_uart_test.c
+++ b/Examples/minimum_user/src/src_user/Applications/DriverInstances/di_uart_test.c
@@ -98,7 +98,7 @@ CCP_CmdRet Cmd_UART_TEST_SEND_TEST(const CommonCmdPacket* packet)
   id = param[0];
 
   ret = UART_TEST_send(&uart_test_instance_, id);
-  return DS_conv_cmd_err_to_ccp_exec_sts(ret);
+  return DS_conv_cmd_err_to_ccp_cmd_ret(ret);
 }
 
 #pragma section

--- a/Examples/minimum_user/src/src_user/Applications/DriverInstances/di_uart_test.h
+++ b/Examples/minimum_user/src/src_user/Applications/DriverInstances/di_uart_test.h
@@ -14,11 +14,11 @@ extern const UART_TEST_Driver* uart_test_instance;
 // アプリケーション
 AppInfo UART_TEST_update(void);
 
-CCP_EXEC_STS Cmd_UART_TEST_INIT_DI(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_UART_TEST_INIT_DI(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_UART_TEST_UPDATE(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_UART_TEST_UPDATE(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_UART_TEST_SEND_TEST(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_UART_TEST_SEND_TEST(const CommonCmdPacket* packet);
 
 
 #endif

--- a/System/AnomalyLogger/anomaly_logger.c
+++ b/System/AnomalyLogger/anomaly_logger.c
@@ -66,7 +66,7 @@ CCP_CmdRet Cmd_AL_ADD_ANOMALY(const CommonCmdPacket* packet)
   }
   else
   {
-    return CCP_EXEC_UNKNOWN;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_UNKNOWN);
   }
 }
 
@@ -213,7 +213,7 @@ CCP_CmdRet Cmd_AL_ENABLE_LOGGING(const CommonCmdPacket* packet)
   }
   else
   {
-    return CCP_EXEC_UNKNOWN;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_UNKNOWN);
   }
 }
 
@@ -239,7 +239,7 @@ CCP_CmdRet Cmd_AL_DISABLE_LOGGING(const CommonCmdPacket* packet)
   }
   else
   {
-    return CCP_EXEC_UNKNOWN;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_UNKNOWN);
   }
 }
 

--- a/System/AnomalyLogger/anomaly_logger.c
+++ b/System/AnomalyLogger/anomaly_logger.c
@@ -61,7 +61,7 @@ CCP_CmdRet Cmd_AL_ADD_ANOMALY(const CommonCmdPacket* packet)
 
   if (ret == AL_ADD_SUCCESS)
   {
-    return CCP_EXEC_SUCCESS;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   }
   else
   {
@@ -124,7 +124,7 @@ CCP_CmdRet Cmd_AL_CLEAR_LIST(const CommonCmdPacket* packet)
 {
   (void)packet;
   AL_clear();
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 // こいつは，AHからも呼ばれるので注意！
@@ -166,7 +166,7 @@ CCP_CmdRet Cmd_AL_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet)
   }
 
   anomaly_logger_.page_no = page;
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
@@ -177,7 +177,7 @@ CCP_CmdRet Cmd_AL_INIT_LOGGING_ENA_FLAG(const CommonCmdPacket* packet)
 {
   (void)packet;
   AL_init_logging_ena_flag_();
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 static void AL_init_logging_ena_flag_(void)
@@ -208,7 +208,7 @@ CCP_CmdRet Cmd_AL_ENABLE_LOGGING(const CommonCmdPacket* packet)
 
   if (ret == 0)
   {
-    return CCP_EXEC_SUCCESS;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   }
   else
   {
@@ -234,7 +234,7 @@ CCP_CmdRet Cmd_AL_DISABLE_LOGGING(const CommonCmdPacket* packet)
 
   if (ret == 0)
   {
-    return CCP_EXEC_SUCCESS;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   }
   else
   {
@@ -319,7 +319,7 @@ CCP_CmdRet Cmd_AL_SET_THRES_OF_NEARLY_FULL(const CommonCmdPacket* packet)
   endian_memcpy(&thres, param, 2);
 
   anomaly_logger_.threshold_of_nearly_full = thres;
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 

--- a/System/AnomalyLogger/anomaly_logger.c
+++ b/System/AnomalyLogger/anomaly_logger.c
@@ -162,7 +162,7 @@ CCP_CmdRet Cmd_AL_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet)
   if (page >= AL_TLM_PAGE_MAX)
   {
     // ページ番号がコマンドテーブル範囲外
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   }
 
   anomaly_logger_.page_no = page;
@@ -201,7 +201,7 @@ CCP_CmdRet Cmd_AL_ENABLE_LOGGING(const CommonCmdPacket* packet)
 
   if ( !(0 <= group && group < AL_GROUP_MAX) )
   {
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   }
 
   ret = AL_enable_logging_(group);
@@ -227,7 +227,7 @@ CCP_CmdRet Cmd_AL_DISABLE_LOGGING(const CommonCmdPacket* packet)
 
   if ( !(0 <= group && group < AL_GROUP_MAX) )
   {
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   }
 
   ret = AL_disable_logging_(group);

--- a/System/AnomalyLogger/anomaly_logger.c
+++ b/System/AnomalyLogger/anomaly_logger.c
@@ -8,6 +8,7 @@
 
 #include "../TimeManager/time_manager.h"
 #include "../../Library/endian_memcpy.h"
+#include "../../TlmCmd/common_cmd_packet_util.h"
 
 static void AL_clear_records_(void);
 static int  AC_is_equal_(const AL_AnomalyCode* lhs,

--- a/System/AnomalyLogger/anomaly_logger.c
+++ b/System/AnomalyLogger/anomaly_logger.c
@@ -46,7 +46,7 @@ void AL_initialize(void)
   AL_load_default_settings();
 }
 
-CCP_EXEC_STS Cmd_AL_ADD_ANOMALY(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_AL_ADD_ANOMALY(const CommonCmdPacket* packet)
 {
   const uint8_t* param = CCP_get_param_head(packet);
   uint32_t group, local;
@@ -120,7 +120,7 @@ int AL_add_anomaly(uint32_t group, uint32_t local)
   return AL_ADD_SUCCESS;
 }
 
-CCP_EXEC_STS Cmd_AL_CLEAR_LIST(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_AL_CLEAR_LIST(const CommonCmdPacket* packet)
 {
   (void)packet;
   AL_clear();
@@ -153,7 +153,7 @@ static int AC_is_equal_(const AL_AnomalyCode* lhs,
   return ((lhs->group == rhs->group) && (lhs->local == rhs->local));
 }
 
-CCP_EXEC_STS Cmd_AL_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_AL_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet)
 {
   uint8_t page;
 
@@ -173,7 +173,7 @@ CCP_EXEC_STS Cmd_AL_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet)
 // 2019-01-18
 // 追加
 
-CCP_EXEC_STS Cmd_AL_INIT_LOGGING_ENA_FLAG(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_AL_INIT_LOGGING_ENA_FLAG(const CommonCmdPacket* packet)
 {
   (void)packet;
   AL_init_logging_ena_flag_();
@@ -190,7 +190,7 @@ static void AL_init_logging_ena_flag_(void)
   }
 }
 
-CCP_EXEC_STS Cmd_AL_ENABLE_LOGGING(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_AL_ENABLE_LOGGING(const CommonCmdPacket* packet)
 {
   const uint8_t* param = CCP_get_param_head(packet);
   uint32_t group;
@@ -216,7 +216,7 @@ CCP_EXEC_STS Cmd_AL_ENABLE_LOGGING(const CommonCmdPacket* packet)
   }
 }
 
-CCP_EXEC_STS Cmd_AL_DISABLE_LOGGING(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_AL_DISABLE_LOGGING(const CommonCmdPacket* packet)
 {
   const uint8_t* param = CCP_get_param_head(packet);
   uint32_t group;
@@ -310,7 +310,7 @@ static int  AL_disable_logging_(uint32_t group)
 }
 
 
-CCP_EXEC_STS Cmd_AL_SET_THRES_OF_NEARLY_FULL(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_AL_SET_THRES_OF_NEARLY_FULL(const CommonCmdPacket* packet)
 {
   const uint8_t* param = CCP_get_param_head(packet);
   uint16_t thres;

--- a/System/AnomalyLogger/anomaly_logger.h
+++ b/System/AnomalyLogger/anomaly_logger.h
@@ -97,19 +97,19 @@ int  AL_is_logging_enable(uint32_t group);
 
 void AL_clear(void);
 
-CCP_EXEC_STS Cmd_AL_ADD_ANOMALY(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_AL_ADD_ANOMALY(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_AL_CLEAR_LIST(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_AL_CLEAR_LIST(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_AL_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_AL_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_AL_INIT_LOGGING_ENA_FLAG(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_AL_INIT_LOGGING_ENA_FLAG(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_AL_ENABLE_LOGGING(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_AL_ENABLE_LOGGING(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_AL_DISABLE_LOGGING(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_AL_DISABLE_LOGGING(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_AL_SET_THRES_OF_NEARLY_FULL(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_AL_SET_THRES_OF_NEARLY_FULL(const CommonCmdPacket* packet);
 
 #else
 #define AL_DISALBE_AT_C2A_CORE

--- a/System/ApplicationManager/app_manager.c
+++ b/System/ApplicationManager/app_manager.c
@@ -79,7 +79,7 @@ CCP_CmdRet Cmd_AM_REGISTER_APP(const CommonCmdPacket* packet)
   case AM_SUCCESS:
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   case AM_INVALID_ID:
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   default:
     return CCP_EXEC_ILLEGAL_CONTEXT;
   }
@@ -98,7 +98,7 @@ CCP_CmdRet Cmd_AM_INITIALIZE_APP(const CommonCmdPacket* packet)
   case AM_NOT_REGISTERED:
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   case AM_INVALID_ID:
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   default:
     return CCP_EXEC_ILLEGAL_CONTEXT;
   }
@@ -152,7 +152,7 @@ CCP_CmdRet Cmd_AM_EXECUTE_APP(const CommonCmdPacket* packet)
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   case AM_INVALID_ID:
   case AM_NOT_REGISTERED:
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   default:
     return CCP_EXEC_ILLEGAL_CONTEXT;
   }
@@ -215,7 +215,7 @@ CCP_CmdRet Cmd_AM_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet)
   if (page >= AM_TLM_PAGE_MAX)
   {
     // ページ番号がコマンドテーブル範囲外
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   }
 
   app_manager_.page_no = page;

--- a/System/ApplicationManager/app_manager.c
+++ b/System/ApplicationManager/app_manager.c
@@ -77,7 +77,7 @@ CCP_CmdRet Cmd_AM_REGISTER_APP(const CommonCmdPacket* packet)
   switch (AM_register_ai(id, &ai))
   {
   case AM_SUCCESS:
-    return CCP_EXEC_SUCCESS;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   case AM_INVALID_ID:
     return CCP_EXEC_ILLEGAL_PARAMETER;
   default:
@@ -96,7 +96,7 @@ CCP_CmdRet Cmd_AM_INITIALIZE_APP(const CommonCmdPacket* packet)
   {
   case AM_SUCCESS:
   case AM_NOT_REGISTERED:
-    return CCP_EXEC_SUCCESS;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   case AM_INVALID_ID:
     return CCP_EXEC_ILLEGAL_PARAMETER;
   default:
@@ -149,7 +149,7 @@ CCP_CmdRet Cmd_AM_EXECUTE_APP(const CommonCmdPacket* packet)
   switch (AM_execute_app_(id))
   {
   case AM_SUCCESS:
-    return CCP_EXEC_SUCCESS;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   case AM_INVALID_ID:
   case AM_NOT_REGISTERED:
     return CCP_EXEC_ILLEGAL_PARAMETER;
@@ -219,7 +219,7 @@ CCP_CmdRet Cmd_AM_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet)
   }
 
   app_manager_.page_no = page;
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 CCP_CmdRet Cmd_AM_CLEAR_APP_INFO(const CommonCmdPacket* packet)
@@ -234,7 +234,7 @@ CCP_CmdRet Cmd_AM_CLEAR_APP_INFO(const CommonCmdPacket* packet)
     app_manager_.ais[i].min  = 0xffffffff;
   }
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 

--- a/System/ApplicationManager/app_manager.c
+++ b/System/ApplicationManager/app_manager.c
@@ -81,7 +81,7 @@ CCP_CmdRet Cmd_AM_REGISTER_APP(const CommonCmdPacket* packet)
   case AM_INVALID_ID:
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   default:
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   }
 }
 
@@ -100,7 +100,7 @@ CCP_CmdRet Cmd_AM_INITIALIZE_APP(const CommonCmdPacket* packet)
   case AM_INVALID_ID:
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   default:
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   }
 }
 
@@ -154,7 +154,7 @@ CCP_CmdRet Cmd_AM_EXECUTE_APP(const CommonCmdPacket* packet)
   case AM_NOT_REGISTERED:
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   default:
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   }
 }
 

--- a/System/ApplicationManager/app_manager.c
+++ b/System/ApplicationManager/app_manager.c
@@ -58,7 +58,7 @@ void AM_initialize_all_apps(void)
   }
 }
 
-CCP_EXEC_STS Cmd_AM_REGISTER_APP(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_AM_REGISTER_APP(const CommonCmdPacket* packet)
 {
   const uint8_t* param = CCP_get_param_head(packet);
   size_t id;
@@ -85,7 +85,7 @@ CCP_EXEC_STS Cmd_AM_REGISTER_APP(const CommonCmdPacket* packet)
   }
 }
 
-CCP_EXEC_STS Cmd_AM_INITIALIZE_APP(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_AM_INITIALIZE_APP(const CommonCmdPacket* packet)
 {
   size_t id = AM_MAX_APPS;
 
@@ -139,7 +139,7 @@ static AM_ACK AM_initialize_app_(size_t id)
   return AM_SUCCESS;
 }
 
-CCP_EXEC_STS Cmd_AM_EXECUTE_APP(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_AM_EXECUTE_APP(const CommonCmdPacket* packet)
 {
   size_t id = AM_MAX_APPS;
 
@@ -206,7 +206,7 @@ static AM_ACK AM_execute_app_(size_t id)
   return AM_SUCCESS;
 }
 
-CCP_EXEC_STS Cmd_AM_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_AM_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet)
 {
   uint8_t page;
 
@@ -222,7 +222,7 @@ CCP_EXEC_STS Cmd_AM_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet)
   return CCP_EXEC_SUCCESS;
 }
 
-CCP_EXEC_STS Cmd_AM_CLEAR_APP_INFO(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_AM_CLEAR_APP_INFO(const CommonCmdPacket* packet)
 {
   int i;
   (void)packet;

--- a/System/ApplicationManager/app_manager.c
+++ b/System/ApplicationManager/app_manager.c
@@ -12,6 +12,7 @@
 #include <src_user/TlmCmd/command_definitions.h>
 #include "../../Library/print.h"   // for Printf
 #include "../../Library/endian_memcpy.h"
+#include "../../TlmCmd/common_cmd_packet_util.h"
 
 static AM_ACK AM_initialize_app_(size_t id);
 static AM_ACK AM_execute_app_(size_t id);

--- a/System/ApplicationManager/app_manager.h
+++ b/System/ApplicationManager/app_manager.h
@@ -34,16 +34,16 @@ AM_ACK AM_register_ai(size_t id,
 
 void AM_initialize_all_apps(void);
 
-CCP_EXEC_STS Cmd_AM_REGISTER_APP(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_AM_REGISTER_APP(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_AM_INITIALIZE_APP(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_AM_INITIALIZE_APP(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_AM_EXECUTE_APP(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_AM_EXECUTE_APP(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_AM_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_AM_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet);
 
 // 2019-07-18 追加
 // min, max, prevのみ消す．initはそのまま
-CCP_EXEC_STS Cmd_AM_CLEAR_APP_INFO(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_AM_CLEAR_APP_INFO(const CommonCmdPacket* packet);
 
 #endif

--- a/System/EventManager/event_handler.c
+++ b/System/EventManager/event_handler.c
@@ -1520,7 +1520,7 @@ CCP_CmdRet Cmd_EH_REGISTER_RULE(const CommonCmdPacket* packet)
   case EH_REGISTER_ACK_ILLEGAL_BCT_ID:
   case EH_REGISTER_ACK_ILLEGAL_ACTIVE_FLAG:
   case EH_REGISTER_ACK_ILLEGAL_MULTI_LEVEL:
-    return CCP_EXEC_ILLEGAL_PARAMETER;    // 正確にはこのコマンドのパラメタではないが．．．
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);    // 正確にはこのコマンドのパラメタではないが．．．
   case EH_REGISTER_ACK_ERR_FULL:
   case EH_REGISTER_ACK_ERR_RULE_OVERWRITE:
   case EH_REGISTER_ACK_ERR_DUPLICATE_FULL:
@@ -1542,7 +1542,7 @@ CCP_CmdRet Cmd_EH_DELETE_RULE(const CommonCmdPacket* packet)
   case EH_RULE_SORTED_INDEX_ACK_OK:
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   case EH_RULE_SORTED_INDEX_ACK_ILLEGAL_RULE_ID:
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   case EH_RULE_SORTED_INDEX_ACK_NOT_FOUND:
     return CCP_EXEC_ILLEGAL_CONTEXT;
   default:
@@ -1561,7 +1561,7 @@ CCP_CmdRet Cmd_EH_INIT_RULE(const CommonCmdPacket* packet)
   case EH_CHECK_RULE_ACK_OK:
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   case EH_CHECK_RULE_ACK_INVALID_RULE_ID:
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   case EH_CHECK_RULE_ACK_UNREGISTERED:
     return CCP_EXEC_ILLEGAL_CONTEXT;
   default:
@@ -1580,7 +1580,7 @@ CCP_CmdRet Cmd_EH_INIT_RULE_FOR_MULTI_LEVEL(const CommonCmdPacket* packet)
   case EH_CHECK_RULE_ACK_OK:
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   case EH_CHECK_RULE_ACK_INVALID_RULE_ID:
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   case EH_CHECK_RULE_ACK_UNREGISTERED:
     return CCP_EXEC_ILLEGAL_CONTEXT;
   default:
@@ -1599,7 +1599,7 @@ CCP_CmdRet Cmd_EH_ACTIVATE_RULE(const CommonCmdPacket* packet)
   case EH_CHECK_RULE_ACK_OK:
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   case EH_CHECK_RULE_ACK_INVALID_RULE_ID:
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   case EH_CHECK_RULE_ACK_UNREGISTERED:
     return CCP_EXEC_ILLEGAL_CONTEXT;
   default:
@@ -1618,7 +1618,7 @@ CCP_CmdRet Cmd_EH_INACTIVATE_RULE(const CommonCmdPacket* packet)
   case EH_CHECK_RULE_ACK_OK:
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   case EH_CHECK_RULE_ACK_INVALID_RULE_ID:
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   case EH_CHECK_RULE_ACK_UNREGISTERED:
     return CCP_EXEC_ILLEGAL_CONTEXT;
   default:
@@ -1637,7 +1637,7 @@ CCP_CmdRet Cmd_EH_ACTIVATE_RULE_FOR_MULTI_LEVEL(const CommonCmdPacket* packet)
   case EH_CHECK_RULE_ACK_OK:
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   case EH_CHECK_RULE_ACK_INVALID_RULE_ID:
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   case EH_CHECK_RULE_ACK_UNREGISTERED:
     return CCP_EXEC_ILLEGAL_CONTEXT;
   default:
@@ -1656,7 +1656,7 @@ CCP_CmdRet Cmd_EH_INACTIVATE_RULE_FOR_MULTI_LEVEL(const CommonCmdPacket* packet)
   case EH_CHECK_RULE_ACK_OK:
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   case EH_CHECK_RULE_ACK_INVALID_RULE_ID:
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   case EH_CHECK_RULE_ACK_UNREGISTERED:
     return CCP_EXEC_ILLEGAL_CONTEXT;
   default:
@@ -1676,7 +1676,7 @@ CCP_CmdRet Cmd_EH_SET_RULE_COUNTER(const CommonCmdPacket* packet)
   case EH_CHECK_RULE_ACK_OK:
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   case EH_CHECK_RULE_ACK_INVALID_RULE_ID:
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   case EH_CHECK_RULE_ACK_UNREGISTERED:
     return CCP_EXEC_ILLEGAL_CONTEXT;
   default:
@@ -1695,7 +1695,7 @@ CCP_CmdRet Cmd_EH_CLEAR_RULE_COUNTER(const CommonCmdPacket* packet)
   case EH_CHECK_RULE_ACK_OK:
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   case EH_CHECK_RULE_ACK_INVALID_RULE_ID:
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   case EH_CHECK_RULE_ACK_UNREGISTERED:
     return CCP_EXEC_ILLEGAL_CONTEXT;
   default:
@@ -1747,7 +1747,7 @@ CCP_CmdRet Cmd_EH_SET_MAX_MULTI_LEVEL_NUM(const CommonCmdPacket* packet)
 CCP_CmdRet Cmd_EH_SET_PAGE_OF_RULE_TABLE_FOR_TLM(const CommonCmdPacket* packet)
 {
   uint8_t page = CCP_get_param_from_packet(packet, 0, uint8_t);
-  if (page >= EH_RULE_TLM_PAGE_MAX) return CCP_EXEC_ILLEGAL_PARAMETER;
+  if (page >= EH_RULE_TLM_PAGE_MAX) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   event_handler_.tlm_info.rule.page_no = page;
   return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
@@ -1756,7 +1756,7 @@ CCP_CmdRet Cmd_EH_SET_PAGE_OF_RULE_TABLE_FOR_TLM(const CommonCmdPacket* packet)
 CCP_CmdRet Cmd_EH_SET_PAGE_OF_RULE_SORTED_IDX_FOR_TLM(const CommonCmdPacket* packet)
 {
   uint8_t page = CCP_get_param_from_packet(packet, 0, uint8_t);
-  if (page >= EH_RULE_TLM_PAGE_MAX) return CCP_EXEC_ILLEGAL_PARAMETER;
+  if (page >= EH_RULE_TLM_PAGE_MAX) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   event_handler_.tlm_info.rule_sorted_index.page_no = page;
   return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
@@ -1765,7 +1765,7 @@ CCP_CmdRet Cmd_EH_SET_PAGE_OF_RULE_SORTED_IDX_FOR_TLM(const CommonCmdPacket* pac
 CCP_CmdRet Cmd_EH_SET_PAGE_OF_LOG_TABLE_FOR_TLM(const CommonCmdPacket* packet)
 {
   uint8_t page = CCP_get_param_from_packet(packet, 0, uint8_t);
-  if (page >= EH_LOG_TLM_PAGE_MAX) return CCP_EXEC_ILLEGAL_PARAMETER;
+  if (page >= EH_LOG_TLM_PAGE_MAX) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   event_handler_.tlm_info.log.page_no = page;
   return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
@@ -1777,7 +1777,7 @@ CCP_CmdRet Cmd_EH_SET_TARGET_ID_OF_RULE_TABLE_FOR_TLM(const CommonCmdPacket* pac
 
   if (EH_check_rule_id_(rule_id) == EH_CHECK_RULE_ACK_INVALID_RULE_ID)
   {
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   }
 
   event_handler_.tlm_info.rule.target_rule_id = rule_id;

--- a/System/EventManager/event_handler.c
+++ b/System/EventManager/event_handler.c
@@ -1449,7 +1449,7 @@ const EH_Log* EH_get_the_nth_log_from_the_latest(uint16_t n)
 }
 
 
-CCP_EXEC_STS Cmd_EH_INIT(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EH_INIT(const CommonCmdPacket* packet)
 {
   (void)packet;
   EH_initialize();
@@ -1457,7 +1457,7 @@ CCP_EXEC_STS Cmd_EH_INIT(const CommonCmdPacket* packet)
 }
 
 
-CCP_EXEC_STS Cmd_EH_CLEAR_ALL_RULE(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EH_CLEAR_ALL_RULE(const CommonCmdPacket* packet)
 {
   (void)packet;
   EH_clear_rules_();
@@ -1465,7 +1465,7 @@ CCP_EXEC_STS Cmd_EH_CLEAR_ALL_RULE(const CommonCmdPacket* packet)
 }
 
 
-CCP_EXEC_STS Cmd_EH_LOAD_DEFAULT_RULE(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EH_LOAD_DEFAULT_RULE(const CommonCmdPacket* packet)
 {
   (void)packet;
   EH_load_default_rules();
@@ -1473,7 +1473,7 @@ CCP_EXEC_STS Cmd_EH_LOAD_DEFAULT_RULE(const CommonCmdPacket* packet)
 }
 
 
-CCP_EXEC_STS Cmd_EH_SET_REGISTER_RULE_EVENT_PARAM(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EH_SET_REGISTER_RULE_EVENT_PARAM(const CommonCmdPacket* packet)
 {
   // 登録する瞬間にしかわからないので，ここでは値のアサーションはせず，
   // Cmd_EH_REGISTER_RULE でアサーションする
@@ -1488,7 +1488,7 @@ CCP_EXEC_STS Cmd_EH_SET_REGISTER_RULE_EVENT_PARAM(const CommonCmdPacket* packet)
 }
 
 
-CCP_EXEC_STS Cmd_EH_SET_REGISTER_RULE_CONDITION_PARAM(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EH_SET_REGISTER_RULE_CONDITION_PARAM(const CommonCmdPacket* packet)
 {
   // 登録する瞬間にしかわからないので，ここでは値のアサーションはせず，
   // Cmd_EH_REGISTER_RULE でアサーションする
@@ -1501,7 +1501,7 @@ CCP_EXEC_STS Cmd_EH_SET_REGISTER_RULE_CONDITION_PARAM(const CommonCmdPacket* pac
 }
 
 
-CCP_EXEC_STS Cmd_EH_REGISTER_RULE(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EH_REGISTER_RULE(const CommonCmdPacket* packet)
 {
   (void)packet;
   event_handler_.reg_from_cmd.register_ack =
@@ -1532,7 +1532,7 @@ CCP_EXEC_STS Cmd_EH_REGISTER_RULE(const CommonCmdPacket* packet)
 }
 
 
-CCP_EXEC_STS Cmd_EH_DELETE_RULE(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EH_DELETE_RULE(const CommonCmdPacket* packet)
 {
   EH_RULE_ID rule_id = (EH_RULE_ID)CCP_get_param_from_packet(packet, 0, uint16_t);
   EH_RULE_SORTED_INDEX_ACK ack = EH_delete_rule_table_(rule_id);
@@ -1551,7 +1551,7 @@ CCP_EXEC_STS Cmd_EH_DELETE_RULE(const CommonCmdPacket* packet)
 }
 
 
-CCP_EXEC_STS Cmd_EH_INIT_RULE(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EH_INIT_RULE(const CommonCmdPacket* packet)
 {
   EH_RULE_ID rule_id = (EH_RULE_ID)CCP_get_param_from_packet(packet, 0, uint16_t);
   EH_CHECK_RULE_ACK ack = EH_init_rule(rule_id);
@@ -1570,7 +1570,7 @@ CCP_EXEC_STS Cmd_EH_INIT_RULE(const CommonCmdPacket* packet)
 }
 
 
-CCP_EXEC_STS Cmd_EH_INIT_RULE_FOR_MULTI_LEVEL(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EH_INIT_RULE_FOR_MULTI_LEVEL(const CommonCmdPacket* packet)
 {
   EH_RULE_ID rule_id = (EH_RULE_ID)CCP_get_param_from_packet(packet, 0, uint16_t);
   EH_CHECK_RULE_ACK ack = EH_init_rule_for_multi_level(rule_id);
@@ -1589,7 +1589,7 @@ CCP_EXEC_STS Cmd_EH_INIT_RULE_FOR_MULTI_LEVEL(const CommonCmdPacket* packet)
 }
 
 
-CCP_EXEC_STS Cmd_EH_ACTIVATE_RULE(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EH_ACTIVATE_RULE(const CommonCmdPacket* packet)
 {
   EH_RULE_ID rule_id = (EH_RULE_ID)CCP_get_param_from_packet(packet, 0, uint16_t);
   EH_CHECK_RULE_ACK ack = EH_activate_rule(rule_id);
@@ -1608,7 +1608,7 @@ CCP_EXEC_STS Cmd_EH_ACTIVATE_RULE(const CommonCmdPacket* packet)
 }
 
 
-CCP_EXEC_STS Cmd_EH_INACTIVATE_RULE(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EH_INACTIVATE_RULE(const CommonCmdPacket* packet)
 {
   EH_RULE_ID rule_id = (EH_RULE_ID)CCP_get_param_from_packet(packet, 0, uint16_t);
   EH_CHECK_RULE_ACK ack = EH_inactivate_rule(rule_id);
@@ -1627,7 +1627,7 @@ CCP_EXEC_STS Cmd_EH_INACTIVATE_RULE(const CommonCmdPacket* packet)
 }
 
 
-CCP_EXEC_STS Cmd_EH_ACTIVATE_RULE_FOR_MULTI_LEVEL(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EH_ACTIVATE_RULE_FOR_MULTI_LEVEL(const CommonCmdPacket* packet)
 {
   EH_RULE_ID rule_id = (EH_RULE_ID)CCP_get_param_from_packet(packet, 0, uint16_t);
   EH_CHECK_RULE_ACK ack = EH_activate_rule_for_multi_level(rule_id);
@@ -1646,7 +1646,7 @@ CCP_EXEC_STS Cmd_EH_ACTIVATE_RULE_FOR_MULTI_LEVEL(const CommonCmdPacket* packet)
 }
 
 
-CCP_EXEC_STS Cmd_EH_INACTIVATE_RULE_FOR_MULTI_LEVEL(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EH_INACTIVATE_RULE_FOR_MULTI_LEVEL(const CommonCmdPacket* packet)
 {
   EH_RULE_ID rule_id = (EH_RULE_ID)CCP_get_param_from_packet(packet, 0, uint16_t);
   EH_CHECK_RULE_ACK ack = EH_inactivate_rule_for_multi_level(rule_id);
@@ -1665,7 +1665,7 @@ CCP_EXEC_STS Cmd_EH_INACTIVATE_RULE_FOR_MULTI_LEVEL(const CommonCmdPacket* packe
 }
 
 
-CCP_EXEC_STS Cmd_EH_SET_RULE_COUNTER(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EH_SET_RULE_COUNTER(const CommonCmdPacket* packet)
 {
   EH_RULE_ID rule_id = (EH_RULE_ID)CCP_get_param_from_packet(packet, 0, uint16_t);
   uint16_t counter = CCP_get_param_from_packet(packet, 1, uint16_t);
@@ -1685,7 +1685,7 @@ CCP_EXEC_STS Cmd_EH_SET_RULE_COUNTER(const CommonCmdPacket* packet)
 }
 
 
-CCP_EXEC_STS Cmd_EH_CLEAR_RULE_COUNTER(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EH_CLEAR_RULE_COUNTER(const CommonCmdPacket* packet)
 {
   EH_RULE_ID rule_id = (EH_RULE_ID)CCP_get_param_from_packet(packet, 0, uint16_t);
   EH_CHECK_RULE_ACK ack = EH_clear_rule_counter(rule_id);
@@ -1704,7 +1704,7 @@ CCP_EXEC_STS Cmd_EH_CLEAR_RULE_COUNTER(const CommonCmdPacket* packet)
 }
 
 
-CCP_EXEC_STS Cmd_EH_CLEAR_RULE_COUNTER_BY_EVENT(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EH_CLEAR_RULE_COUNTER_BY_EVENT(const CommonCmdPacket* packet)
 {
   EL_GROUP group = (EL_GROUP)CCP_get_param_from_packet(packet, 0, uint32_t);
   uint32_t local = (EL_GROUP)CCP_get_param_from_packet(packet, 1, uint32_t);
@@ -1715,7 +1715,7 @@ CCP_EXEC_STS Cmd_EH_CLEAR_RULE_COUNTER_BY_EVENT(const CommonCmdPacket* packet)
 }
 
 
-CCP_EXEC_STS Cmd_EH_CLEAR_LOG(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EH_CLEAR_LOG(const CommonCmdPacket* packet)
 {
   (void)packet;
   EH_clear_log_();
@@ -1723,28 +1723,28 @@ CCP_EXEC_STS Cmd_EH_CLEAR_LOG(const CommonCmdPacket* packet)
 }
 
 
-CCP_EXEC_STS Cmd_EH_SET_MAX_RESPONSE_NUM(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EH_SET_MAX_RESPONSE_NUM(const CommonCmdPacket* packet)
 {
   event_handler_.exec_settings.max_response_num = CCP_get_param_from_packet(packet, 0, uint8_t);
   return CCP_EXEC_SUCCESS;
 }
 
 
-CCP_EXEC_STS Cmd_EH_SET_MAX_CHECK_EVENT_NUM(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EH_SET_MAX_CHECK_EVENT_NUM(const CommonCmdPacket* packet)
 {
   event_handler_.exec_settings.max_check_event_num = CCP_get_param_from_packet(packet, 0, uint16_t);
   return CCP_EXEC_SUCCESS;
 }
 
 
-CCP_EXEC_STS Cmd_EH_SET_MAX_MULTI_LEVEL_NUM(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EH_SET_MAX_MULTI_LEVEL_NUM(const CommonCmdPacket* packet)
 {
   event_handler_.exec_settings.max_multi_level_num = CCP_get_param_from_packet(packet, 0, uint8_t);
   return CCP_EXEC_SUCCESS;
 }
 
 
-CCP_EXEC_STS Cmd_EH_SET_PAGE_OF_RULE_TABLE_FOR_TLM(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EH_SET_PAGE_OF_RULE_TABLE_FOR_TLM(const CommonCmdPacket* packet)
 {
   uint8_t page = CCP_get_param_from_packet(packet, 0, uint8_t);
   if (page >= EH_RULE_TLM_PAGE_MAX) return CCP_EXEC_ILLEGAL_PARAMETER;
@@ -1753,7 +1753,7 @@ CCP_EXEC_STS Cmd_EH_SET_PAGE_OF_RULE_TABLE_FOR_TLM(const CommonCmdPacket* packet
 }
 
 
-CCP_EXEC_STS Cmd_EH_SET_PAGE_OF_RULE_SORTED_IDX_FOR_TLM(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EH_SET_PAGE_OF_RULE_SORTED_IDX_FOR_TLM(const CommonCmdPacket* packet)
 {
   uint8_t page = CCP_get_param_from_packet(packet, 0, uint8_t);
   if (page >= EH_RULE_TLM_PAGE_MAX) return CCP_EXEC_ILLEGAL_PARAMETER;
@@ -1762,7 +1762,7 @@ CCP_EXEC_STS Cmd_EH_SET_PAGE_OF_RULE_SORTED_IDX_FOR_TLM(const CommonCmdPacket* p
 }
 
 
-CCP_EXEC_STS Cmd_EH_SET_PAGE_OF_LOG_TABLE_FOR_TLM(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EH_SET_PAGE_OF_LOG_TABLE_FOR_TLM(const CommonCmdPacket* packet)
 {
   uint8_t page = CCP_get_param_from_packet(packet, 0, uint8_t);
   if (page >= EH_LOG_TLM_PAGE_MAX) return CCP_EXEC_ILLEGAL_PARAMETER;
@@ -1771,7 +1771,7 @@ CCP_EXEC_STS Cmd_EH_SET_PAGE_OF_LOG_TABLE_FOR_TLM(const CommonCmdPacket* packet)
 }
 
 
-CCP_EXEC_STS Cmd_EH_SET_TARGET_ID_OF_RULE_TABLE_FOR_TLM(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EH_SET_TARGET_ID_OF_RULE_TABLE_FOR_TLM(const CommonCmdPacket* packet)
 {
   EH_RULE_ID rule_id = (EH_RULE_ID)CCP_get_param_from_packet(packet, 0, uint16_t);
 
@@ -1785,7 +1785,7 @@ CCP_EXEC_STS Cmd_EH_SET_TARGET_ID_OF_RULE_TABLE_FOR_TLM(const CommonCmdPacket* p
 }
 
 
-CCP_EXEC_STS Cmd_EH_MATCH_EVENT_COUNTER_TO_EL(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EH_MATCH_EVENT_COUNTER_TO_EL(const CommonCmdPacket* packet)
 {
   (void)packet;
   EH_match_event_counter_to_el();
@@ -1793,7 +1793,7 @@ CCP_EXEC_STS Cmd_EH_MATCH_EVENT_COUNTER_TO_EL(const CommonCmdPacket* packet)
 }
 
 
-CCP_EXEC_STS Cmd_EH_INIT_RULE_BY_EVENT_GROUP(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EH_INIT_RULE_BY_EVENT_GROUP(const CommonCmdPacket* packet)
 {
   EL_GROUP group = (EL_GROUP)CCP_get_param_from_packet(packet, 0, uint32_t);
   EH_init_rule_by_event_group(group);
@@ -1801,7 +1801,7 @@ CCP_EXEC_STS Cmd_EH_INIT_RULE_BY_EVENT_GROUP(const CommonCmdPacket* packet)
 }
 
 
-CCP_EXEC_STS Cmd_EH_INIT_RULE_BY_EVENT_GROUP_FOR_MULTI_LEVEL(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EH_INIT_RULE_BY_EVENT_GROUP_FOR_MULTI_LEVEL(const CommonCmdPacket* packet)
 {
   EL_GROUP group = (EL_GROUP)CCP_get_param_from_packet(packet, 0, uint32_t);
   EH_init_rule_by_event_group_for_multi_level(group);
@@ -1809,7 +1809,7 @@ CCP_EXEC_STS Cmd_EH_INIT_RULE_BY_EVENT_GROUP_FOR_MULTI_LEVEL(const CommonCmdPack
 }
 
 
-CCP_EXEC_STS Cmd_EH_ACTIVATE_RULE_BY_EVENT_GROUP(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EH_ACTIVATE_RULE_BY_EVENT_GROUP(const CommonCmdPacket* packet)
 {
   EL_GROUP group = (EL_GROUP)CCP_get_param_from_packet(packet, 0, uint32_t);
   EH_activate_rule_by_event_group(group);
@@ -1817,7 +1817,7 @@ CCP_EXEC_STS Cmd_EH_ACTIVATE_RULE_BY_EVENT_GROUP(const CommonCmdPacket* packet)
 }
 
 
-CCP_EXEC_STS Cmd_EH_INACTIVATE_RULE_BY_EVENT_GROUP(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EH_INACTIVATE_RULE_BY_EVENT_GROUP(const CommonCmdPacket* packet)
 {
   EL_GROUP group = (EL_GROUP)CCP_get_param_from_packet(packet, 0, uint32_t);
   EH_inactivate_rule_by_event_group(group);
@@ -1825,7 +1825,7 @@ CCP_EXEC_STS Cmd_EH_INACTIVATE_RULE_BY_EVENT_GROUP(const CommonCmdPacket* packet
 }
 
 
-CCP_EXEC_STS Cmd_EH_ACTIVATE_RULE_BY_EVENT_GROUP_FOR_MULTI_LEVEL(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EH_ACTIVATE_RULE_BY_EVENT_GROUP_FOR_MULTI_LEVEL(const CommonCmdPacket* packet)
 {
   EL_GROUP group = (EL_GROUP)CCP_get_param_from_packet(packet, 0, uint32_t);
   EH_activate_rule_by_event_group_for_multi_level(group);
@@ -1833,7 +1833,7 @@ CCP_EXEC_STS Cmd_EH_ACTIVATE_RULE_BY_EVENT_GROUP_FOR_MULTI_LEVEL(const CommonCmd
 }
 
 
-CCP_EXEC_STS Cmd_EH_INACTIVATE_RULE_BY_EVENT_GROUP_FOR_MULTI_LEVEL(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EH_INACTIVATE_RULE_BY_EVENT_GROUP_FOR_MULTI_LEVEL(const CommonCmdPacket* packet)
 {
   EL_GROUP group = (EL_GROUP)CCP_get_param_from_packet(packet, 0, uint32_t);
   EH_inactivate_rule_by_event_group_for_multi_level(group);

--- a/System/EventManager/event_handler.c
+++ b/System/EventManager/event_handler.c
@@ -1525,9 +1525,9 @@ CCP_CmdRet Cmd_EH_REGISTER_RULE(const CommonCmdPacket* packet)
   case EH_REGISTER_ACK_ERR_RULE_OVERWRITE:
   case EH_REGISTER_ACK_ERR_DUPLICATE_FULL:
   case EH_REGISTER_ACK_UNKNOWN_ERR:
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   default:
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   }
 }
 
@@ -1544,9 +1544,9 @@ CCP_CmdRet Cmd_EH_DELETE_RULE(const CommonCmdPacket* packet)
   case EH_RULE_SORTED_INDEX_ACK_ILLEGAL_RULE_ID:
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   case EH_RULE_SORTED_INDEX_ACK_NOT_FOUND:
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   default:
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   }
 }
 
@@ -1563,9 +1563,9 @@ CCP_CmdRet Cmd_EH_INIT_RULE(const CommonCmdPacket* packet)
   case EH_CHECK_RULE_ACK_INVALID_RULE_ID:
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   case EH_CHECK_RULE_ACK_UNREGISTERED:
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   default:
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   }
 }
 
@@ -1582,9 +1582,9 @@ CCP_CmdRet Cmd_EH_INIT_RULE_FOR_MULTI_LEVEL(const CommonCmdPacket* packet)
   case EH_CHECK_RULE_ACK_INVALID_RULE_ID:
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   case EH_CHECK_RULE_ACK_UNREGISTERED:
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   default:
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   }
 }
 
@@ -1601,9 +1601,9 @@ CCP_CmdRet Cmd_EH_ACTIVATE_RULE(const CommonCmdPacket* packet)
   case EH_CHECK_RULE_ACK_INVALID_RULE_ID:
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   case EH_CHECK_RULE_ACK_UNREGISTERED:
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   default:
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   }
 }
 
@@ -1620,9 +1620,9 @@ CCP_CmdRet Cmd_EH_INACTIVATE_RULE(const CommonCmdPacket* packet)
   case EH_CHECK_RULE_ACK_INVALID_RULE_ID:
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   case EH_CHECK_RULE_ACK_UNREGISTERED:
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   default:
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   }
 }
 
@@ -1639,9 +1639,9 @@ CCP_CmdRet Cmd_EH_ACTIVATE_RULE_FOR_MULTI_LEVEL(const CommonCmdPacket* packet)
   case EH_CHECK_RULE_ACK_INVALID_RULE_ID:
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   case EH_CHECK_RULE_ACK_UNREGISTERED:
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   default:
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   }
 }
 
@@ -1658,9 +1658,9 @@ CCP_CmdRet Cmd_EH_INACTIVATE_RULE_FOR_MULTI_LEVEL(const CommonCmdPacket* packet)
   case EH_CHECK_RULE_ACK_INVALID_RULE_ID:
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   case EH_CHECK_RULE_ACK_UNREGISTERED:
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   default:
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   }
 }
 
@@ -1678,9 +1678,9 @@ CCP_CmdRet Cmd_EH_SET_RULE_COUNTER(const CommonCmdPacket* packet)
   case EH_CHECK_RULE_ACK_INVALID_RULE_ID:
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   case EH_CHECK_RULE_ACK_UNREGISTERED:
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   default:
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   }
 }
 
@@ -1697,9 +1697,9 @@ CCP_CmdRet Cmd_EH_CLEAR_RULE_COUNTER(const CommonCmdPacket* packet)
   case EH_CHECK_RULE_ACK_INVALID_RULE_ID:
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   case EH_CHECK_RULE_ACK_UNREGISTERED:
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   default:
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   }
 }
 

--- a/System/EventManager/event_handler.c
+++ b/System/EventManager/event_handler.c
@@ -1453,7 +1453,7 @@ CCP_CmdRet Cmd_EH_INIT(const CommonCmdPacket* packet)
 {
   (void)packet;
   EH_initialize();
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
@@ -1461,7 +1461,7 @@ CCP_CmdRet Cmd_EH_CLEAR_ALL_RULE(const CommonCmdPacket* packet)
 {
   (void)packet;
   EH_clear_rules_();
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
@@ -1469,7 +1469,7 @@ CCP_CmdRet Cmd_EH_LOAD_DEFAULT_RULE(const CommonCmdPacket* packet)
 {
   (void)packet;
   EH_load_default_rules();
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
@@ -1484,7 +1484,7 @@ CCP_CmdRet Cmd_EH_SET_REGISTER_RULE_EVENT_PARAM(const CommonCmdPacket* packet)
   event_handler_.reg_from_cmd.settings.should_match_err_level = CCP_get_param_from_packet(packet, 4, uint8_t);
   event_handler_.reg_from_cmd.settings.deploy_bct_id = CCP_get_param_from_packet(packet, 5, bct_id_t);
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
@@ -1497,7 +1497,7 @@ CCP_CmdRet Cmd_EH_SET_REGISTER_RULE_CONDITION_PARAM(const CommonCmdPacket* packe
   event_handler_.reg_from_cmd.settings.condition.time_threshold_ms = CCP_get_param_from_packet(packet, 2, uint32_t);
   event_handler_.reg_from_cmd.settings.is_active = CCP_get_param_from_packet(packet, 3, uint8_t);
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
@@ -1510,7 +1510,7 @@ CCP_CmdRet Cmd_EH_REGISTER_RULE(const CommonCmdPacket* packet)
   switch (event_handler_.reg_from_cmd.register_ack)
   {
   case EH_REGISTER_ACK_OK:
-    return CCP_EXEC_SUCCESS;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   case EH_REGISTER_ACK_ILLEGAL_RULE_ID:
   case EH_REGISTER_ACK_ILLEGAL_GROUP:
   case EH_REGISTER_ACK_ILLEGAL_ERROR_LEVEL:
@@ -1540,7 +1540,7 @@ CCP_CmdRet Cmd_EH_DELETE_RULE(const CommonCmdPacket* packet)
   switch (ack)
   {
   case EH_RULE_SORTED_INDEX_ACK_OK:
-    return CCP_EXEC_SUCCESS;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   case EH_RULE_SORTED_INDEX_ACK_ILLEGAL_RULE_ID:
     return CCP_EXEC_ILLEGAL_PARAMETER;
   case EH_RULE_SORTED_INDEX_ACK_NOT_FOUND:
@@ -1559,7 +1559,7 @@ CCP_CmdRet Cmd_EH_INIT_RULE(const CommonCmdPacket* packet)
   switch (ack)
   {
   case EH_CHECK_RULE_ACK_OK:
-    return CCP_EXEC_SUCCESS;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   case EH_CHECK_RULE_ACK_INVALID_RULE_ID:
     return CCP_EXEC_ILLEGAL_PARAMETER;
   case EH_CHECK_RULE_ACK_UNREGISTERED:
@@ -1578,7 +1578,7 @@ CCP_CmdRet Cmd_EH_INIT_RULE_FOR_MULTI_LEVEL(const CommonCmdPacket* packet)
   switch (ack)
   {
   case EH_CHECK_RULE_ACK_OK:
-    return CCP_EXEC_SUCCESS;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   case EH_CHECK_RULE_ACK_INVALID_RULE_ID:
     return CCP_EXEC_ILLEGAL_PARAMETER;
   case EH_CHECK_RULE_ACK_UNREGISTERED:
@@ -1597,7 +1597,7 @@ CCP_CmdRet Cmd_EH_ACTIVATE_RULE(const CommonCmdPacket* packet)
   switch (ack)
   {
   case EH_CHECK_RULE_ACK_OK:
-    return CCP_EXEC_SUCCESS;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   case EH_CHECK_RULE_ACK_INVALID_RULE_ID:
     return CCP_EXEC_ILLEGAL_PARAMETER;
   case EH_CHECK_RULE_ACK_UNREGISTERED:
@@ -1616,7 +1616,7 @@ CCP_CmdRet Cmd_EH_INACTIVATE_RULE(const CommonCmdPacket* packet)
   switch (ack)
   {
   case EH_CHECK_RULE_ACK_OK:
-    return CCP_EXEC_SUCCESS;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   case EH_CHECK_RULE_ACK_INVALID_RULE_ID:
     return CCP_EXEC_ILLEGAL_PARAMETER;
   case EH_CHECK_RULE_ACK_UNREGISTERED:
@@ -1635,7 +1635,7 @@ CCP_CmdRet Cmd_EH_ACTIVATE_RULE_FOR_MULTI_LEVEL(const CommonCmdPacket* packet)
   switch (ack)
   {
   case EH_CHECK_RULE_ACK_OK:
-    return CCP_EXEC_SUCCESS;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   case EH_CHECK_RULE_ACK_INVALID_RULE_ID:
     return CCP_EXEC_ILLEGAL_PARAMETER;
   case EH_CHECK_RULE_ACK_UNREGISTERED:
@@ -1654,7 +1654,7 @@ CCP_CmdRet Cmd_EH_INACTIVATE_RULE_FOR_MULTI_LEVEL(const CommonCmdPacket* packet)
   switch (ack)
   {
   case EH_CHECK_RULE_ACK_OK:
-    return CCP_EXEC_SUCCESS;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   case EH_CHECK_RULE_ACK_INVALID_RULE_ID:
     return CCP_EXEC_ILLEGAL_PARAMETER;
   case EH_CHECK_RULE_ACK_UNREGISTERED:
@@ -1674,7 +1674,7 @@ CCP_CmdRet Cmd_EH_SET_RULE_COUNTER(const CommonCmdPacket* packet)
   switch (ack)
   {
   case EH_CHECK_RULE_ACK_OK:
-    return CCP_EXEC_SUCCESS;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   case EH_CHECK_RULE_ACK_INVALID_RULE_ID:
     return CCP_EXEC_ILLEGAL_PARAMETER;
   case EH_CHECK_RULE_ACK_UNREGISTERED:
@@ -1693,7 +1693,7 @@ CCP_CmdRet Cmd_EH_CLEAR_RULE_COUNTER(const CommonCmdPacket* packet)
   switch (ack)
   {
   case EH_CHECK_RULE_ACK_OK:
-    return CCP_EXEC_SUCCESS;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   case EH_CHECK_RULE_ACK_INVALID_RULE_ID:
     return CCP_EXEC_ILLEGAL_PARAMETER;
   case EH_CHECK_RULE_ACK_UNREGISTERED:
@@ -1711,7 +1711,7 @@ CCP_CmdRet Cmd_EH_CLEAR_RULE_COUNTER_BY_EVENT(const CommonCmdPacket* packet)
   EL_ERROR_LEVEL err_level = (EL_ERROR_LEVEL)CCP_get_param_from_packet(packet, 2, uint8_t);
 
   EH_clear_rule_counter_by_event(group, local, err_level);
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
@@ -1719,28 +1719,28 @@ CCP_CmdRet Cmd_EH_CLEAR_LOG(const CommonCmdPacket* packet)
 {
   (void)packet;
   EH_clear_log_();
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
 CCP_CmdRet Cmd_EH_SET_MAX_RESPONSE_NUM(const CommonCmdPacket* packet)
 {
   event_handler_.exec_settings.max_response_num = CCP_get_param_from_packet(packet, 0, uint8_t);
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
 CCP_CmdRet Cmd_EH_SET_MAX_CHECK_EVENT_NUM(const CommonCmdPacket* packet)
 {
   event_handler_.exec_settings.max_check_event_num = CCP_get_param_from_packet(packet, 0, uint16_t);
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
 CCP_CmdRet Cmd_EH_SET_MAX_MULTI_LEVEL_NUM(const CommonCmdPacket* packet)
 {
   event_handler_.exec_settings.max_multi_level_num = CCP_get_param_from_packet(packet, 0, uint8_t);
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
@@ -1749,7 +1749,7 @@ CCP_CmdRet Cmd_EH_SET_PAGE_OF_RULE_TABLE_FOR_TLM(const CommonCmdPacket* packet)
   uint8_t page = CCP_get_param_from_packet(packet, 0, uint8_t);
   if (page >= EH_RULE_TLM_PAGE_MAX) return CCP_EXEC_ILLEGAL_PARAMETER;
   event_handler_.tlm_info.rule.page_no = page;
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
@@ -1758,7 +1758,7 @@ CCP_CmdRet Cmd_EH_SET_PAGE_OF_RULE_SORTED_IDX_FOR_TLM(const CommonCmdPacket* pac
   uint8_t page = CCP_get_param_from_packet(packet, 0, uint8_t);
   if (page >= EH_RULE_TLM_PAGE_MAX) return CCP_EXEC_ILLEGAL_PARAMETER;
   event_handler_.tlm_info.rule_sorted_index.page_no = page;
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
@@ -1767,7 +1767,7 @@ CCP_CmdRet Cmd_EH_SET_PAGE_OF_LOG_TABLE_FOR_TLM(const CommonCmdPacket* packet)
   uint8_t page = CCP_get_param_from_packet(packet, 0, uint8_t);
   if (page >= EH_LOG_TLM_PAGE_MAX) return CCP_EXEC_ILLEGAL_PARAMETER;
   event_handler_.tlm_info.log.page_no = page;
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
@@ -1781,7 +1781,7 @@ CCP_CmdRet Cmd_EH_SET_TARGET_ID_OF_RULE_TABLE_FOR_TLM(const CommonCmdPacket* pac
   }
 
   event_handler_.tlm_info.rule.target_rule_id = rule_id;
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
@@ -1789,7 +1789,7 @@ CCP_CmdRet Cmd_EH_MATCH_EVENT_COUNTER_TO_EL(const CommonCmdPacket* packet)
 {
   (void)packet;
   EH_match_event_counter_to_el();
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
@@ -1797,7 +1797,7 @@ CCP_CmdRet Cmd_EH_INIT_RULE_BY_EVENT_GROUP(const CommonCmdPacket* packet)
 {
   EL_GROUP group = (EL_GROUP)CCP_get_param_from_packet(packet, 0, uint32_t);
   EH_init_rule_by_event_group(group);
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
@@ -1805,7 +1805,7 @@ CCP_CmdRet Cmd_EH_INIT_RULE_BY_EVENT_GROUP_FOR_MULTI_LEVEL(const CommonCmdPacket
 {
   EL_GROUP group = (EL_GROUP)CCP_get_param_from_packet(packet, 0, uint32_t);
   EH_init_rule_by_event_group_for_multi_level(group);
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
@@ -1813,7 +1813,7 @@ CCP_CmdRet Cmd_EH_ACTIVATE_RULE_BY_EVENT_GROUP(const CommonCmdPacket* packet)
 {
   EL_GROUP group = (EL_GROUP)CCP_get_param_from_packet(packet, 0, uint32_t);
   EH_activate_rule_by_event_group(group);
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
@@ -1821,7 +1821,7 @@ CCP_CmdRet Cmd_EH_INACTIVATE_RULE_BY_EVENT_GROUP(const CommonCmdPacket* packet)
 {
   EL_GROUP group = (EL_GROUP)CCP_get_param_from_packet(packet, 0, uint32_t);
   EH_inactivate_rule_by_event_group(group);
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
@@ -1829,7 +1829,7 @@ CCP_CmdRet Cmd_EH_ACTIVATE_RULE_BY_EVENT_GROUP_FOR_MULTI_LEVEL(const CommonCmdPa
 {
   EL_GROUP group = (EL_GROUP)CCP_get_param_from_packet(packet, 0, uint32_t);
   EH_activate_rule_by_event_group_for_multi_level(group);
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
@@ -1837,7 +1837,7 @@ CCP_CmdRet Cmd_EH_INACTIVATE_RULE_BY_EVENT_GROUP_FOR_MULTI_LEVEL(const CommonCmd
 {
   EL_GROUP group = (EL_GROUP)CCP_get_param_from_packet(packet, 0, uint32_t);
   EH_inactivate_rule_by_event_group_for_multi_level(group);
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 #endif  // EL_IS_ENABLE_TLOG

--- a/System/EventManager/event_handler.h
+++ b/System/EventManager/event_handler.h
@@ -548,71 +548,71 @@ void EH_match_event_counter_to_el(void);
 const EH_Log* EH_get_the_nth_log_from_the_latest(uint16_t n);
 
 
-CCP_EXEC_STS Cmd_EH_INIT(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EH_INIT(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_EH_CLEAR_ALL_RULE(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EH_CLEAR_ALL_RULE(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_EH_LOAD_DEFAULT_RULE(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EH_LOAD_DEFAULT_RULE(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_EH_SET_REGISTER_RULE_EVENT_PARAM(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EH_SET_REGISTER_RULE_EVENT_PARAM(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_EH_SET_REGISTER_RULE_CONDITION_PARAM(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EH_SET_REGISTER_RULE_CONDITION_PARAM(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_EH_REGISTER_RULE(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EH_REGISTER_RULE(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_EH_DELETE_RULE(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EH_DELETE_RULE(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_EH_INIT_RULE(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EH_INIT_RULE(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_EH_INIT_RULE_FOR_MULTI_LEVEL(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EH_INIT_RULE_FOR_MULTI_LEVEL(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_EH_ACTIVATE_RULE(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EH_ACTIVATE_RULE(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_EH_INACTIVATE_RULE(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EH_INACTIVATE_RULE(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_EH_ACTIVATE_RULE_FOR_MULTI_LEVEL(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EH_ACTIVATE_RULE_FOR_MULTI_LEVEL(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_EH_INACTIVATE_RULE_FOR_MULTI_LEVEL(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EH_INACTIVATE_RULE_FOR_MULTI_LEVEL(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_EH_SET_RULE_COUNTER(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EH_SET_RULE_COUNTER(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_EH_CLEAR_RULE_COUNTER(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EH_CLEAR_RULE_COUNTER(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_EH_CLEAR_RULE_COUNTER_BY_EVENT(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EH_CLEAR_RULE_COUNTER_BY_EVENT(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_EH_CLEAR_LOG(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EH_CLEAR_LOG(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_EH_SET_MAX_RESPONSE_NUM(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EH_SET_MAX_RESPONSE_NUM(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_EH_SET_MAX_CHECK_EVENT_NUM(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EH_SET_MAX_CHECK_EVENT_NUM(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_EH_SET_MAX_MULTI_LEVEL_NUM(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EH_SET_MAX_MULTI_LEVEL_NUM(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_EH_SET_PAGE_OF_RULE_TABLE_FOR_TLM(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EH_SET_PAGE_OF_RULE_TABLE_FOR_TLM(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_EH_SET_PAGE_OF_RULE_SORTED_IDX_FOR_TLM(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EH_SET_PAGE_OF_RULE_SORTED_IDX_FOR_TLM(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_EH_SET_PAGE_OF_LOG_TABLE_FOR_TLM(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EH_SET_PAGE_OF_LOG_TABLE_FOR_TLM(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_EH_SET_TARGET_ID_OF_RULE_TABLE_FOR_TLM(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EH_SET_TARGET_ID_OF_RULE_TABLE_FOR_TLM(const CommonCmdPacket* packet);
 
 /**
  * @brief 新しい EL_Event 発生を検出するためのカウンタを強制的に EL のカウンタに合わせる
  */
-CCP_EXEC_STS Cmd_EH_MATCH_EVENT_COUNTER_TO_EL(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EH_MATCH_EVENT_COUNTER_TO_EL(const CommonCmdPacket* packet);
 
 // by_event_group 関数
-CCP_EXEC_STS Cmd_EH_INIT_RULE_BY_EVENT_GROUP(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EH_INIT_RULE_BY_EVENT_GROUP(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_EH_INIT_RULE_BY_EVENT_GROUP_FOR_MULTI_LEVEL(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EH_INIT_RULE_BY_EVENT_GROUP_FOR_MULTI_LEVEL(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_EH_ACTIVATE_RULE_BY_EVENT_GROUP(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EH_ACTIVATE_RULE_BY_EVENT_GROUP(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_EH_INACTIVATE_RULE_BY_EVENT_GROUP(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EH_INACTIVATE_RULE_BY_EVENT_GROUP(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_EH_ACTIVATE_RULE_BY_EVENT_GROUP_FOR_MULTI_LEVEL(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EH_ACTIVATE_RULE_BY_EVENT_GROUP_FOR_MULTI_LEVEL(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_EH_INACTIVATE_RULE_BY_EVENT_GROUP_FOR_MULTI_LEVEL(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EH_INACTIVATE_RULE_BY_EVENT_GROUP_FOR_MULTI_LEVEL(const CommonCmdPacket* packet);
 
 #endif  // EL_IS_ENABLE_TLOG
 

--- a/System/EventManager/event_logger.c
+++ b/System/EventManager/event_logger.c
@@ -748,7 +748,7 @@ const EL_Event* EL_get_the_nth_tlog_from_the_latest(EL_ERROR_LEVEL err_level, ui
 #endif
 
 
-CCP_EXEC_STS Cmd_EL_INIT(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EL_INIT(const CommonCmdPacket* packet)
 {
   (void)packet;
   EL_initialize();
@@ -756,7 +756,7 @@ CCP_EXEC_STS Cmd_EL_INIT(const CommonCmdPacket* packet)
 }
 
 
-CCP_EXEC_STS Cmd_EL_CLEAR_LOG_ALL(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EL_CLEAR_LOG_ALL(const CommonCmdPacket* packet)
 {
   (void)packet;
 
@@ -775,7 +775,7 @@ CCP_EXEC_STS Cmd_EL_CLEAR_LOG_ALL(const CommonCmdPacket* packet)
 }
 
 
-CCP_EXEC_STS Cmd_EL_CLEAR_LOG_BY_ERR_LEVEL(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EL_CLEAR_LOG_BY_ERR_LEVEL(const CommonCmdPacket* packet)
 {
   EL_ERROR_LEVEL err_level = (EL_ERROR_LEVEL)CCP_get_param_from_packet(packet, 0, uint8_t);
 
@@ -794,7 +794,7 @@ CCP_EXEC_STS Cmd_EL_CLEAR_LOG_BY_ERR_LEVEL(const CommonCmdPacket* packet)
 }
 
 
-CCP_EXEC_STS Cmd_EL_CLEAR_STATISTICS(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EL_CLEAR_STATISTICS(const CommonCmdPacket* packet)
 {
   (void)packet;
   EL_clear_statistics_();
@@ -803,7 +803,7 @@ CCP_EXEC_STS Cmd_EL_CLEAR_STATISTICS(const CommonCmdPacket* packet)
 
 
 #ifdef EL_IS_ENABLE_TLOG
-CCP_EXEC_STS Cmd_EL_CLEAR_TLOG(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EL_CLEAR_TLOG(const CommonCmdPacket* packet)
 {
   EL_ERROR_LEVEL err_level = (EL_ERROR_LEVEL)CCP_get_param_from_packet(packet, 0, uint8_t);
 
@@ -818,7 +818,7 @@ CCP_EXEC_STS Cmd_EL_CLEAR_TLOG(const CommonCmdPacket* packet)
 
 
 #ifdef EL_IS_ENABLE_CLOG
-CCP_EXEC_STS Cmd_EL_CLEAR_CLOG(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EL_CLEAR_CLOG(const CommonCmdPacket* packet)
 {
   EL_ERROR_LEVEL err_level = (EL_ERROR_LEVEL)CCP_get_param_from_packet(packet, 0, uint8_t);
 
@@ -832,7 +832,7 @@ CCP_EXEC_STS Cmd_EL_CLEAR_CLOG(const CommonCmdPacket* packet)
 #endif
 
 
-CCP_EXEC_STS Cmd_EL_RECORD_EVENT(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EL_RECORD_EVENT(const CommonCmdPacket* packet)
 {
   EL_GROUP group = (EL_GROUP)CCP_get_param_from_packet(packet, 0, uint32_t);
   uint32_t local = CCP_get_param_from_packet(packet, 1, uint32_t);
@@ -861,7 +861,7 @@ CCP_EXEC_STS Cmd_EL_RECORD_EVENT(const CommonCmdPacket* packet)
 
 
 #ifdef EL_IS_ENABLE_TLOG
-CCP_EXEC_STS Cmd_EL_TLOG_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EL_TLOG_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet)
 {
   uint8_t page_no = CCP_get_param_from_packet(packet, 0, uint8_t);
   EL_ERROR_LEVEL err_level = (EL_ERROR_LEVEL)CCP_get_param_from_packet(packet, 1, uint8_t);
@@ -900,7 +900,7 @@ CCP_EXEC_STS Cmd_EL_TLOG_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet)
 
 
 #ifdef EL_IS_ENABLE_CLOG
-CCP_EXEC_STS Cmd_EL_CLOG_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EL_CLOG_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet)
 {
   uint8_t page_no = CCP_get_param_from_packet(packet, 0, uint8_t);
   EL_ERROR_LEVEL err_level = (EL_ERROR_LEVEL)CCP_get_param_from_packet(packet, 1, uint8_t);
@@ -938,7 +938,7 @@ CCP_EXEC_STS Cmd_EL_CLOG_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet)
 #endif
 
 
-CCP_EXEC_STS Cmd_EL_INIT_LOGGING_SETTINGS(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EL_INIT_LOGGING_SETTINGS(const CommonCmdPacket* packet)
 {
   (void)packet;
   EL_enable_all_logging();
@@ -947,7 +947,7 @@ CCP_EXEC_STS Cmd_EL_INIT_LOGGING_SETTINGS(const CommonCmdPacket* packet)
 }
 
 
-CCP_EXEC_STS Cmd_EL_ENABLE_LOGGING(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EL_ENABLE_LOGGING(const CommonCmdPacket* packet)
 {
   EL_GROUP group = (EL_GROUP)CCP_get_param_from_packet(packet, 0, uint32_t);
 
@@ -965,7 +965,7 @@ CCP_EXEC_STS Cmd_EL_ENABLE_LOGGING(const CommonCmdPacket* packet)
 }
 
 
-CCP_EXEC_STS Cmd_EL_DISABLE_LOGGING(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EL_DISABLE_LOGGING(const CommonCmdPacket* packet)
 {
   EL_GROUP group = (EL_GROUP)CCP_get_param_from_packet(packet, 0, uint32_t);
 
@@ -983,7 +983,7 @@ CCP_EXEC_STS Cmd_EL_DISABLE_LOGGING(const CommonCmdPacket* packet)
 }
 
 
-CCP_EXEC_STS Cmd_EL_ENABLE_LOGGING_ALL(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EL_ENABLE_LOGGING_ALL(const CommonCmdPacket* packet)
 {
   (void)packet;
   EL_enable_all_logging();
@@ -991,7 +991,7 @@ CCP_EXEC_STS Cmd_EL_ENABLE_LOGGING_ALL(const CommonCmdPacket* packet)
 }
 
 
-CCP_EXEC_STS Cmd_EL_DISABLE_LOGGING_ALL(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EL_DISABLE_LOGGING_ALL(const CommonCmdPacket* packet)
 {
   (void)packet;
   EL_disable_all_logging();
@@ -1000,7 +1000,7 @@ CCP_EXEC_STS Cmd_EL_DISABLE_LOGGING_ALL(const CommonCmdPacket* packet)
 
 
 #ifdef EL_IS_ENABLE_TLOG
-CCP_EXEC_STS Cmd_EL_ENABLE_TLOG_OVERWRITE(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EL_ENABLE_TLOG_OVERWRITE(const CommonCmdPacket* packet)
 {
   EL_ERROR_LEVEL err_level = (EL_ERROR_LEVEL)CCP_get_param_from_packet(packet, 0, uint8_t);
 
@@ -1018,7 +1018,7 @@ CCP_EXEC_STS Cmd_EL_ENABLE_TLOG_OVERWRITE(const CommonCmdPacket* packet)
 }
 
 
-CCP_EXEC_STS Cmd_EL_DISABLE_TLOG_OVERWRITE(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EL_DISABLE_TLOG_OVERWRITE(const CommonCmdPacket* packet)
 {
   EL_ERROR_LEVEL err_level = (EL_ERROR_LEVEL)CCP_get_param_from_packet(packet, 0, uint8_t);
 
@@ -1036,7 +1036,7 @@ CCP_EXEC_STS Cmd_EL_DISABLE_TLOG_OVERWRITE(const CommonCmdPacket* packet)
 }
 
 
-CCP_EXEC_STS Cmd_EL_ENABLE_TLOG_OVERWRITE_ALL(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EL_ENABLE_TLOG_OVERWRITE_ALL(const CommonCmdPacket* packet)
 {
   (void)packet;
   EL_enable_tlog_overwrite_all();
@@ -1044,7 +1044,7 @@ CCP_EXEC_STS Cmd_EL_ENABLE_TLOG_OVERWRITE_ALL(const CommonCmdPacket* packet)
 }
 
 
-CCP_EXEC_STS Cmd_EL_DISABLE_TLOG_OVERWRITE_ALL(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_EL_DISABLE_TLOG_OVERWRITE_ALL(const CommonCmdPacket* packet)
 {
   (void)packet;
   EL_disable_tlog_overwrite_all();

--- a/System/EventManager/event_logger.c
+++ b/System/EventManager/event_logger.c
@@ -752,7 +752,7 @@ CCP_CmdRet Cmd_EL_INIT(const CommonCmdPacket* packet)
 {
   (void)packet;
   EL_initialize();
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
@@ -771,7 +771,7 @@ CCP_CmdRet Cmd_EL_CLEAR_LOG_ALL(const CommonCmdPacket* packet)
   EL_clear_latest_event_();
   EL_clear_statistics_();
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
@@ -790,7 +790,7 @@ CCP_CmdRet Cmd_EL_CLEAR_LOG_BY_ERR_LEVEL(const CommonCmdPacket* packet)
   EL_clear_clog_(err_level);
 #endif
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
@@ -798,7 +798,7 @@ CCP_CmdRet Cmd_EL_CLEAR_STATISTICS(const CommonCmdPacket* packet)
 {
   (void)packet;
   EL_clear_statistics_();
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
@@ -812,7 +812,7 @@ CCP_CmdRet Cmd_EL_CLEAR_TLOG(const CommonCmdPacket* packet)
 
   EL_clear_tlog_(err_level);
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 #endif
 
@@ -827,7 +827,7 @@ CCP_CmdRet Cmd_EL_CLEAR_CLOG(const CommonCmdPacket* packet)
 
   EL_clear_clog_(err_level);
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 #endif
 
@@ -844,10 +844,10 @@ CCP_CmdRet Cmd_EL_RECORD_EVENT(const CommonCmdPacket* packet)
   switch (ack)
   {
   case EL_ACK_OK:
-    return CCP_EXEC_SUCCESS;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   case EL_ACK_TLOG_FULL:
     // 要検討だが，これは正常ではあるのでこれでよし
-    return CCP_EXEC_SUCCESS;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   case EL_ACK_ILLEGAL_GROUP:
     return CCP_EXEC_ILLEGAL_PARAMETER;
   case EL_ACK_ILLEGAL_ERROR_LEVEL:
@@ -894,7 +894,7 @@ CCP_CmdRet Cmd_EL_TLOG_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet)
   event_logger_.tlm_info.tlog.page_no = page_no;
   event_logger_.tlm_info.tlog.err_level = err_level;
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 #endif
 
@@ -933,7 +933,7 @@ CCP_CmdRet Cmd_EL_CLOG_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet)
   event_logger_.tlm_info.clog.page_no = page_no;
   event_logger_.tlm_info.clog.err_level = err_level;
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 #endif
 
@@ -943,7 +943,7 @@ CCP_CmdRet Cmd_EL_INIT_LOGGING_SETTINGS(const CommonCmdPacket* packet)
   (void)packet;
   EL_enable_all_logging();
   EL_load_default_settings();
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
@@ -956,7 +956,7 @@ CCP_CmdRet Cmd_EL_ENABLE_LOGGING(const CommonCmdPacket* packet)
   switch (ack)
   {
   case EL_ACK_OK:
-    return CCP_EXEC_SUCCESS;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   case EL_ACK_ILLEGAL_GROUP:
     return CCP_EXEC_ILLEGAL_PARAMETER;
   default:
@@ -974,7 +974,7 @@ CCP_CmdRet Cmd_EL_DISABLE_LOGGING(const CommonCmdPacket* packet)
   switch (ack)
   {
   case EL_ACK_OK:
-    return CCP_EXEC_SUCCESS;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   case EL_ACK_ILLEGAL_GROUP:
     return CCP_EXEC_ILLEGAL_PARAMETER;
   default:
@@ -987,7 +987,7 @@ CCP_CmdRet Cmd_EL_ENABLE_LOGGING_ALL(const CommonCmdPacket* packet)
 {
   (void)packet;
   EL_enable_all_logging();
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
@@ -995,7 +995,7 @@ CCP_CmdRet Cmd_EL_DISABLE_LOGGING_ALL(const CommonCmdPacket* packet)
 {
   (void)packet;
   EL_disable_all_logging();
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
@@ -1009,7 +1009,7 @@ CCP_CmdRet Cmd_EL_ENABLE_TLOG_OVERWRITE(const CommonCmdPacket* packet)
   switch (ack)
   {
   case EL_ACK_OK:
-    return CCP_EXEC_SUCCESS;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   case EL_ACK_ILLEGAL_ERROR_LEVEL:
     return CCP_EXEC_ILLEGAL_PARAMETER;
   default:
@@ -1027,7 +1027,7 @@ CCP_CmdRet Cmd_EL_DISABLE_TLOG_OVERWRITE(const CommonCmdPacket* packet)
   switch (ack)
   {
   case EL_ACK_OK:
-    return CCP_EXEC_SUCCESS;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   case EL_ACK_ILLEGAL_ERROR_LEVEL:
     return CCP_EXEC_ILLEGAL_PARAMETER;
   default:
@@ -1040,7 +1040,7 @@ CCP_CmdRet Cmd_EL_ENABLE_TLOG_OVERWRITE_ALL(const CommonCmdPacket* packet)
 {
   (void)packet;
   EL_enable_tlog_overwrite_all();
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
@@ -1048,7 +1048,7 @@ CCP_CmdRet Cmd_EL_DISABLE_TLOG_OVERWRITE_ALL(const CommonCmdPacket* packet)
 {
   (void)packet;
   EL_disable_tlog_overwrite_all();
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 #endif
 

--- a/System/EventManager/event_logger.c
+++ b/System/EventManager/event_logger.c
@@ -853,9 +853,9 @@ CCP_CmdRet Cmd_EL_RECORD_EVENT(const CommonCmdPacket* packet)
   case EL_ACK_ILLEGAL_ERROR_LEVEL:
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   case EL_ACK_DISABLE_LOGGING:
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   default:
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   }
 }
 
@@ -960,7 +960,7 @@ CCP_CmdRet Cmd_EL_ENABLE_LOGGING(const CommonCmdPacket* packet)
   case EL_ACK_ILLEGAL_GROUP:
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   default:
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   }
 }
 
@@ -978,7 +978,7 @@ CCP_CmdRet Cmd_EL_DISABLE_LOGGING(const CommonCmdPacket* packet)
   case EL_ACK_ILLEGAL_GROUP:
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   default:
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   }
 }
 
@@ -1013,7 +1013,7 @@ CCP_CmdRet Cmd_EL_ENABLE_TLOG_OVERWRITE(const CommonCmdPacket* packet)
   case EL_ACK_ILLEGAL_ERROR_LEVEL:
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   default:
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   }
 }
 
@@ -1031,7 +1031,7 @@ CCP_CmdRet Cmd_EL_DISABLE_TLOG_OVERWRITE(const CommonCmdPacket* packet)
   case EL_ACK_ILLEGAL_ERROR_LEVEL:
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   default:
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   }
 }
 

--- a/System/EventManager/event_logger.c
+++ b/System/EventManager/event_logger.c
@@ -779,8 +779,8 @@ CCP_CmdRet Cmd_EL_CLEAR_LOG_BY_ERR_LEVEL(const CommonCmdPacket* packet)
 {
   EL_ERROR_LEVEL err_level = (EL_ERROR_LEVEL)CCP_get_param_from_packet(packet, 0, uint8_t);
 
-  if (err_level < 0) return CCP_EXEC_ILLEGAL_PARAMETER;
-  if (err_level >= EL_ERROR_LEVEL_MAX) return CCP_EXEC_ILLEGAL_PARAMETER;
+  if (err_level < 0) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
+  if (err_level >= EL_ERROR_LEVEL_MAX) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
 
 #ifdef EL_IS_ENABLE_TLOG
   EL_clear_tlog_(err_level);
@@ -807,8 +807,8 @@ CCP_CmdRet Cmd_EL_CLEAR_TLOG(const CommonCmdPacket* packet)
 {
   EL_ERROR_LEVEL err_level = (EL_ERROR_LEVEL)CCP_get_param_from_packet(packet, 0, uint8_t);
 
-  if (err_level < 0) return CCP_EXEC_ILLEGAL_PARAMETER;
-  if (err_level >= EL_ERROR_LEVEL_MAX) return CCP_EXEC_ILLEGAL_PARAMETER;
+  if (err_level < 0) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
+  if (err_level >= EL_ERROR_LEVEL_MAX) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
 
   EL_clear_tlog_(err_level);
 
@@ -822,8 +822,8 @@ CCP_CmdRet Cmd_EL_CLEAR_CLOG(const CommonCmdPacket* packet)
 {
   EL_ERROR_LEVEL err_level = (EL_ERROR_LEVEL)CCP_get_param_from_packet(packet, 0, uint8_t);
 
-  if (err_level < 0) return CCP_EXEC_ILLEGAL_PARAMETER;
-  if (err_level >= EL_ERROR_LEVEL_MAX) return CCP_EXEC_ILLEGAL_PARAMETER;
+  if (err_level < 0) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
+  if (err_level >= EL_ERROR_LEVEL_MAX) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
 
   EL_clear_clog_(err_level);
 
@@ -849,9 +849,9 @@ CCP_CmdRet Cmd_EL_RECORD_EVENT(const CommonCmdPacket* packet)
     // 要検討だが，これは正常ではあるのでこれでよし
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   case EL_ACK_ILLEGAL_GROUP:
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   case EL_ACK_ILLEGAL_ERROR_LEVEL:
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   case EL_ACK_DISABLE_LOGGING:
     return CCP_EXEC_ILLEGAL_CONTEXT;
   default:
@@ -869,26 +869,26 @@ CCP_CmdRet Cmd_EL_TLOG_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet)
   switch (err_level)
   {
   case EL_ERROR_LEVEL_HIGH:
-    if (page_no >= EL_TLOG_TLM_PAGE_MAX_HIGH) return CCP_EXEC_ILLEGAL_PARAMETER;
+    if (page_no >= EL_TLOG_TLM_PAGE_MAX_HIGH) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
     break;
 #ifdef EL_IS_ENABLE_MIDDLE_ERROR_LEVEL
   case EL_ERROR_LEVEL_MIDDLE:
-    if (page_no >= EL_TLOG_TLM_PAGE_MAX_MIDDLE) return CCP_EXEC_ILLEGAL_PARAMETER;
+    if (page_no >= EL_TLOG_TLM_PAGE_MAX_MIDDLE) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
     break;
 #endif
   case EL_ERROR_LEVEL_LOW:
-    if (page_no >= EL_TLOG_TLM_PAGE_MAX_LOW) return CCP_EXEC_ILLEGAL_PARAMETER;
+    if (page_no >= EL_TLOG_TLM_PAGE_MAX_LOW) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
     break;
 #ifdef EL_IS_ENABLE_EL_ERROR_LEVEL
   case EL_ERROR_LEVEL_EL:
-    if (page_no > (EL_TLOG_LOG_SIZE_MAX_EL - 1) / EL_TLOG_TLM_PAGE_SIZE) return CCP_EXEC_ILLEGAL_PARAMETER;
+    if (page_no > (EL_TLOG_LOG_SIZE_MAX_EL - 1) / EL_TLOG_TLM_PAGE_SIZE) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
     break;
 #endif
   case EL_ERROR_LEVEL_EH:
-    if (page_no > (EL_TLOG_LOG_SIZE_MAX_EH - 1) / EL_TLOG_TLM_PAGE_SIZE) return CCP_EXEC_ILLEGAL_PARAMETER;
+    if (page_no > (EL_TLOG_LOG_SIZE_MAX_EH - 1) / EL_TLOG_TLM_PAGE_SIZE) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
     break;
   default:
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   }
 
   event_logger_.tlm_info.tlog.page_no = page_no;
@@ -908,26 +908,26 @@ CCP_CmdRet Cmd_EL_CLOG_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet)
   switch (err_level)
   {
   case EL_ERROR_LEVEL_HIGH:
-    if (page_no >= EL_CLOG_TLM_PAGE_MAX_HIGH) return CCP_EXEC_ILLEGAL_PARAMETER;
+    if (page_no >= EL_CLOG_TLM_PAGE_MAX_HIGH) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
     break;
 #ifdef EL_IS_ENABLE_MIDDLE_ERROR_LEVEL
   case EL_ERROR_LEVEL_MIDDLE:
-    if (page_no >= EL_CLOG_TLM_PAGE_MAX_MIDDLE) return CCP_EXEC_ILLEGAL_PARAMETER;
+    if (page_no >= EL_CLOG_TLM_PAGE_MAX_MIDDLE) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
     break;
 #endif
   case EL_ERROR_LEVEL_LOW:
-    if (page_no >= EL_CLOG_TLM_PAGE_MAX_LOW) return CCP_EXEC_ILLEGAL_PARAMETER;
+    if (page_no >= EL_CLOG_TLM_PAGE_MAX_LOW) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
     break;
 #ifdef EL_IS_ENABLE_EL_ERROR_LEVEL
   case EL_ERROR_LEVEL_EL:
-    if (page_no > (EL_CLOG_LOG_SIZE_MAX_EL - 1) / EL_CLOG_TLM_PAGE_SIZE) return CCP_EXEC_ILLEGAL_PARAMETER;
+    if (page_no > (EL_CLOG_LOG_SIZE_MAX_EL - 1) / EL_CLOG_TLM_PAGE_SIZE) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
     break;
 #endif
   case EL_ERROR_LEVEL_EH:
-    if (page_no > (EL_CLOG_LOG_SIZE_MAX_EH - 1) / EL_CLOG_TLM_PAGE_SIZE) return CCP_EXEC_ILLEGAL_PARAMETER;
+    if (page_no > (EL_CLOG_LOG_SIZE_MAX_EH - 1) / EL_CLOG_TLM_PAGE_SIZE) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
     break;
   default:
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   }
 
   event_logger_.tlm_info.clog.page_no = page_no;
@@ -958,7 +958,7 @@ CCP_CmdRet Cmd_EL_ENABLE_LOGGING(const CommonCmdPacket* packet)
   case EL_ACK_OK:
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   case EL_ACK_ILLEGAL_GROUP:
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   default:
     return CCP_EXEC_ILLEGAL_CONTEXT;
   }
@@ -976,7 +976,7 @@ CCP_CmdRet Cmd_EL_DISABLE_LOGGING(const CommonCmdPacket* packet)
   case EL_ACK_OK:
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   case EL_ACK_ILLEGAL_GROUP:
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   default:
     return CCP_EXEC_ILLEGAL_CONTEXT;
   }
@@ -1011,7 +1011,7 @@ CCP_CmdRet Cmd_EL_ENABLE_TLOG_OVERWRITE(const CommonCmdPacket* packet)
   case EL_ACK_OK:
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   case EL_ACK_ILLEGAL_ERROR_LEVEL:
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   default:
     return CCP_EXEC_ILLEGAL_CONTEXT;
   }
@@ -1029,7 +1029,7 @@ CCP_CmdRet Cmd_EL_DISABLE_TLOG_OVERWRITE(const CommonCmdPacket* packet)
   case EL_ACK_OK:
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   case EL_ACK_ILLEGAL_ERROR_LEVEL:
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   default:
     return CCP_EXEC_ILLEGAL_CONTEXT;
   }

--- a/System/EventManager/event_logger.h
+++ b/System/EventManager/event_logger.h
@@ -511,50 +511,50 @@ int EL_is_tlog_overwrite_enable(EL_ERROR_LEVEL err_level);
 const EL_Event* EL_get_the_nth_tlog_from_the_latest(EL_ERROR_LEVEL err_level, uint16_t n);
 #endif
 
-CCP_EXEC_STS Cmd_EL_INIT(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EL_INIT(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_EL_CLEAR_LOG_ALL(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EL_CLEAR_LOG_ALL(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_EL_CLEAR_LOG_BY_ERR_LEVEL(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EL_CLEAR_LOG_BY_ERR_LEVEL(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_EL_CLEAR_STATISTICS(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EL_CLEAR_STATISTICS(const CommonCmdPacket* packet);
 
 #ifdef EL_IS_ENABLE_TLOG
-CCP_EXEC_STS Cmd_EL_CLEAR_TLOG(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EL_CLEAR_TLOG(const CommonCmdPacket* packet);
 #endif
 
 #ifdef EL_IS_ENABLE_CLOG
-CCP_EXEC_STS Cmd_EL_CLEAR_CLOG(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EL_CLEAR_CLOG(const CommonCmdPacket* packet);
 #endif
 
-CCP_EXEC_STS Cmd_EL_RECORD_EVENT(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EL_RECORD_EVENT(const CommonCmdPacket* packet);
 
 #ifdef EL_IS_ENABLE_TLOG
-CCP_EXEC_STS Cmd_EL_TLOG_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EL_TLOG_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet);
 #endif
 
 #ifdef EL_IS_ENABLE_CLOG
-CCP_EXEC_STS Cmd_EL_CLOG_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EL_CLOG_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet);
 #endif
 
-CCP_EXEC_STS Cmd_EL_INIT_LOGGING_SETTINGS(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EL_INIT_LOGGING_SETTINGS(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_EL_ENABLE_LOGGING(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EL_ENABLE_LOGGING(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_EL_DISABLE_LOGGING(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EL_DISABLE_LOGGING(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_EL_ENABLE_LOGGING_ALL(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EL_ENABLE_LOGGING_ALL(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_EL_DISABLE_LOGGING_ALL(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EL_DISABLE_LOGGING_ALL(const CommonCmdPacket* packet);
 
 #ifdef EL_IS_ENABLE_TLOG
-CCP_EXEC_STS Cmd_EL_ENABLE_TLOG_OVERWRITE(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EL_ENABLE_TLOG_OVERWRITE(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_EL_DISABLE_TLOG_OVERWRITE(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EL_DISABLE_TLOG_OVERWRITE(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_EL_ENABLE_TLOG_OVERWRITE_ALL(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EL_ENABLE_TLOG_OVERWRITE_ALL(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_EL_DISABLE_TLOG_OVERWRITE_ALL(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_EL_DISABLE_TLOG_OVERWRITE_ALL(const CommonCmdPacket* packet);
 #endif
 
 #endif

--- a/System/ModeManager/mode_manager.c
+++ b/System/ModeManager/mode_manager.c
@@ -83,7 +83,7 @@ void MM_clear_transition_table_(void)
  * @brief
  * モード遷移後にタスクリストとして実行するブロックコマンドを設定するコマンド
  */
-CCP_EXEC_STS Cmd_MM_SET_MODE_LIST(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_MM_SET_MODE_LIST(const CommonCmdPacket* packet)
 {
   MD_MODEID mode;
   bct_id_t  bc_index;
@@ -135,7 +135,7 @@ MM_ACK MM_set_mode_list(MD_MODEID mode, bct_id_t  bc_index)
  * @brief
  * モード遷移時に実行するブロックコマンドを設定するコマンド
  */
-CCP_EXEC_STS Cmd_MM_SET_TRANSITION_TABLE(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_MM_SET_TRANSITION_TABLE(const CommonCmdPacket* packet)
 {
   unsigned char from, to;
   bct_id_t bc_index;
@@ -190,7 +190,7 @@ MM_ACK MM_set_transition_table(MD_MODEID from,
  * @brief
  * モード遷移を開始するコマンド
  */
-CCP_EXEC_STS Cmd_MM_START_TRANSITION(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_MM_START_TRANSITION(const CommonCmdPacket* packet)
 {
   MD_MODEID id;
 
@@ -258,7 +258,7 @@ static MM_ACK MM_start_transition_(MD_MODEID id)
  * モード遷移のブロックコマンドの最後に入れて使う
  * 入っていない場合、タスクリストが遷移先のモードに置き換わらないので注意
  */
-CCP_EXEC_STS Cmd_MM_FINISH_TRANSITION(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_MM_FINISH_TRANSITION(const CommonCmdPacket* packet)
 {
   (void)packet;
 
@@ -312,7 +312,7 @@ static void MM_deploy_block_cmd_(bct_id_t bc_index)
   CCP_form_and_exec_block_deploy_cmd(TLCD_ID_DEPLOY_BC, bc_index);
 }
 
-CCP_EXEC_STS Cmd_MM_UPDATE_TRANSITION_TABLE_FOR_TLM(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_MM_UPDATE_TRANSITION_TABLE_FOR_TLM(const CommonCmdPacket* packet)
 {
   (void)packet;
   MM_update_transition_table_for_tlm();

--- a/System/ModeManager/mode_manager.c
+++ b/System/ModeManager/mode_manager.c
@@ -92,7 +92,7 @@ CCP_CmdRet Cmd_MM_SET_MODE_LIST(const CommonCmdPacket* packet)
   if (CCP_get_param_len(packet) != (1 + SIZE_OF_BCT_ID_T))
   {
     // パラメータはパケットヘッダとuint8_t 2個（mode, index)。
-    return CCP_EXEC_ILLEGAL_LENGTH;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_LENGTH);
   }
 
   // どのモードにどのブロックコマンドを登録するかを引数から読み出す
@@ -144,7 +144,7 @@ CCP_CmdRet Cmd_MM_SET_TRANSITION_TABLE(const CommonCmdPacket* packet)
   if (CCP_get_param_len(packet) != 1 + 1 + SIZE_OF_BCT_ID_T)
   {
     // コマンドはパケットヘッダとuint8_t 3個（from, to, index)。
-    return CCP_EXEC_ILLEGAL_LENGTH;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_LENGTH);
   }
 
   // どのモード遷移にどのブロックコマンドを登録するかを引数から読み出す

--- a/System/ModeManager/mode_manager.c
+++ b/System/ModeManager/mode_manager.c
@@ -102,7 +102,7 @@ CCP_CmdRet Cmd_MM_SET_MODE_LIST(const CommonCmdPacket* packet)
   mode_manager_.mm_ack = MM_set_mode_list(mode, bc_index);
   if (mode_manager_.mm_ack != MM_SUCCESS)
   {
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   }
   return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
@@ -155,7 +155,7 @@ CCP_CmdRet Cmd_MM_SET_TRANSITION_TABLE(const CommonCmdPacket* packet)
   mode_manager_.mm_ack = MM_set_transition_table((MD_MODEID)from, (MD_MODEID)to, bc_index);
   if (mode_manager_.mm_ack != MM_SUCCESS)
   {
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   }
   return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
@@ -201,7 +201,7 @@ CCP_CmdRet Cmd_MM_START_TRANSITION(const CommonCmdPacket* packet)
   mode_manager_.mm_ack = MM_start_transition_(id);
   if (mode_manager_.mm_ack != MM_SUCCESS)
   {
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   }
   return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
@@ -265,7 +265,7 @@ CCP_CmdRet Cmd_MM_FINISH_TRANSITION(const CommonCmdPacket* packet)
   mode_manager_.mm_ack = MM_finish_transition_();
   if (mode_manager_.mm_ack != MM_SUCCESS)
   {
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   }
   return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }

--- a/System/ModeManager/mode_manager.c
+++ b/System/ModeManager/mode_manager.c
@@ -104,7 +104,7 @@ CCP_CmdRet Cmd_MM_SET_MODE_LIST(const CommonCmdPacket* packet)
   {
     return CCP_EXEC_ILLEGAL_CONTEXT;
   }
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 MM_ACK MM_set_mode_list(MD_MODEID mode, bct_id_t  bc_index)
@@ -157,7 +157,7 @@ CCP_CmdRet Cmd_MM_SET_TRANSITION_TABLE(const CommonCmdPacket* packet)
   {
     return CCP_EXEC_ILLEGAL_CONTEXT;
   }
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 MM_ACK MM_set_transition_table(MD_MODEID from,
@@ -203,7 +203,7 @@ CCP_CmdRet Cmd_MM_START_TRANSITION(const CommonCmdPacket* packet)
   {
     return CCP_EXEC_ILLEGAL_CONTEXT;
   }
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 static MM_ACK MM_start_transition_(MD_MODEID id)
@@ -267,7 +267,7 @@ CCP_CmdRet Cmd_MM_FINISH_TRANSITION(const CommonCmdPacket* packet)
   {
     return CCP_EXEC_ILLEGAL_CONTEXT;
   }
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 static MM_ACK MM_finish_transition_(void)
@@ -317,7 +317,7 @@ CCP_CmdRet Cmd_MM_UPDATE_TRANSITION_TABLE_FOR_TLM(const CommonCmdPacket* packet)
   (void)packet;
   MM_update_transition_table_for_tlm();
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 uint16_t MM_update_transition_table_for_tlm(void)

--- a/System/ModeManager/mode_manager.h
+++ b/System/ModeManager/mode_manager.h
@@ -112,10 +112,10 @@ MM_ACK MM_set_transition_table(MD_MODEID from, MD_MODEID to, bct_id_t bc_index);
  */
 bct_id_t MM_get_tasklist_id_of_mode(MD_MODEID mode);
 
-CCP_EXEC_STS Cmd_MM_SET_MODE_LIST(const CommonCmdPacket* packet);
-CCP_EXEC_STS Cmd_MM_SET_TRANSITION_TABLE(const CommonCmdPacket* packet);
-CCP_EXEC_STS Cmd_MM_START_TRANSITION(const CommonCmdPacket* packet);
-CCP_EXEC_STS Cmd_MM_FINISH_TRANSITION(const CommonCmdPacket* packet);
-CCP_EXEC_STS Cmd_MM_UPDATE_TRANSITION_TABLE_FOR_TLM(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_MM_SET_MODE_LIST(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_MM_SET_TRANSITION_TABLE(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_MM_START_TRANSITION(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_MM_FINISH_TRANSITION(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_MM_UPDATE_TRANSITION_TABLE_FOR_TLM(const CommonCmdPacket* packet);
 
 #endif

--- a/System/TaskManager/task_dispatcher.c
+++ b/System/TaskManager/task_dispatcher.c
@@ -6,6 +6,7 @@
 
 #include "../../TlmCmd/packet_list_util.h"
 #include "../../TlmCmd/block_command_executor.h"
+#include "../../TlmCmd/common_cmd_packet_util.h"
 #include "../ModeManager/mode_manager.h"
 #include "../TimeManager/time_manager.h"
 #include "../AnomalyLogger/anomaly_logger.h"

--- a/System/TaskManager/task_dispatcher.c
+++ b/System/TaskManager/task_dispatcher.c
@@ -184,7 +184,7 @@ void TDSP_resync_internal_counter(void)
   TDSP_info_.activated_at = TMGR_get_master_total_cycle();
 }
 
-CCP_EXEC_STS Cmd_TDSP_SET_TASK_LIST(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_TDSP_SET_TASK_LIST(const CommonCmdPacket* packet)
 {
   // FIXME: u8 でいいのか？ まあ，いい気もする．
   TDSP_ACK ack = TDSP_set_task_list_id((bct_id_t)(CCP_get_param_head(packet)[0]));

--- a/System/TaskManager/task_dispatcher.c
+++ b/System/TaskManager/task_dispatcher.c
@@ -198,7 +198,7 @@ CCP_CmdRet Cmd_TDSP_SET_TASK_LIST(const CommonCmdPacket* packet)
   case TDSP_INACTIVE_BCT_ID:
   case TDSP_EMPTY_BC:
   default:
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   }
 }
 

--- a/System/TaskManager/task_dispatcher.c
+++ b/System/TaskManager/task_dispatcher.c
@@ -192,7 +192,7 @@ CCP_CmdRet Cmd_TDSP_SET_TASK_LIST(const CommonCmdPacket* packet)
   switch (ack)
   {
   case TDSP_SUCCESS:
-    return CCP_EXEC_SUCCESS;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   case TDSP_INVAILD_BCT_ID:
     return CCP_EXEC_ILLEGAL_PARAMETER;
   case TDSP_INACTIVE_BCT_ID:

--- a/System/TaskManager/task_dispatcher.c
+++ b/System/TaskManager/task_dispatcher.c
@@ -194,7 +194,7 @@ CCP_CmdRet Cmd_TDSP_SET_TASK_LIST(const CommonCmdPacket* packet)
   case TDSP_SUCCESS:
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   case TDSP_INVAILD_BCT_ID:
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   case TDSP_INACTIVE_BCT_ID:
   case TDSP_EMPTY_BC:
   default:

--- a/System/TaskManager/task_dispatcher.h
+++ b/System/TaskManager/task_dispatcher.h
@@ -71,7 +71,7 @@ void TDSP_resync_internal_counter(void);
 /**
  * @brief 指定したブロックコマンドを、次にタスクリストに展開するものとして登録するコマンド
  */
-CCP_EXEC_STS Cmd_TDSP_SET_TASK_LIST(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_TDSP_SET_TASK_LIST(const CommonCmdPacket* packet);
 
 AppInfo print_tdsp_status(void);
 

--- a/System/TimeManager/time_manager.c
+++ b/System/TimeManager/time_manager.c
@@ -239,7 +239,7 @@ static CCP_EXEC_STS TMGR_conv_tmgr_ack_to_ccp_exec_sts_(TMGR_ACK ack)
   case TMGR_ACK_OK:
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   case TMGR_ACK_PARAM_ERR:
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   default:
     return CCP_EXEC_ILLEGAL_CONTEXT;
   }
@@ -261,9 +261,9 @@ CCP_CmdRet Cmd_TMGR_UPDATE_UNIXTIME(const CommonCmdPacket* packet)
   step_t step = CCP_get_param_from_packet(packet, 2, cycle_t);
   TMGR_ACK ack;
 
-  if (unixtime < 0) return CCP_EXEC_ILLEGAL_PARAMETER;
-  if (total_cycle >= OBCT_MAX_CYCLE) return CCP_EXEC_ILLEGAL_PARAMETER;
-  if (step >= OBCT_STEPS_PER_CYCLE) return CCP_EXEC_ILLEGAL_PARAMETER;
+  if (unixtime < 0) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
+  if (total_cycle >= OBCT_MAX_CYCLE) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
+  if (step >= OBCT_STEPS_PER_CYCLE) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
 
   time.total_cycle = total_cycle;
   time.step = step;

--- a/System/TimeManager/time_manager.c
+++ b/System/TimeManager/time_manager.c
@@ -237,7 +237,7 @@ static CCP_EXEC_STS TMGR_conv_tmgr_ack_to_ccp_exec_sts_(TMGR_ACK ack)
   switch (ack)
   {
   case TMGR_ACK_OK:
-    return CCP_EXEC_SUCCESS;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
   case TMGR_ACK_PARAM_ERR:
     return CCP_EXEC_ILLEGAL_PARAMETER;
   default:
@@ -295,7 +295,7 @@ CCP_CmdRet Cmd_TMGR_RESET_CYCLE_CORRECTION(const CommonCmdPacket* packet)
   (void)packet;
   TMGR_set_cycle_correction_(1.0);
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 CCP_CmdRet Cmd_TMGR_CLEAR_UNIXTIME_INFO(const CommonCmdPacket* packet)
@@ -303,7 +303,7 @@ CCP_CmdRet Cmd_TMGR_CLEAR_UNIXTIME_INFO(const CommonCmdPacket* packet)
   (void)packet;
   TMGR_clear_unixtime_info();
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 #pragma section

--- a/System/TimeManager/time_manager.c
+++ b/System/TimeManager/time_manager.c
@@ -245,7 +245,7 @@ static CCP_EXEC_STS TMGR_conv_tmgr_ack_to_ccp_exec_sts_(TMGR_ACK ack)
   }
 }
 
-CCP_EXEC_STS Cmd_TMGR_SET_TIME(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_TMGR_SET_TIME(const CommonCmdPacket* packet)
 {
   cycle_t set_value = CCP_get_param_from_packet(packet, 0, cycle_t);
   TMGR_ACK ack = TMGR_set_master_total_cycle_(set_value);
@@ -253,7 +253,7 @@ CCP_EXEC_STS Cmd_TMGR_SET_TIME(const CommonCmdPacket* packet)
   return TMGR_conv_tmgr_ack_to_ccp_exec_sts_(ack);
 }
 
-CCP_EXEC_STS Cmd_TMGR_UPDATE_UNIXTIME(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_TMGR_UPDATE_UNIXTIME(const CommonCmdPacket* packet)
 {
   ObcTime time;
   double unixtime = CCP_get_param_from_packet(packet, 0, double);
@@ -274,7 +274,7 @@ CCP_EXEC_STS Cmd_TMGR_UPDATE_UNIXTIME(const CommonCmdPacket* packet)
   return TMGR_conv_tmgr_ack_to_ccp_exec_sts_(ack);
 }
 
-CCP_EXEC_STS Cmd_TMGR_SET_UTL_UNIXTIME_EPOCH(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_TMGR_SET_UTL_UNIXTIME_EPOCH(const CommonCmdPacket* packet)
 {
   double utl_unixtime_epoch = CCP_get_param_from_packet(packet, 0, double);
   TMGR_ACK ack = TMGR_set_utl_unixtime_epoch_(utl_unixtime_epoch);
@@ -282,7 +282,7 @@ CCP_EXEC_STS Cmd_TMGR_SET_UTL_UNIXTIME_EPOCH(const CommonCmdPacket* packet)
   return TMGR_conv_tmgr_ack_to_ccp_exec_sts_(ack);
 }
 
-CCP_EXEC_STS Cmd_TMGR_SET_CYCLE_CORRECTION(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_TMGR_SET_CYCLE_CORRECTION(const CommonCmdPacket* packet)
 {
   double cycle_correction = CCP_get_param_from_packet(packet, 0, double);
   TMGR_ACK ack = TMGR_set_cycle_correction_(cycle_correction);
@@ -290,7 +290,7 @@ CCP_EXEC_STS Cmd_TMGR_SET_CYCLE_CORRECTION(const CommonCmdPacket* packet)
   return TMGR_conv_tmgr_ack_to_ccp_exec_sts_(ack);
 }
 
-CCP_EXEC_STS Cmd_TMGR_RESET_CYCLE_CORRECTION(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_TMGR_RESET_CYCLE_CORRECTION(const CommonCmdPacket* packet)
 {
   (void)packet;
   TMGR_set_cycle_correction_(1.0);
@@ -298,7 +298,7 @@ CCP_EXEC_STS Cmd_TMGR_RESET_CYCLE_CORRECTION(const CommonCmdPacket* packet)
   return CCP_EXEC_SUCCESS;
 }
 
-CCP_EXEC_STS Cmd_TMGR_CLEAR_UNIXTIME_INFO(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_TMGR_CLEAR_UNIXTIME_INFO(const CommonCmdPacket* packet)
 {
   (void)packet;
   TMGR_clear_unixtime_info();

--- a/System/TimeManager/time_manager.c
+++ b/System/TimeManager/time_manager.c
@@ -241,7 +241,7 @@ static CCP_EXEC_STS TMGR_conv_tmgr_ack_to_ccp_exec_sts_(TMGR_ACK ack)
   case TMGR_ACK_PARAM_ERR:
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   default:
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   }
 }
 

--- a/System/TimeManager/time_manager.c
+++ b/System/TimeManager/time_manager.c
@@ -36,9 +36,9 @@ static TMGR_ACK TMGR_set_cycle_correction_(double cycle_correction);
 /**
  * @brief enum 変換用関数
  * @param[in] ack: TMGR_ACK
- * @return CCP_EXEC_STS
+ * @return CCP_CmdRet
  */
-static CCP_EXEC_STS TMGR_conv_tmgr_ack_to_ccp_exec_sts_(TMGR_ACK ack);
+static CCP_CmdRet TMGR_conv_tmgr_ack_to_ccp_cmd_ret_(TMGR_ACK ack);
 
 void TMGR_init(void)
 {
@@ -232,7 +232,7 @@ static TMGR_ACK TMGR_set_cycle_correction_(double cycle_correction)
   return TMGR_ACK_OK;
 }
 
-static CCP_EXEC_STS TMGR_conv_tmgr_ack_to_ccp_exec_sts_(TMGR_ACK ack)
+static CCP_CmdRet TMGR_conv_tmgr_ack_to_ccp_cmd_ret_(TMGR_ACK ack)
 {
   switch (ack)
   {
@@ -250,7 +250,7 @@ CCP_CmdRet Cmd_TMGR_SET_TIME(const CommonCmdPacket* packet)
   cycle_t set_value = CCP_get_param_from_packet(packet, 0, cycle_t);
   TMGR_ACK ack = TMGR_set_master_total_cycle_(set_value);
 
-  return TMGR_conv_tmgr_ack_to_ccp_exec_sts_(ack);
+  return TMGR_conv_tmgr_ack_to_ccp_cmd_ret_(ack);
 }
 
 CCP_CmdRet Cmd_TMGR_UPDATE_UNIXTIME(const CommonCmdPacket* packet)
@@ -271,7 +271,7 @@ CCP_CmdRet Cmd_TMGR_UPDATE_UNIXTIME(const CommonCmdPacket* packet)
 
   ack = TMGR_update_unixtime(unixtime, &time);
 
-  return TMGR_conv_tmgr_ack_to_ccp_exec_sts_(ack);
+  return TMGR_conv_tmgr_ack_to_ccp_cmd_ret_(ack);
 }
 
 CCP_CmdRet Cmd_TMGR_SET_UTL_UNIXTIME_EPOCH(const CommonCmdPacket* packet)
@@ -279,7 +279,7 @@ CCP_CmdRet Cmd_TMGR_SET_UTL_UNIXTIME_EPOCH(const CommonCmdPacket* packet)
   double utl_unixtime_epoch = CCP_get_param_from_packet(packet, 0, double);
   TMGR_ACK ack = TMGR_set_utl_unixtime_epoch_(utl_unixtime_epoch);
 
-  return TMGR_conv_tmgr_ack_to_ccp_exec_sts_(ack);
+  return TMGR_conv_tmgr_ack_to_ccp_cmd_ret_(ack);
 }
 
 CCP_CmdRet Cmd_TMGR_SET_CYCLE_CORRECTION(const CommonCmdPacket* packet)
@@ -287,7 +287,7 @@ CCP_CmdRet Cmd_TMGR_SET_CYCLE_CORRECTION(const CommonCmdPacket* packet)
   double cycle_correction = CCP_get_param_from_packet(packet, 0, double);
   TMGR_ACK ack = TMGR_set_cycle_correction_(cycle_correction);
 
-  return TMGR_conv_tmgr_ack_to_ccp_exec_sts_(ack);
+  return TMGR_conv_tmgr_ack_to_ccp_cmd_ret_(ack);
 }
 
 CCP_CmdRet Cmd_TMGR_RESET_CYCLE_CORRECTION(const CommonCmdPacket* packet)

--- a/System/TimeManager/time_manager.h
+++ b/System/TimeManager/time_manager.h
@@ -228,16 +228,16 @@ ObcTime TMGR_get_obc_time_from_unixtime(const double unixtime);
  */
 cycle_t TMGR_get_ti_from_utl_unixtime(const cycle_t utl_unixtime);
 
-CCP_EXEC_STS Cmd_TMGR_SET_TIME(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_TMGR_SET_TIME(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_TMGR_UPDATE_UNIXTIME(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_TMGR_UPDATE_UNIXTIME(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_TMGR_SET_UTL_UNIXTIME_EPOCH(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_TMGR_SET_UTL_UNIXTIME_EPOCH(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_TMGR_SET_CYCLE_CORRECTION(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_TMGR_SET_CYCLE_CORRECTION(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_TMGR_RESET_CYCLE_CORRECTION(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_TMGR_RESET_CYCLE_CORRECTION(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_TMGR_CLEAR_UNIXTIME_INFO(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_TMGR_CLEAR_UNIXTIME_INFO(const CommonCmdPacket* packet);
 
 #endif

--- a/System/WatchdogTimer/watchdog_timer.c
+++ b/System/WatchdogTimer/watchdog_timer.c
@@ -6,6 +6,7 @@
  */
 #include "watchdog_timer.h"
 #include "../../Library/print.h"
+#include "../../TlmCmd/common_cmd_packet_util.h"
 
 static WDT_Config wdt_config_;
 const WDT_Config* const wdt_config = &wdt_config_;

--- a/System/WatchdogTimer/watchdog_timer.c
+++ b/System/WatchdogTimer/watchdog_timer.c
@@ -43,7 +43,7 @@ void WDT_clear_wdt(void)
 // ここからリプロ対象内！！
 
 
-CCP_EXEC_STS Cmd_WDT_INIT(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_WDT_INIT(const CommonCmdPacket* packet)
 {
   (void)packet;
 
@@ -51,7 +51,7 @@ CCP_EXEC_STS Cmd_WDT_INIT(const CommonCmdPacket* packet)
   return CCP_EXEC_SUCCESS;
 }
 
-CCP_EXEC_STS Cmd_WDT_ENABLE(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_WDT_ENABLE(const CommonCmdPacket* packet)
 {
   int ret;
   (void)packet;
@@ -67,7 +67,7 @@ CCP_EXEC_STS Cmd_WDT_ENABLE(const CommonCmdPacket* packet)
   return CCP_EXEC_SUCCESS;
 }
 
-CCP_EXEC_STS Cmd_WDT_DISABLE(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_WDT_DISABLE(const CommonCmdPacket* packet)
 {
   int ret;
   (void)packet;
@@ -83,7 +83,7 @@ CCP_EXEC_STS Cmd_WDT_DISABLE(const CommonCmdPacket* packet)
   return CCP_EXEC_SUCCESS;
 }
 
-CCP_EXEC_STS Cmd_WDT_STOP_CLEAR(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_WDT_STOP_CLEAR(const CommonCmdPacket* packet)
 {
   (void)packet;
 
@@ -92,7 +92,7 @@ CCP_EXEC_STS Cmd_WDT_STOP_CLEAR(const CommonCmdPacket* packet)
   return CCP_EXEC_SUCCESS;
 }
 
-CCP_EXEC_STS Cmd_WDT_START_CLEAR(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_WDT_START_CLEAR(const CommonCmdPacket* packet)
 {
   (void)packet;
 

--- a/System/WatchdogTimer/watchdog_timer.c
+++ b/System/WatchdogTimer/watchdog_timer.c
@@ -61,7 +61,7 @@ CCP_CmdRet Cmd_WDT_ENABLE(const CommonCmdPacket* packet)
 
   if (ret != 0)
   {
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   }
 
   return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
@@ -77,7 +77,7 @@ CCP_CmdRet Cmd_WDT_DISABLE(const CommonCmdPacket* packet)
 
   if (ret != 0)
   {
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
   }
 
   return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);

--- a/System/WatchdogTimer/watchdog_timer.c
+++ b/System/WatchdogTimer/watchdog_timer.c
@@ -48,7 +48,7 @@ CCP_CmdRet Cmd_WDT_INIT(const CommonCmdPacket* packet)
   (void)packet;
 
   wdt_init_();
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 CCP_CmdRet Cmd_WDT_ENABLE(const CommonCmdPacket* packet)
@@ -64,7 +64,7 @@ CCP_CmdRet Cmd_WDT_ENABLE(const CommonCmdPacket* packet)
     return CCP_EXEC_ILLEGAL_CONTEXT;
   }
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 CCP_CmdRet Cmd_WDT_DISABLE(const CommonCmdPacket* packet)
@@ -80,7 +80,7 @@ CCP_CmdRet Cmd_WDT_DISABLE(const CommonCmdPacket* packet)
     return CCP_EXEC_ILLEGAL_CONTEXT;
   }
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 CCP_CmdRet Cmd_WDT_STOP_CLEAR(const CommonCmdPacket* packet)
@@ -89,7 +89,7 @@ CCP_CmdRet Cmd_WDT_STOP_CLEAR(const CommonCmdPacket* packet)
 
   wdt_config_.is_clear_enable = 0;
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 CCP_CmdRet Cmd_WDT_START_CLEAR(const CommonCmdPacket* packet)
@@ -98,7 +98,7 @@ CCP_CmdRet Cmd_WDT_START_CLEAR(const CommonCmdPacket* packet)
 
   wdt_config_.is_clear_enable = 1;
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 #pragma section

--- a/System/WatchdogTimer/watchdog_timer.h
+++ b/System/WatchdogTimer/watchdog_timer.h
@@ -31,10 +31,10 @@ void WDT_clear_wdt(void);
 // ↑全再プロ対象外
 // ↓全再プロ対象内
 
-CCP_EXEC_STS Cmd_WDT_INIT(const CommonCmdPacket* packet);
-CCP_EXEC_STS Cmd_WDT_ENABLE(const CommonCmdPacket* packet);
-CCP_EXEC_STS Cmd_WDT_DISABLE(const CommonCmdPacket* packet);
-CCP_EXEC_STS Cmd_WDT_STOP_CLEAR(const CommonCmdPacket* packet);
-CCP_EXEC_STS Cmd_WDT_START_CLEAR(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_WDT_INIT(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_WDT_ENABLE(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_WDT_DISABLE(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_WDT_STOP_CLEAR(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_WDT_START_CLEAR(const CommonCmdPacket* packet);
 
 #endif

--- a/TlmCmd/block_command_executor.c
+++ b/TlmCmd/block_command_executor.c
@@ -239,7 +239,7 @@ static CCP_EXEC_STS BCE_rotate_block_cmd_(bct_id_t block)
   if (bc_exe_params->rotate.counter < bc_exe_params->rotate.interval)
   {
     BCE_set_bc_exe_params_(block, bc_exe_params);
-    return CCP_EXEC_SUCCESS; // スキップ
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS); // スキップ
   }
 
   bc_exe_params->rotate.counter = 0;
@@ -295,7 +295,7 @@ static CCP_EXEC_STS BCE_combine_block_cmd_(bct_id_t block)
     if (ack != CCP_EXEC_SUCCESS) return ack;
   }
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 // 2019/10/01 追加
@@ -375,14 +375,14 @@ static CCP_EXEC_STS BCE_timelimit_combine_block_cmd_(bct_id_t block, step_t limi
       }
 
       BCE_set_bc_exe_params_(block, bc_exe_params);
-      return CCP_EXEC_SUCCESS;    // 異常ではないのでこれを返す
+      return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);    // 異常ではないのでこれを返す
     }
   }
 
   BCE_set_bc_exe_params_(block, bc_exe_params);
 
   // 最後まで実行できた
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 BCT_ACK BCE_reset_rotator_info(const bct_id_t block)
@@ -521,7 +521,7 @@ CCP_CmdRet Cmd_BCE_SET_ROTATE_INTERVAL(const CommonCmdPacket* packet)
   bc_exe_params->rotate.interval = interval;
   BCE_set_bc_exe_params_(block, bc_exe_params);
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 #pragma section

--- a/TlmCmd/block_command_executor.c
+++ b/TlmCmd/block_command_executor.c
@@ -154,7 +154,7 @@ CCP_CmdRet Cmd_BCE_ACTIVATE_BLOCK_BY_ID(const CommonCmdPacket* packet)
   if (CCP_get_param_len(packet) != SIZE_OF_BCT_ID_T)
   {
     // パラメータはブロック番号
-    return CCP_EXEC_ILLEGAL_LENGTH;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_LENGTH);
   }
 
   endian_memcpy(&block, CCP_get_param_head(packet), SIZE_OF_BCT_ID_T);
@@ -171,7 +171,7 @@ CCP_CmdRet Cmd_BCE_INACTIVATE_BLOCK_BY_ID(const CommonCmdPacket* packet)
   if (CCP_get_param_len(packet) != SIZE_OF_BCT_ID_T)
   {
     // パラメータはブロック番号
-    return CCP_EXEC_ILLEGAL_LENGTH;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_LENGTH);
   }
 
   endian_memcpy(&block, CCP_get_param_head(packet), SIZE_OF_BCT_ID_T);
@@ -214,7 +214,7 @@ CCP_CmdRet Cmd_BCE_ROTATE_BLOCK(const CommonCmdPacket* packet)
   if (CCP_get_param_len(packet) != SIZE_OF_BCT_ID_T)
   {
     // パラメータはブロック番号
-    return CCP_EXEC_ILLEGAL_LENGTH;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_LENGTH);
   }
 
   // パラメータを読み出し。
@@ -263,7 +263,7 @@ CCP_CmdRet Cmd_BCE_COMBINE_BLOCK(const CommonCmdPacket* packet)
   if (CCP_get_param_len(packet) != SIZE_OF_BCT_ID_T)
   {
     // パラメータはブロック番号
-    return CCP_EXEC_ILLEGAL_LENGTH;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_LENGTH);
   }
 
   // パラメータを読み出し。
@@ -310,7 +310,7 @@ CCP_CmdRet Cmd_BCE_TIMELIMIT_COMBINE_BLOCK(const CommonCmdPacket* packet)
   if (CCP_get_param_len(packet) != SIZE_OF_BCT_ID_T + 1)
   {
     // パラメータはブロック番号 + 制限時間 [step]
-    return CCP_EXEC_ILLEGAL_LENGTH;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_LENGTH);
   }
 
   // パラメータを読み出し。
@@ -469,7 +469,7 @@ CCP_CmdRet Cmd_BCE_RESET_ROTATOR_INFO(const CommonCmdPacket* packet)
   if (CCP_get_param_len(packet) != SIZE_OF_BCT_ID_T)
   {
     // パラメータはブロック番号
-    return CCP_EXEC_ILLEGAL_LENGTH;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_LENGTH);
   }
 
   // パラメータを読み出し。
@@ -485,7 +485,7 @@ CCP_CmdRet Cmd_BCE_RESET_COMBINER_INFO(const CommonCmdPacket* packet)
   if (CCP_get_param_len(packet) != SIZE_OF_BCT_ID_T)
   {
     // パラメータはブロック番号
-    return CCP_EXEC_ILLEGAL_LENGTH;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_LENGTH);
   }
 
   // パラメータを読み出し。
@@ -504,7 +504,7 @@ CCP_CmdRet Cmd_BCE_SET_ROTATE_INTERVAL(const CommonCmdPacket* packet)
   if (CCP_get_param_len(packet) != (SIZE_OF_BCT_ID_T + 2))
   {
     // パラメータはブロック番号2Byte＋周期2Byte = 4Bytes
-    return CCP_EXEC_ILLEGAL_LENGTH;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_LENGTH);
   }
 
   // パラメータを読み出し。

--- a/TlmCmd/block_command_executor.c
+++ b/TlmCmd/block_command_executor.c
@@ -115,7 +115,7 @@ BCT_ACK BCE_clear_block(const bct_id_t block)
   return BCT_SUCCESS;
 }
 
-CCP_EXEC_STS Cmd_BCE_ACTIVATE_BLOCK(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_BCE_ACTIVATE_BLOCK(const CommonCmdPacket* packet)
 {
   BCT_ACK ack;
   (void)packet;
@@ -146,7 +146,7 @@ BCT_ACK BCE_activate_block(void)
   return BCT_SUCCESS;
 }
 
-CCP_EXEC_STS Cmd_BCE_ACTIVATE_BLOCK_BY_ID(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_BCE_ACTIVATE_BLOCK_BY_ID(const CommonCmdPacket* packet)
 {
   bct_id_t block;
   BCT_ACK ack;
@@ -163,7 +163,7 @@ CCP_EXEC_STS Cmd_BCE_ACTIVATE_BLOCK_BY_ID(const CommonCmdPacket* packet)
   return BCT_convert_bct_ack_to_ccp_exec_sts(ack);
 }
 
-CCP_EXEC_STS Cmd_BCE_INACTIVATE_BLOCK_BY_ID(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_BCE_INACTIVATE_BLOCK_BY_ID(const CommonCmdPacket* packet)
 {
   bct_id_t block;
   BCT_ACK ack;
@@ -207,7 +207,7 @@ BCT_ACK BCE_inactivate_block_by_id(bct_id_t block)
   return BCT_SUCCESS;
 }
 
-CCP_EXEC_STS Cmd_BCE_ROTATE_BLOCK(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_BCE_ROTATE_BLOCK(const CommonCmdPacket* packet)
 {
   bct_id_t block;
 
@@ -256,7 +256,7 @@ static CCP_EXEC_STS BCE_rotate_block_cmd_(bct_id_t block)
   return ack;
 }
 
-CCP_EXEC_STS Cmd_BCE_COMBINE_BLOCK(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_BCE_COMBINE_BLOCK(const CommonCmdPacket* packet)
 {
   bct_id_t block;
 
@@ -301,7 +301,7 @@ static CCP_EXEC_STS BCE_combine_block_cmd_(bct_id_t block)
 // 2019/10/01 追加
 // 時間制限付きコンバイナ
 // （時間が来たら打ち切り．したがって，必ず設定時間はすぎる）
-CCP_EXEC_STS Cmd_BCE_TIMELIMIT_COMBINE_BLOCK(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_BCE_TIMELIMIT_COMBINE_BLOCK(const CommonCmdPacket* packet)
 {
   const uint8_t* param = CCP_get_param_head(packet);
   bct_id_t block;
@@ -462,7 +462,7 @@ BCT_ACK BCE_swap_contents(const bct_id_t block_a, const bct_id_t block_b)
   return BCT_SUCCESS;
 }
 
-CCP_EXEC_STS Cmd_BCE_RESET_ROTATOR_INFO(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_BCE_RESET_ROTATOR_INFO(const CommonCmdPacket* packet)
 {
   bct_id_t block;
 
@@ -478,7 +478,7 @@ CCP_EXEC_STS Cmd_BCE_RESET_ROTATOR_INFO(const CommonCmdPacket* packet)
   return BCT_convert_bct_ack_to_ccp_exec_sts(BCE_reset_rotator_info(block));
 }
 
-CCP_EXEC_STS Cmd_BCE_RESET_COMBINER_INFO(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_BCE_RESET_COMBINER_INFO(const CommonCmdPacket* packet)
 {
   bct_id_t block;
 
@@ -494,7 +494,7 @@ CCP_EXEC_STS Cmd_BCE_RESET_COMBINER_INFO(const CommonCmdPacket* packet)
   return BCT_convert_bct_ack_to_ccp_exec_sts(BCE_reset_combiner_info(block));
 }
 
-CCP_EXEC_STS Cmd_BCE_SET_ROTATE_INTERVAL(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_BCE_SET_ROTATE_INTERVAL(const CommonCmdPacket* packet)
 {
   const unsigned char* param = CCP_get_param_head(packet);
   bct_id_t block;

--- a/TlmCmd/block_command_executor.c
+++ b/TlmCmd/block_command_executor.c
@@ -232,8 +232,8 @@ static CCP_EXEC_STS BCE_rotate_block_cmd_(bct_id_t block)
   if (block >= BCT_MAX_BLOCKS) return BCT_convert_bct_ack_to_ccp_exec_sts(BCT_INVALID_BLOCK_NO);
 
   bc_exe_params = BCE_get_bc_exe_params_(block);
-  if (!bc_exe_params->is_active) return CCP_EXEC_ILLEGAL_CONTEXT;
-  if (bc_exe_params->rotate.interval == 0) return CCP_EXEC_ILLEGAL_CONTEXT;
+  if (!bc_exe_params->is_active) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
+  if (bc_exe_params->rotate.interval == 0) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
 
   ++bc_exe_params->rotate.counter;
   if (bc_exe_params->rotate.counter < bc_exe_params->rotate.interval)
@@ -282,7 +282,7 @@ static CCP_EXEC_STS BCE_combine_block_cmd_(bct_id_t block)
 
   length = BCT_get_bc_length(block);
 
-  if (!BCE_is_active(block)) return CCP_EXEC_ILLEGAL_CONTEXT;
+  if (!BCE_is_active(block)) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
 
   for (cmd = 0; cmd < length; ++cmd)
   {
@@ -334,7 +334,7 @@ static CCP_EXEC_STS BCE_timelimit_combine_block_cmd_(bct_id_t block, step_t limi
   if (block >= BCT_MAX_BLOCKS) return BCT_convert_bct_ack_to_ccp_exec_sts(BCT_INVALID_BLOCK_NO);
 
   bc_exe_params = BCE_get_bc_exe_params_(block);
-  if (!bc_exe_params->is_active) return CCP_EXEC_ILLEGAL_CONTEXT;
+  if (!bc_exe_params->is_active) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
 
   ++bc_exe_params->timelimit_combine.call_num;
   length = BCT_get_bc_length(block);

--- a/TlmCmd/block_command_executor.c
+++ b/TlmCmd/block_command_executor.c
@@ -514,7 +514,7 @@ CCP_CmdRet Cmd_BCE_SET_ROTATE_INTERVAL(const CommonCmdPacket* packet)
   if (interval == 0 || block >= BCT_MAX_BLOCKS)
   {
     // 0で割りに行くのでここではじく
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   }
 
   bc_exe_params = BCE_get_bc_exe_params_(block);

--- a/TlmCmd/block_command_executor.c
+++ b/TlmCmd/block_command_executor.c
@@ -122,7 +122,7 @@ CCP_CmdRet Cmd_BCE_ACTIVATE_BLOCK(const CommonCmdPacket* packet)
 
   ack = BCE_activate_block();
 
-  return BCT_convert_bct_ack_to_ccp_exec_sts(ack);
+  return BCT_convert_bct_ack_to_ccp_cmd_ret(ack);
 }
 
 BCT_ACK BCE_activate_block(void)
@@ -160,7 +160,7 @@ CCP_CmdRet Cmd_BCE_ACTIVATE_BLOCK_BY_ID(const CommonCmdPacket* packet)
   endian_memcpy(&block, CCP_get_param_head(packet), SIZE_OF_BCT_ID_T);
   ack = BCE_activate_block_by_id(block);
 
-  return BCT_convert_bct_ack_to_ccp_exec_sts(ack);
+  return BCT_convert_bct_ack_to_ccp_cmd_ret(ack);
 }
 
 CCP_CmdRet Cmd_BCE_INACTIVATE_BLOCK_BY_ID(const CommonCmdPacket* packet)
@@ -178,7 +178,7 @@ CCP_CmdRet Cmd_BCE_INACTIVATE_BLOCK_BY_ID(const CommonCmdPacket* packet)
 
   ack = BCE_inactivate_block_by_id(block);
 
-  return BCT_convert_bct_ack_to_ccp_exec_sts(ack);
+  return BCT_convert_bct_ack_to_ccp_cmd_ret(ack);
 }
 
 BCT_ACK BCE_activate_block_by_id(bct_id_t block)
@@ -229,7 +229,7 @@ static CCP_EXEC_STS BCE_rotate_block_cmd_(bct_id_t block)
   BCE_Params* bc_exe_params;
   BCT_Pos pos;
 
-  if (block >= BCT_MAX_BLOCKS) return BCT_convert_bct_ack_to_ccp_exec_sts(BCT_INVALID_BLOCK_NO);
+  if (block >= BCT_MAX_BLOCKS) return BCT_convert_bct_ack_to_ccp_cmd_ret(BCT_INVALID_BLOCK_NO);
 
   bc_exe_params = BCE_get_bc_exe_params_(block);
   if (!bc_exe_params->is_active) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
@@ -278,7 +278,7 @@ static CCP_EXEC_STS BCE_combine_block_cmd_(bct_id_t block)
   CCP_EXEC_STS ack;
   uint8_t length;
 
-  if (block >= BCT_MAX_BLOCKS) return BCT_convert_bct_ack_to_ccp_exec_sts(BCT_INVALID_BLOCK_NO);
+  if (block >= BCT_MAX_BLOCKS) return BCT_convert_bct_ack_to_ccp_cmd_ret(BCT_INVALID_BLOCK_NO);
 
   length = BCT_get_bc_length(block);
 
@@ -331,7 +331,7 @@ static CCP_EXEC_STS BCE_timelimit_combine_block_cmd_(bct_id_t block, step_t limi
   ObcTime finish;
   step_t diff;
 
-  if (block >= BCT_MAX_BLOCKS) return BCT_convert_bct_ack_to_ccp_exec_sts(BCT_INVALID_BLOCK_NO);
+  if (block >= BCT_MAX_BLOCKS) return BCT_convert_bct_ack_to_ccp_cmd_ret(BCT_INVALID_BLOCK_NO);
 
   bc_exe_params = BCE_get_bc_exe_params_(block);
   if (!bc_exe_params->is_active) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
@@ -475,7 +475,7 @@ CCP_CmdRet Cmd_BCE_RESET_ROTATOR_INFO(const CommonCmdPacket* packet)
   // パラメータを読み出し。
   endian_memcpy(&block, CCP_get_param_head(packet), SIZE_OF_BCT_ID_T);
 
-  return BCT_convert_bct_ack_to_ccp_exec_sts(BCE_reset_rotator_info(block));
+  return BCT_convert_bct_ack_to_ccp_cmd_ret(BCE_reset_rotator_info(block));
 }
 
 CCP_CmdRet Cmd_BCE_RESET_COMBINER_INFO(const CommonCmdPacket* packet)
@@ -491,7 +491,7 @@ CCP_CmdRet Cmd_BCE_RESET_COMBINER_INFO(const CommonCmdPacket* packet)
   // パラメータを読み出し。
   endian_memcpy(&block, CCP_get_param_head(packet), SIZE_OF_BCT_ID_T);
 
-  return BCT_convert_bct_ack_to_ccp_exec_sts(BCE_reset_combiner_info(block));
+  return BCT_convert_bct_ack_to_ccp_cmd_ret(BCE_reset_combiner_info(block));
 }
 
 CCP_CmdRet Cmd_BCE_SET_ROTATE_INTERVAL(const CommonCmdPacket* packet)

--- a/TlmCmd/block_command_executor.c
+++ b/TlmCmd/block_command_executor.c
@@ -36,28 +36,28 @@ static void BCE_set_bc_exe_params_(const bct_id_t block, const BCE_Params* bc_ex
 /**
  * @brief rotator の実行主体
  * @param[in] block: BC の idx
- * @return CCP_EXEC_STS
+ * @return CCP_CmdRet
  * @note  rotator はひたすらその BC に含まれる Cmd をループで実行し続ける
  *        interval[cycle] ごとに 1つの Cmd が実行される.
  */
-static CCP_EXEC_STS BCE_rotate_block_cmd_(bct_id_t block);
+static CCP_CmdRet BCE_rotate_block_cmd_(bct_id_t block);
 
 /**
  * @brief BC をまとめて一括で実行する
  * @param[in] block: BC の idx
- * @return CCP_EXEC_STS
+ * @return CCP_CmdRet
  * @note  BC の内部で BC を実行する時など
  */
-static CCP_EXEC_STS BCE_combine_block_cmd_(bct_id_t block);
+static CCP_CmdRet BCE_combine_block_cmd_(bct_id_t block);
 
 /**
  * @brief BC をまとめて一括で実行する
  * @param[in] block: BC の idx
  * @param[in] limit_step: 実行制限時間 [step]
- * @return CCP_EXEC_STS
+ * @return CCP_CmdRet
  * @note 時間を制限を設けてBCを実行したい時など
  */
-static CCP_EXEC_STS BCE_timelimit_combine_block_cmd_(bct_id_t block, step_t limit_step);
+static CCP_CmdRet BCE_timelimit_combine_block_cmd_(bct_id_t block, step_t limit_step);
 
 /**
  * @brief 時間制限付きの combiner
@@ -223,7 +223,7 @@ CCP_CmdRet Cmd_BCE_ROTATE_BLOCK(const CommonCmdPacket* packet)
   return BCE_rotate_block_cmd_(block);
 }
 
-static CCP_EXEC_STS BCE_rotate_block_cmd_(bct_id_t block)
+static CCP_CmdRet BCE_rotate_block_cmd_(bct_id_t block)
 {
   CCP_EXEC_STS ack;
   BCE_Params* bc_exe_params;
@@ -253,7 +253,7 @@ static CCP_EXEC_STS BCE_rotate_block_cmd_(bct_id_t block)
   BCT_load_cmd(&pos, &BCE_packet_);
   ack = PH_dispatch_command(&BCE_packet_);
 
-  return ack;
+  return CCP_make_cmd_ret_without_err_code(ack);
 }
 
 CCP_CmdRet Cmd_BCE_COMBINE_BLOCK(const CommonCmdPacket* packet)
@@ -272,7 +272,7 @@ CCP_CmdRet Cmd_BCE_COMBINE_BLOCK(const CommonCmdPacket* packet)
   return BCE_combine_block_cmd_(block);
 }
 
-static CCP_EXEC_STS BCE_combine_block_cmd_(bct_id_t block)
+static CCP_CmdRet BCE_combine_block_cmd_(bct_id_t block)
 {
   uint8_t cmd;
   CCP_EXEC_STS ack;
@@ -292,7 +292,7 @@ static CCP_EXEC_STS BCE_combine_block_cmd_(bct_id_t block)
     BCT_load_cmd(&pos, &BCE_packet_);
     ack = PH_dispatch_command(&BCE_packet_);
 
-    if (ack != CCP_EXEC_SUCCESS) return ack;
+    if (ack != CCP_EXEC_SUCCESS) return CCP_make_cmd_ret_without_err_code(ack);
   }
 
   return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
@@ -320,7 +320,7 @@ CCP_CmdRet Cmd_BCE_TIMELIMIT_COMBINE_BLOCK(const CommonCmdPacket* packet)
   return BCE_timelimit_combine_block_cmd_(block, limit_step);
 }
 
-static CCP_EXEC_STS BCE_timelimit_combine_block_cmd_(bct_id_t block, step_t limit_step)
+static CCP_CmdRet BCE_timelimit_combine_block_cmd_(bct_id_t block, step_t limit_step)
 {
   uint8_t cmd;
   uint8_t length;
@@ -358,7 +358,7 @@ static CCP_EXEC_STS BCE_timelimit_combine_block_cmd_(bct_id_t block, step_t limi
     if (ack != CCP_EXEC_SUCCESS)
     {
       BCE_set_bc_exe_params_(block, bc_exe_params);
-      return ack;
+      return CCP_make_cmd_ret_without_err_code(ack);
     }
 
     // 時間判定

--- a/TlmCmd/block_command_executor.h
+++ b/TlmCmd/block_command_executor.h
@@ -124,14 +124,14 @@ BCT_ACK BCE_swap_address(const bct_id_t block_a, const bct_id_t block_b);
  */
 BCT_ACK BCE_swap_contents(const bct_id_t block_a, const bct_id_t block_b);
 
-CCP_EXEC_STS Cmd_BCE_ACTIVATE_BLOCK(const CommonCmdPacket* packet);
-CCP_EXEC_STS Cmd_BCE_ACTIVATE_BLOCK_BY_ID(const CommonCmdPacket* packet);
-CCP_EXEC_STS Cmd_BCE_INACTIVATE_BLOCK_BY_ID(const CommonCmdPacket* packet);
-CCP_EXEC_STS Cmd_BCE_ROTATE_BLOCK(const CommonCmdPacket* packet);
-CCP_EXEC_STS Cmd_BCE_COMBINE_BLOCK(const CommonCmdPacket* packet);
-CCP_EXEC_STS Cmd_BCE_TIMELIMIT_COMBINE_BLOCK(const CommonCmdPacket* packet);
-CCP_EXEC_STS Cmd_BCE_RESET_ROTATOR_INFO(const CommonCmdPacket* packet);
-CCP_EXEC_STS Cmd_BCE_RESET_COMBINER_INFO(const CommonCmdPacket* packet);
-CCP_EXEC_STS Cmd_BCE_SET_ROTATE_INTERVAL(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_BCE_ACTIVATE_BLOCK(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_BCE_ACTIVATE_BLOCK_BY_ID(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_BCE_INACTIVATE_BLOCK_BY_ID(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_BCE_ROTATE_BLOCK(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_BCE_COMBINE_BLOCK(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_BCE_TIMELIMIT_COMBINE_BLOCK(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_BCE_RESET_ROTATOR_INFO(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_BCE_RESET_COMBINER_INFO(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_BCE_SET_ROTATE_INTERVAL(const CommonCmdPacket* packet);
 
 #endif

--- a/TlmCmd/block_command_table.c
+++ b/TlmCmd/block_command_table.c
@@ -383,7 +383,7 @@ BCT_ACK BCT_swap_contents(const bct_id_t block_a, const bct_id_t block_b)
   return BCT_SUCCESS;
 }
 
-CCP_EXEC_STS BCT_convert_bct_ack_to_ccp_exec_sts(BCT_ACK ack)
+CCP_CmdRet BCT_convert_bct_ack_to_ccp_cmd_ret(BCT_ACK ack)
 {
   switch (ack)
   {
@@ -430,7 +430,7 @@ CCP_CmdRet Cmd_BCT_CLEAR_BLOCK(const CommonCmdPacket* packet)
   // 指定されたブロック番号のクリアを実行。
   ack = BCT_clear_block(block);
 
-  return BCT_convert_bct_ack_to_ccp_exec_sts(ack);
+  return BCT_convert_bct_ack_to_ccp_cmd_ret(ack);
 }
 
 BCT_ACK BCT_clear_block(const bct_id_t block)
@@ -464,7 +464,7 @@ CCP_CmdRet Cmd_BCT_SET_BLOCK_POSITION(const CommonCmdPacket* packet)
 
   ack = BCT_set_position_(&pos);
 
-  return BCT_convert_bct_ack_to_ccp_exec_sts(ack);
+  return BCT_convert_bct_ack_to_ccp_cmd_ret(ack);
 }
 
 CCP_CmdRet Cmd_BCT_COPY_BCT(const CommonCmdPacket* packet)
@@ -478,7 +478,7 @@ CCP_CmdRet Cmd_BCT_COPY_BCT(const CommonCmdPacket* packet)
   endian_memcpy(&src_block, param + SIZE_OF_BCT_ID_T, SIZE_OF_BCT_ID_T);
 
   ack = BCT_copy_bct(dst_block, src_block);
-  return BCT_convert_bct_ack_to_ccp_exec_sts(ack);
+  return BCT_convert_bct_ack_to_ccp_cmd_ret(ack);
 }
 
 CCP_CmdRet Cmd_BCT_OVERWRITE_CMD(const CommonCmdPacket* packet)

--- a/TlmCmd/block_command_table.c
+++ b/TlmCmd/block_command_table.c
@@ -390,11 +390,12 @@ CCP_CmdRet BCT_convert_bct_ack_to_ccp_cmd_ret(BCT_ACK ack)
   case BCT_SUCCESS:
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 
+  // FIXME: これだめじゃん？
   case BCT_INVALID_BLOCK_NO:
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
 
   case BCT_INVALID_CMD_NO:
-    return CCP_EXEC_CMD_NOT_DEFINED;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_CMD_NOT_DEFINED);
 
   case BCT_DEFECTIVE_BLOCK:
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
@@ -408,8 +409,9 @@ CCP_CmdRet BCT_convert_bct_ack_to_ccp_cmd_ret(BCT_ACK ack)
   case BCT_ZERO_PERIOD:
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
 
+  // FIXME: これだめじゃん？
   default:
-    return CCP_EXEC_UNKNOWN;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_UNKNOWN);
   }
 }
 

--- a/TlmCmd/block_command_table.c
+++ b/TlmCmd/block_command_table.c
@@ -397,13 +397,13 @@ CCP_EXEC_STS BCT_convert_bct_ack_to_ccp_exec_sts(BCT_ACK ack)
     return CCP_EXEC_CMD_NOT_DEFINED;
 
   case BCT_DEFECTIVE_BLOCK:
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
 
   case BCT_CMD_TOO_LONG:
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
 
   case BCT_BC_FULL:
-    return CCP_EXEC_ILLEGAL_CONTEXT;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
 
   case BCT_ZERO_PERIOD:
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
@@ -520,7 +520,7 @@ CCP_CmdRet Cmd_BCT_FILL_NOP(const CommonCmdPacket* packet)
   uint8_t num_nop = CCP_get_param_from_packet(packet, 0, uint8_t);
 
   if (num_nop > 10 || num_nop < 1) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
-  if (block_command_table_.pos.cmd + num_nop != 10) return CCP_EXEC_ILLEGAL_CONTEXT;
+  if (block_command_table_.pos.cmd + num_nop != 10) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
 
   for (ti = 11 - (cycle_t)num_nop; ti < 11; ++ti)
   {

--- a/TlmCmd/block_command_table.c
+++ b/TlmCmd/block_command_table.c
@@ -421,7 +421,7 @@ CCP_CmdRet Cmd_BCT_CLEAR_BLOCK(const CommonCmdPacket* packet)
   if (CCP_get_param_len(packet) != SIZE_OF_BCT_ID_T)
   {
     // パラメータはブロック番号
-    return CCP_EXEC_ILLEGAL_LENGTH;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_LENGTH);
   }
 
   // パラメータを読み出し。
@@ -455,7 +455,7 @@ CCP_CmdRet Cmd_BCT_SET_BLOCK_POSITION(const CommonCmdPacket* packet)
   if (CCP_get_param_len(packet) != (SIZE_OF_BCT_ID_T + 1))
   {
     // パラメータはブロック番号とコマンド番号1Byte。
-    return CCP_EXEC_ILLEGAL_LENGTH;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_LENGTH);
   }
 
   // パラメータを読み出し
@@ -473,7 +473,7 @@ CCP_CmdRet Cmd_BCT_COPY_BCT(const CommonCmdPacket* packet)
   uint16_t dst_block, src_block;
   BCT_ACK ack;
 
-  if (CCP_get_param_len(packet) != 2 * SIZE_OF_BCT_ID_T) return CCP_EXEC_ILLEGAL_LENGTH;
+  if (CCP_get_param_len(packet) != 2 * SIZE_OF_BCT_ID_T) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_LENGTH);
   endian_memcpy(&dst_block, param, SIZE_OF_BCT_ID_T);
   endian_memcpy(&src_block, param + SIZE_OF_BCT_ID_T, SIZE_OF_BCT_ID_T);
 
@@ -499,7 +499,7 @@ CCP_CmdRet Cmd_BCT_OVERWRITE_CMD(const CommonCmdPacket* packet)
   uint16_t cmd_param_len;
 
   // raw なので引数長チェック
-  if (real_param_len < min_cmd_param_len || real_param_len > max_cmd_param_len) return CCP_EXEC_ILLEGAL_LENGTH;
+  if (real_param_len < min_cmd_param_len || real_param_len > max_cmd_param_len) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_LENGTH);
 
   cmd_param_len = real_param_len - min_cmd_param_len;
   CCP_get_raw_param_from_packet(packet, new_cmd_param, cmd_param_len);

--- a/TlmCmd/block_command_table.c
+++ b/TlmCmd/block_command_table.c
@@ -388,7 +388,7 @@ CCP_EXEC_STS BCT_convert_bct_ack_to_ccp_exec_sts(BCT_ACK ack)
   switch (ack)
   {
   case BCT_SUCCESS:
-    return CCP_EXEC_SUCCESS;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 
   case BCT_INVALID_BLOCK_NO:
     return CCP_EXEC_ILLEGAL_PARAMETER;
@@ -508,7 +508,7 @@ CCP_CmdRet Cmd_BCT_OVERWRITE_CMD(const CommonCmdPacket* packet)
   CCP_form_tlc((CommonCmdPacket*)&new_bct_cmddata, ti, cmd_id, new_cmd_param, cmd_param_len);
   BCT_overwrite_cmd(&pos, (CommonCmdPacket*)&new_bct_cmddata);
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 // 長さ 10 の BC に NOP を登録するコマンド. 使用前提が狭すぎるか??
@@ -528,7 +528,7 @@ CCP_CmdRet Cmd_BCT_FILL_NOP(const CommonCmdPacket* packet)
     BCT_register_cmd(&temp_packet_);
   }
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 #pragma section

--- a/TlmCmd/block_command_table.c
+++ b/TlmCmd/block_command_table.c
@@ -413,7 +413,7 @@ CCP_EXEC_STS BCT_convert_bct_ack_to_ccp_exec_sts(BCT_ACK ack)
   }
 }
 
-CCP_EXEC_STS Cmd_BCT_CLEAR_BLOCK(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_BCT_CLEAR_BLOCK(const CommonCmdPacket* packet)
 {
   bct_id_t block;
   BCT_ACK  ack;
@@ -446,7 +446,7 @@ BCT_ACK BCT_clear_block(const bct_id_t block)
   return BCT_SUCCESS;
 }
 
-CCP_EXEC_STS Cmd_BCT_SET_BLOCK_POSITION(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_BCT_SET_BLOCK_POSITION(const CommonCmdPacket* packet)
 {
   const unsigned char* param = CCP_get_param_head(packet);
   BCT_Pos pos;
@@ -467,7 +467,7 @@ CCP_EXEC_STS Cmd_BCT_SET_BLOCK_POSITION(const CommonCmdPacket* packet)
   return BCT_convert_bct_ack_to_ccp_exec_sts(ack);
 }
 
-CCP_EXEC_STS Cmd_BCT_COPY_BCT(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_BCT_COPY_BCT(const CommonCmdPacket* packet)
 {
   const unsigned char* param = CCP_get_param_head(packet);
   uint16_t dst_block, src_block;
@@ -481,7 +481,7 @@ CCP_EXEC_STS Cmd_BCT_COPY_BCT(const CommonCmdPacket* packet)
   return BCT_convert_bct_ack_to_ccp_exec_sts(ack);
 }
 
-CCP_EXEC_STS Cmd_BCT_OVERWRITE_CMD(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_BCT_OVERWRITE_CMD(const CommonCmdPacket* packet)
 {
   CMD_CODE cmd_id = (CMD_CODE)CCP_get_param_from_packet(packet, 0, uint16_t);
   cycle_t  ti     = (cycle_t)CCP_get_param_from_packet(packet, 1, uint32_t);
@@ -513,7 +513,7 @@ CCP_EXEC_STS Cmd_BCT_OVERWRITE_CMD(const CommonCmdPacket* packet)
 
 // 長さ 10 の BC に NOP を登録するコマンド. 使用前提が狭すぎるか??
 // パス運用時に使用するので, 一応厳密にしておいたほうがいい気もする.
-CCP_EXEC_STS Cmd_BCT_FILL_NOP(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_BCT_FILL_NOP(const CommonCmdPacket* packet)
 {
   static CommonCmdPacket temp_packet_;
   cycle_t ti;

--- a/TlmCmd/block_command_table.c
+++ b/TlmCmd/block_command_table.c
@@ -391,7 +391,7 @@ CCP_EXEC_STS BCT_convert_bct_ack_to_ccp_exec_sts(BCT_ACK ack)
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 
   case BCT_INVALID_BLOCK_NO:
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
 
   case BCT_INVALID_CMD_NO:
     return CCP_EXEC_CMD_NOT_DEFINED;
@@ -400,13 +400,13 @@ CCP_EXEC_STS BCT_convert_bct_ack_to_ccp_exec_sts(BCT_ACK ack)
     return CCP_EXEC_ILLEGAL_CONTEXT;
 
   case BCT_CMD_TOO_LONG:
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
 
   case BCT_BC_FULL:
     return CCP_EXEC_ILLEGAL_CONTEXT;
 
   case BCT_ZERO_PERIOD:
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
 
   default:
     return CCP_EXEC_UNKNOWN;
@@ -519,7 +519,7 @@ CCP_CmdRet Cmd_BCT_FILL_NOP(const CommonCmdPacket* packet)
   cycle_t ti;
   uint8_t num_nop = CCP_get_param_from_packet(packet, 0, uint8_t);
 
-  if (num_nop > 10 || num_nop < 1) return CCP_EXEC_ILLEGAL_PARAMETER;
+  if (num_nop > 10 || num_nop < 1) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   if (block_command_table_.pos.cmd + num_nop != 10) return CCP_EXEC_ILLEGAL_CONTEXT;
 
   for (ti = 11 - (cycle_t)num_nop; ti < 11; ++ti)

--- a/TlmCmd/block_command_table.h
+++ b/TlmCmd/block_command_table.h
@@ -292,10 +292,10 @@ BCT_ACK BCT_swap_contents(const bct_id_t block_a, const bct_id_t block_b);
  */
 CCP_EXEC_STS BCT_convert_bct_ack_to_ccp_exec_sts(BCT_ACK ack);
 
-CCP_EXEC_STS Cmd_BCT_CLEAR_BLOCK(const CommonCmdPacket* packet);
-CCP_EXEC_STS Cmd_BCT_SET_BLOCK_POSITION(const CommonCmdPacket* packet);
-CCP_EXEC_STS Cmd_BCT_COPY_BCT(const CommonCmdPacket* packet);
-CCP_EXEC_STS Cmd_BCT_OVERWRITE_CMD(const CommonCmdPacket* packet);
-CCP_EXEC_STS Cmd_BCT_FILL_NOP(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_BCT_CLEAR_BLOCK(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_BCT_SET_BLOCK_POSITION(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_BCT_COPY_BCT(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_BCT_OVERWRITE_CMD(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_BCT_FILL_NOP(const CommonCmdPacket* packet);
 
 #endif

--- a/TlmCmd/block_command_table.h
+++ b/TlmCmd/block_command_table.h
@@ -288,9 +288,9 @@ BCT_ACK BCT_swap_contents(const bct_id_t block_a, const bct_id_t block_b);
 /**
  * @brief  返り値用 enum 変換用関数
  * @param  ack: BCT_ACK
- * @return CCP_EXEC_STS
+ * @return CCP_CmdRet
  */
-CCP_EXEC_STS BCT_convert_bct_ack_to_ccp_exec_sts(BCT_ACK ack);
+CCP_CmdRet BCT_convert_bct_ack_to_ccp_cmd_ret(BCT_ACK ack);
 
 CCP_CmdRet Cmd_BCT_CLEAR_BLOCK(const CommonCmdPacket* packet);
 CCP_CmdRet Cmd_BCT_SET_BLOCK_POSITION(const CommonCmdPacket* packet);

--- a/TlmCmd/command_analyze.c
+++ b/TlmCmd/command_analyze.c
@@ -184,7 +184,7 @@ CCP_CmdRet Cmd_CA_INIT(const CommonCmdPacket* packet)
 {
   (void)packet;
   CA_initialize();
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 CCP_CmdRet Cmd_CA_REGISTER_CMD(const CommonCmdPacket* packet)
@@ -215,7 +215,7 @@ CCP_CmdRet Cmd_CA_REGISTER_CMD(const CommonCmdPacket* packet)
     command_analyze_.cmd_table[cmd_code].param_size_infos[i].packed_info.bit.second = param_size_infos[i] & 0x0f;
   }
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 CCP_CmdRet Cmd_CA_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet)
@@ -229,7 +229,7 @@ CCP_CmdRet Cmd_CA_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet)
   }
 
   command_analyze_.tlm_page_no = page;
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 #pragma section

--- a/TlmCmd/command_analyze.c
+++ b/TlmCmd/command_analyze.c
@@ -53,10 +53,11 @@ void CA_initialize(void)
   CA_load_cmd_table(command_analyze_.cmd_table);
 }
 
+// FIXME: 本当は CCP_CmdRet を返すべきだが，一旦ここで握りつぶす（あとで直す．PRを分割したい）
 CCP_EXEC_STS CA_execute_cmd(const CommonCmdPacket* packet)
 {
   CMD_CODE cmd_code = CCP_get_id(packet);
-  CCP_EXEC_STS (*cmd_func)(const CommonCmdPacket*) = NULL;
+  CCP_CmdRet (*cmd_func)(const CommonCmdPacket*) = NULL;
 
   if (cmd_code >= CA_MAX_CMDS)
   {
@@ -73,9 +74,9 @@ CCP_EXEC_STS CA_execute_cmd(const CommonCmdPacket* packet)
   {
     // ここで最低限のパラメタ長チェックをするが， bct_id_t など，内部定義を使っているものは各コマンド内部でもアサーションすること
     uint16_t param_len = CCP_get_param_len(packet);
-    if (CA_ckeck_cmd_param_len(cmd_code, param_len) != CA_ACK_OK) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_LENGTH);
+    if (CA_ckeck_cmd_param_len(cmd_code, param_len) != CA_ACK_OK) return CCP_EXEC_ILLEGAL_LENGTH;
 
-    return cmd_func(packet);
+    return cmd_func(packet).exec_sts;
   }
   else
   {

--- a/TlmCmd/command_analyze.c
+++ b/TlmCmd/command_analyze.c
@@ -180,14 +180,14 @@ static CA_PARAM_SIZE_TYPE CA_get_param_size_type_(CMD_CODE cmd_code, uint8_t n)
   }
 }
 
-CCP_EXEC_STS Cmd_CA_INIT(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_CA_INIT(const CommonCmdPacket* packet)
 {
   (void)packet;
   CA_initialize();
   return CCP_EXEC_SUCCESS;
 }
 
-CCP_EXEC_STS Cmd_CA_REGISTER_CMD(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_CA_REGISTER_CMD(const CommonCmdPacket* packet)
 {
   uint8_t param_size_infos[(CA_MAX_CMD_PARAM_NUM + 1) / 2];
   CMD_CODE cmd_code = (CMD_CODE)CCP_get_param_from_packet(packet, 0, uint16_t);
@@ -218,7 +218,7 @@ CCP_EXEC_STS Cmd_CA_REGISTER_CMD(const CommonCmdPacket* packet)
   return CCP_EXEC_SUCCESS;
 }
 
-CCP_EXEC_STS Cmd_CA_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_CA_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet)
 {
   uint8_t page = CCP_get_param_from_packet(packet, 0, uint8_t);
 

--- a/TlmCmd/command_analyze.c
+++ b/TlmCmd/command_analyze.c
@@ -73,7 +73,7 @@ CCP_EXEC_STS CA_execute_cmd(const CommonCmdPacket* packet)
   {
     // ここで最低限のパラメタ長チェックをするが， bct_id_t など，内部定義を使っているものは各コマンド内部でもアサーションすること
     uint16_t param_len = CCP_get_param_len(packet);
-    if (CA_ckeck_cmd_param_len(cmd_code, param_len) != CA_ACK_OK) return CCP_EXEC_ILLEGAL_LENGTH;
+    if (CA_ckeck_cmd_param_len(cmd_code, param_len) != CA_ACK_OK) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_LENGTH);
 
     return cmd_func(packet);
   }
@@ -196,10 +196,10 @@ CCP_CmdRet Cmd_CA_REGISTER_CMD(const CommonCmdPacket* packet)
   uint8_t i;
 
   // raw パラメタなので，引数長チェック
-  if (CCP_get_param_len(packet) != 6 + sizeof(param_size_infos)) return CCP_EXEC_ILLEGAL_LENGTH;
+  if (CCP_get_param_len(packet) != 6 + sizeof(param_size_infos)) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_LENGTH);
 
   ret = CCP_get_raw_param_from_packet(packet, param_size_infos, sizeof(param_size_infos));
-  if (ret != sizeof(param_size_infos)) return CCP_EXEC_ILLEGAL_LENGTH;
+  if (ret != sizeof(param_size_infos)) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_LENGTH);
 
   if (cmd_code >= CA_MAX_CMDS)
   {

--- a/TlmCmd/command_analyze.c
+++ b/TlmCmd/command_analyze.c
@@ -204,7 +204,7 @@ CCP_CmdRet Cmd_CA_REGISTER_CMD(const CommonCmdPacket* packet)
   if (cmd_code >= CA_MAX_CMDS)
   {
     // 登録指定位置がコマンド数上限を超えている場合は異常判定
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   }
 
   // ローレベルコマンドなので，アサーションしない
@@ -225,7 +225,7 @@ CCP_CmdRet Cmd_CA_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet)
   if (page >= CA_TLM_PAGE_MAX)
   {
     // ページ番号がコマンドテーブル範囲外
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   }
 
   command_analyze_.tlm_page_no = page;

--- a/TlmCmd/command_analyze.c
+++ b/TlmCmd/command_analyze.c
@@ -209,7 +209,7 @@ CCP_CmdRet Cmd_CA_REGISTER_CMD(const CommonCmdPacket* packet)
   }
 
   // ローレベルコマンドなので，アサーションしない
-  command_analyze_.cmd_table[cmd_code].cmd_func = (CCP_EXEC_STS (*)(const CommonCmdPacket*))cmd_func;
+  command_analyze_.cmd_table[cmd_code].cmd_func = (CCP_CmdRet (*)(const CommonCmdPacket*))cmd_func;
   for (i = 0; i < sizeof(param_size_infos); ++i)
   {
     command_analyze_.cmd_table[cmd_code].param_size_infos[i].packed_info.bit.first = ( param_size_infos[i] & 0xf0 ) >> 4;

--- a/TlmCmd/command_analyze.h
+++ b/TlmCmd/command_analyze.h
@@ -67,7 +67,7 @@ typedef enum
  */
 typedef struct
 {
-  CCP_EXEC_STS (*cmd_func)(const CommonCmdPacket*);                         //!< コマンドとなる関数
+  CCP_CmdRet (*cmd_func)(const CommonCmdPacket*);                           //!< コマンドとなる関数
   CA_PackedParamSizeInfo param_size_infos[(CA_MAX_CMD_PARAM_NUM + 1) / 2];  //!< パラメタサイズ情報
 } CA_CmdInfo;
 

--- a/TlmCmd/command_analyze.h
+++ b/TlmCmd/command_analyze.h
@@ -149,10 +149,10 @@ int CA_has_raw_param(CMD_CODE cmd_code);
  */
 void CA_load_cmd_table(CA_CmdInfo cmd_table[CA_MAX_CMDS]);
 
-CCP_EXEC_STS Cmd_CA_INIT(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_CA_INIT(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_CA_REGISTER_CMD(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_CA_REGISTER_CMD(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_CA_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_CA_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet);
 
 #endif

--- a/TlmCmd/common_cmd_packet.h
+++ b/TlmCmd/common_cmd_packet.h
@@ -71,6 +71,16 @@ typedef enum
   CCP_EXEC_TYPE_UNKNOWN
 } CCP_EXEC_TYPE;
 
+/**
+ * @struct CCP_CmdRet
+ * @brief  コマンド返り値
+ */
+typedef struct
+{
+  CCP_EXEC_STS exec_sts;    //!< CCP_EXEC_STS．Cmd の統一的なエラーコード
+  uint32_t     err_code;    //!< 各 Cmd ユニークなエラーコード．各 App で定義する enum などを入れることを想定．
+} CCP_CmdRet;
+
 
 /**
  * @brief  有効なパケットかチェックする

--- a/TlmCmd/common_cmd_packet_util.c
+++ b/TlmCmd/common_cmd_packet_util.c
@@ -70,6 +70,21 @@ static CCP_UTIL_ACK CCP_raise_err_at_param_generator_(void);
 static CCP_UTIL_ACK CCP_prepare_param_for_packet_(void* param, uint8_t byte);
 
 
+CCP_CmdRet CCP_make_cmd_ret(CCP_EXEC_STS exec_sts, uint32_t err_code)
+{
+  CCP_CmdRet ret;
+  ret.exec_sts = exec_sts;
+  ret.err_code = err_code;
+  return ret;
+}
+
+
+CCP_CmdRet CCP_make_cmd_ret_without_err_code(CCP_EXEC_STS exec_sts)
+{
+  return CCP_make_cmd_ret(exec_sts, 0);
+}
+
+
 void CCP_form_nop_rtc_(CommonCmdPacket* packet)
 {
   CCP_form_rtc(packet, Cmd_CODE_NOP, NULL, 0);

--- a/TlmCmd/common_cmd_packet_util.h
+++ b/TlmCmd/common_cmd_packet_util.h
@@ -21,6 +21,23 @@ typedef enum
   CCP_UTIL_ACK_PARAM_ERR     //!< パラメタエラー
 } CCP_UTIL_ACK;
 
+
+/**
+ * @brief コマンド返り値である CCP_CmdRet を作成
+ * @note  err_code を使わないときはそれを明示するために CCP_make_cmd_ret_without_err_code をつかうこと
+ * @param[in] exec_sts: コマンド実行結果 (CCP_EXEC_STS)
+ * @param[in] err_code: ユーザー定義エラーコード
+ * @return CCP_CmdRet
+ */
+CCP_CmdRet CCP_make_cmd_ret(CCP_EXEC_STS exec_sts, uint32_t err_code);
+
+/**
+ * @brief コマンド返り値である CCP_CmdRet を作成（エラーコード不使用版）
+ * @param[in] exec_sts: コマンド実行結果 (CCP_EXEC_STS)
+ * @return CCP_CmdRet
+ */
+CCP_CmdRet CCP_make_cmd_ret_without_err_code(CCP_EXEC_STS exec_sts);
+
 /**
  * @brief App 実行 TL コマンドを生成
  * @note  生成した時は CCP_EXEC_TYPE_TL_FROM_GS

--- a/TlmCmd/telemetry_frame.c
+++ b/TlmCmd/telemetry_frame.c
@@ -103,7 +103,7 @@ CCP_CmdRet Cmd_TF_INIT(const CommonCmdPacket* packet)
 {
   (void)packet;
   TF_initialize();
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 CCP_CmdRet Cmd_TF_REGISTER_TLM(const CommonCmdPacket* packet)
@@ -118,7 +118,7 @@ CCP_CmdRet Cmd_TF_REGISTER_TLM(const CommonCmdPacket* packet)
   }
 
   telemetry_frame_.tlm_table[tlm_id].tlm_func = (TF_TLM_FUNC_ACK (*)(uint8_t*, uint16_t*, uint16_t))tlm_func;
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 CCP_CmdRet Cmd_TF_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet)
@@ -132,7 +132,7 @@ CCP_CmdRet Cmd_TF_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet)
   }
 
   telemetry_frame_.tlm_page_no = page;
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 #pragma section

--- a/TlmCmd/telemetry_frame.c
+++ b/TlmCmd/telemetry_frame.c
@@ -99,14 +99,14 @@ void TF_copy_double(uint8_t* ptr, double data)
   endian_memcpy(ptr, &data, sizeof(double));
 }
 
-CCP_EXEC_STS Cmd_TF_INIT(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_TF_INIT(const CommonCmdPacket* packet)
 {
   (void)packet;
   TF_initialize();
   return CCP_EXEC_SUCCESS;
 }
 
-CCP_EXEC_STS Cmd_TF_REGISTER_TLM(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_TF_REGISTER_TLM(const CommonCmdPacket* packet)
 {
   TLM_CODE tlm_id = (TLM_CODE)CCP_get_param_from_packet(packet, 0, uint8_t);
   uint32_t tlm_func = CCP_get_param_from_packet(packet, 1, uint32_t);
@@ -121,7 +121,7 @@ CCP_EXEC_STS Cmd_TF_REGISTER_TLM(const CommonCmdPacket* packet)
   return CCP_EXEC_SUCCESS;
 }
 
-CCP_EXEC_STS Cmd_TF_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_TF_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet)
 {
   uint8_t page = CCP_get_param_from_packet(packet, 0, uint8_t);
 

--- a/TlmCmd/telemetry_frame.c
+++ b/TlmCmd/telemetry_frame.c
@@ -114,7 +114,7 @@ CCP_CmdRet Cmd_TF_REGISTER_TLM(const CommonCmdPacket* packet)
   if (tlm_id >= TF_MAX_TLMS)
   {
     // 登録指定位置がテレメトリ数上限を超えている場合は異常判定
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   }
 
   telemetry_frame_.tlm_table[tlm_id].tlm_func = (TF_TLM_FUNC_ACK (*)(uint8_t*, uint16_t*, uint16_t))tlm_func;
@@ -128,7 +128,7 @@ CCP_CmdRet Cmd_TF_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet)
   if (page >= TF_TLM_PAGE_MAX)
   {
     // ページ番号がコマンドテーブル範囲外
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   }
 
   telemetry_frame_.tlm_page_no = page;

--- a/TlmCmd/telemetry_frame.h
+++ b/TlmCmd/telemetry_frame.h
@@ -78,11 +78,11 @@ TF_TLM_FUNC_ACK TF_generate_contents(TLM_CODE tlm_id,
  */
 void TF_load_tlm_table(TF_TlmInfo tlm_table[TF_MAX_TLMS]);
 
-CCP_EXEC_STS Cmd_TF_INIT(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_TF_INIT(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_TF_REGISTER_TLM(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_TF_REGISTER_TLM(const CommonCmdPacket* packet);
 
-CCP_EXEC_STS Cmd_TF_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_TF_SET_PAGE_FOR_TLM(const CommonCmdPacket* packet);
 
 void TF_copy_u8(uint8_t* ptr, uint8_t data);
 

--- a/TlmCmd/telemetry_generator.c
+++ b/TlmCmd/telemetry_generator.c
@@ -93,7 +93,7 @@ CCP_CmdRet Cmd_GENERATE_TLM(const CommonCmdPacket* packet)
     --num_dumps;
   }
 
-  return CCP_EXEC_SUCCESS;
+  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 // FIXME: space packet 大工事でビット幅が変わってるので直す！

--- a/TlmCmd/telemetry_generator.c
+++ b/TlmCmd/telemetry_generator.c
@@ -52,7 +52,7 @@ CCP_CmdRet Cmd_GENERATE_TLM(const CommonCmdPacket* packet)
 
   // 範囲外のTLM IDを除外
   if (ack == TF_TLM_FUNC_ACK_NOT_DEFINED) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
-  if (ack != TF_TLM_FUNC_ACK_SUCCESS) return CCP_EXEC_ILLEGAL_CONTEXT;
+  if (ack != TF_TLM_FUNC_ACK_SUCCESS) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
 
   // Header
   if (APID_is_other_obc_tlm_apid(CTP_get_apid(&ctp_)))

--- a/TlmCmd/telemetry_generator.c
+++ b/TlmCmd/telemetry_generator.c
@@ -35,7 +35,7 @@ CCP_CmdRet Cmd_GENERATE_TLM(const CommonCmdPacket* packet)
     // パケット生成回数の上限は8回とする。
     // 32kbpsでのDL時に8VCDU/secで1秒分の通信量。
     // これを超える場合は複数回コマンドを送信して対応する。
-    return CCP_EXEC_ILLEGAL_PARAMETER;
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   }
 
   // ctp の ヘッダ部分の APID をクリア
@@ -51,7 +51,7 @@ CCP_CmdRet Cmd_GENERATE_TLM(const CommonCmdPacket* packet)
                              TSP_MAX_LEN);
 
   // 範囲外のTLM IDを除外
-  if (ack == TF_TLM_FUNC_ACK_NOT_DEFINED) return CCP_EXEC_ILLEGAL_PARAMETER;
+  if (ack == TF_TLM_FUNC_ACK_NOT_DEFINED) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
   if (ack != TF_TLM_FUNC_ACK_SUCCESS) return CCP_EXEC_ILLEGAL_CONTEXT;
 
   // Header

--- a/TlmCmd/telemetry_generator.c
+++ b/TlmCmd/telemetry_generator.c
@@ -17,7 +17,7 @@ static uint8_t TG_get_next_adu_counter_(void);
 
 // FIXME: 現在のコードは，MOBC と 2nd OBC の Tlm id がユニークであることを想定している
 //        本来被っても良いはず
-CCP_EXEC_STS Cmd_GENERATE_TLM(const CommonCmdPacket* packet)
+CCP_CmdRet Cmd_GENERATE_TLM(const CommonCmdPacket* packet)
 {
   static CommonTlmPacket ctp_;
   uint8_t category = CCP_get_param_from_packet(packet, 0, uint8_t);

--- a/TlmCmd/telemetry_generator.h
+++ b/TlmCmd/telemetry_generator.h
@@ -3,6 +3,6 @@
 
 #include "common_cmd_packet.h"
 
-CCP_EXEC_STS Cmd_GENERATE_TLM(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_GENERATE_TLM(const CommonCmdPacket* packet);
 
 #endif


### PR DESCRIPTION
## 概要
Cmd の返り値を CCP_EXEC_STS から CCP_CmdRet に

## Issue
- https://github.com/ut-issl/c2a-core/issues/376

## 詳細
- See Issue
- 大事なのはここ
  - https://github.com/ut-issl/c2a-core/blob/5314cbf6a8074a377cb5fc64f3f121367a081e65/TlmCmd/common_cmd_packet_util.h#L25-L39

## 検証結果
既存のテストが全て通った

## 影響範囲
- user部すべてのcmdと user ph と cmd dispatcherに影響

## 別 PR でやる部分
- 影響範囲が大きいので `CA_execute_cmd` や `DI_AOBC_dispatch_command` 部分で返り値を既存のものに握りつぶしているところの修正
  - https://github.com/ut-issl/c2a-core/blob/65c8ff4f9e9525b65eec34baa490c0d492712562/TlmCmd/command_analyze.c#L56-L79
  - https://github.com/ut-issl/c2a-core/blob/bb23c3ef56b5d4ddf775235e3d1acba0c328167c/Examples/minimum_user/src/src_user/Applications/DriverInstances/di_aobc.c#L99-L100
- https://github.com/ut-issl/c2a-core/issues/420
