### PR TITLE
コマンド返り値が CCP_CmdRet に変わったことに付随する細かい改善

### DIFF
--- a/Drivers/Super/driver_super.c
+++ b/Drivers/Super/driver_super.c
@@ -1687,15 +1687,15 @@ CCP_CmdRet DS_conv_driver_err_to_ccp_cmd_ret(DS_DRIVER_ERR_CODE code)
   case DS_DRIVER_ERR_CODE_ILLEGAL_CONTEXT:
   case DS_DRIVER_ERR_CODE_UNKNOWN_ERR:
     // 全てこれでいいのかは，要検討
-    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
+    return CCP_make_cmd_ret(CCP_EXEC_ILLEGAL_CONTEXT, (uint32_t)code);
   case DS_DRIVER_ERR_CODE_ILLEGAL_PARAMETER:
-    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
+    return CCP_make_cmd_ret(CCP_EXEC_ILLEGAL_PARAMETER, (uint32_t)code);
   case DS_DRIVER_ERR_CODE_ILLEGAL_LENGTH:
-    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_LENGTH);
+    return CCP_make_cmd_ret(CCP_EXEC_ILLEGAL_LENGTH, (uint32_t)code);
   default:
     // ここに来るのは以下
     // DS_DRIVER_ERR_CODE_OK
-    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
+    return CCP_make_cmd_ret(CCP_EXEC_SUCCESS, (uint32_t)code);
   }
 }
 
@@ -1705,11 +1705,11 @@ CCP_CmdRet DS_conv_cmd_err_to_ccp_cmd_ret(DS_CMD_ERR_CODE code)
   switch (code)
   {
   case DS_CMD_ILLEGAL_CONTEXT:
-    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
+    return CCP_make_cmd_ret(CCP_EXEC_ILLEGAL_CONTEXT, (uint32_t)code);
   case DS_CMD_ILLEGAL_PARAMETER:
-    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
+    return CCP_make_cmd_ret(CCP_EXEC_ILLEGAL_PARAMETER, (uint32_t)code);
   case DS_CMD_ILLEGAL_LENGTH:
-    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_LENGTH);
+    return CCP_make_cmd_ret(CCP_EXEC_ILLEGAL_LENGTH, (uint32_t)code);
   default:
     // ここに来るのは以下の３つ
     // DS_CMD_OK
@@ -1717,7 +1717,7 @@ CCP_CmdRet DS_conv_cmd_err_to_ccp_cmd_ret(DS_CMD_ERR_CODE code)
     // DS_CMD_UNKNOWN_ERR
     // 下２つのエラーはDriver側の問題で，そちらでエラー情報を持つべき
     // ここでは SUCCESSを返す
-    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
+    return CCP_make_cmd_ret(CCP_EXEC_SUCCESS, (uint32_t)code);
   }
 }
 

--- a/System/TimeManager/time_manager.c
+++ b/System/TimeManager/time_manager.c
@@ -237,11 +237,11 @@ static CCP_CmdRet TMGR_conv_tmgr_ack_to_ccp_cmd_ret_(TMGR_ACK ack)
   switch (ack)
   {
   case TMGR_ACK_OK:
-    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
+    return CCP_make_cmd_ret(CCP_EXEC_SUCCESS, (uint32_t)ack);
   case TMGR_ACK_PARAM_ERR:
-    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
+    return CCP_make_cmd_ret(CCP_EXEC_ILLEGAL_PARAMETER, (uint32_t)ack);
   default:
-    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
+    return CCP_make_cmd_ret(CCP_EXEC_ILLEGAL_CONTEXT, (uint32_t)ack);
   }
 }
 

--- a/TlmCmd/block_command_table.c
+++ b/TlmCmd/block_command_table.c
@@ -388,30 +388,30 @@ CCP_CmdRet BCT_convert_bct_ack_to_ccp_cmd_ret(BCT_ACK ack)
   switch (ack)
   {
   case BCT_SUCCESS:
-    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
+    return CCP_make_cmd_ret(CCP_EXEC_SUCCESS, (uint32_t)ack);
 
   // FIXME: これだめじゃん？
   case BCT_INVALID_BLOCK_NO:
-    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
+    return CCP_make_cmd_ret(CCP_EXEC_ILLEGAL_PARAMETER, (uint32_t)ack);
 
   case BCT_INVALID_CMD_NO:
-    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_CMD_NOT_DEFINED);
+    return CCP_make_cmd_ret(CCP_EXEC_CMD_NOT_DEFINED, (uint32_t)ack);
 
   case BCT_DEFECTIVE_BLOCK:
-    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
+    return CCP_make_cmd_ret(CCP_EXEC_ILLEGAL_CONTEXT, (uint32_t)ack);
 
   case BCT_CMD_TOO_LONG:
-    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
+    return CCP_make_cmd_ret(CCP_EXEC_ILLEGAL_PARAMETER, (uint32_t)ack);
 
   case BCT_BC_FULL:
-    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
+    return CCP_make_cmd_ret(CCP_EXEC_ILLEGAL_CONTEXT, (uint32_t)ack);
 
   case BCT_ZERO_PERIOD:
-    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_PARAMETER);
+    return CCP_make_cmd_ret(CCP_EXEC_ILLEGAL_PARAMETER, (uint32_t)ack);
 
   // FIXME: これだめじゃん？
   default:
-    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_UNKNOWN);
+    return CCP_make_cmd_ret(CCP_EXEC_UNKNOWN, (uint32_t)ack);
   }
 }
 


### PR DESCRIPTION
## 概要
コマンド返り値が CCP_CmdRet に変わったことに付随する細かい改善

## Issue
- https://github.com/ut-issl/c2a-core/issues/420

関連としては
- https://github.com/ut-issl/c2a-core/issues/376
- https://github.com/ut-issl/c2a-core/pull/417


## 詳細
せっかくエラーコードがあるものは，それも残すようにした．

## 検証結果
既存のテストが全て通った

## 影響範囲
とくになし
