### PR TITLE
Cmd の返り値を CCP_EXEC_STS から CCP_CmdRet に（つづき）

### DIFF
--- a/Examples/2nd_obc_user/src/src_user/Applications/UserDefined/debug_apps.c
+++ b/Examples/2nd_obc_user/src/src_user/Applications/UserDefined/debug_apps.c
@@ -88,12 +88,13 @@ void APP_DBG_print_time_stamp_(void)
 void APP_DBG_print_cmd_status_(void)
 {
   VT100_erase_line();
-  Printf("CMD: GS %3d, RT %3d, Ack %3d, Code 0x%02x, Sts %3d\n",
+  Printf("CMD: GS %3d, RT %3d, Ack %2d, ID 0x%02x, Sts %1d, EC %d\n",
          (PL_count_executed_nodes(&PH_gs_cmd_list) & 0xff),
          (PL_count_executed_nodes(&PH_rt_cmd_list) & 0xff),
          mobc_driver->info.c2a.ph_ack,
          gs_command_dispatcher->prev.code,
-         gs_command_dispatcher->prev.sts);
+         gs_command_dispatcher->prev.cmd_ret.exec_sts,
+         gs_command_dispatcher->prev.cmd_ret.err_code);
 }
 
 void APP_DBG_print_event_logger0_(void)

--- a/Examples/2nd_obc_user/src/src_user/TlmCmd/telemetry_definitions.c
+++ b/Examples/2nd_obc_user/src/src_user/TlmCmd/telemetry_definitions.c
@@ -32,14 +32,14 @@ static TF_TLM_FUNC_ACK Tlm_AOBC_AOBC_(uint8_t* packet, uint16_t* len, uint16_t m
   TF_copy_u32(&packet[50], (uint32_t)(TDSP_info->tskd.prev_err.time.total_cycle));
   TF_copy_u8(&packet[54], (uint8_t)(TDSP_info->tskd.prev_err.time.step));
   TF_copy_u16(&packet[55], (uint16_t)(TDSP_info->tskd.prev_err.code));
-  TF_copy_i32(&packet[57], (int32_t)(TDSP_info->tskd.prev_err.sts));
+  // TF_copy_i32(&packet[57], (int32_t)(TDSP_info->tskd.prev_err.sts));
   TF_copy_u32(&packet[61], PL_count_executed_nodes(&PH_gs_cmd_list));
   TF_copy_u32(&packet[65], (uint32_t)(gs_command_dispatcher->prev.time.total_cycle));
   TF_copy_u16(&packet[69], (uint16_t)(gs_command_dispatcher->prev.code));
   TF_copy_i32(&packet[71], (int32_t)(gs_command_dispatcher->prev.sts));
   TF_copy_u32(&packet[75], (uint32_t)(gs_command_dispatcher->prev_err.time.total_cycle));
   TF_copy_u16(&packet[79], (uint16_t)(gs_command_dispatcher->prev_err.code));
-  TF_copy_i32(&packet[81], (int32_t)(gs_command_dispatcher->prev_err.sts));
+  // TF_copy_i32(&packet[81], (int32_t)(gs_command_dispatcher->prev_err.sts));
   TF_copy_u32(&packet[85], (uint32_t)(gs_command_dispatcher->error_counter));
   TF_copy_u32(&packet[89], PL_count_executed_nodes(&PH_rt_cmd_list));
   TF_copy_u32(&packet[93], (uint32_t)(realtime_command_dispatcher->prev.time.total_cycle));
@@ -47,7 +47,7 @@ static TF_TLM_FUNC_ACK Tlm_AOBC_AOBC_(uint8_t* packet, uint16_t* len, uint16_t m
   TF_copy_i32(&packet[99], (int32_t)(realtime_command_dispatcher->prev.sts));
   TF_copy_u32(&packet[103], (uint32_t)(realtime_command_dispatcher->prev_err.time.total_cycle));
   TF_copy_u16(&packet[107], (uint16_t)(realtime_command_dispatcher->prev_err.code));
-  TF_copy_i32(&packet[109], (int32_t)(realtime_command_dispatcher->prev_err.sts));
+  // TF_copy_i32(&packet[109], (int32_t)(realtime_command_dispatcher->prev_err.sts));
   TF_copy_u32(&packet[113], (uint32_t)(realtime_command_dispatcher->error_counter));
   TF_copy_u32(&packet[117], PL_count_executed_nodes(&PH_tl_cmd_list[TLCD_ID_FROM_GS]));
   TF_copy_u8(&packet[121], (uint8_t)(PL_count_active_nodes(&PH_tl_cmd_list[TLCD_ID_FROM_GS])));
@@ -56,7 +56,7 @@ static TF_TLM_FUNC_ACK Tlm_AOBC_AOBC_(uint8_t* packet, uint16_t* len, uint16_t m
   TF_copy_i32(&packet[128], (int32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev.sts));
   TF_copy_u32(&packet[132], (uint32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev_err.time.total_cycle));
   TF_copy_u16(&packet[136], (uint16_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev_err.code));
-  TF_copy_i32(&packet[138], (int32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev_err.sts));
+  // TF_copy_i32(&packet[138], (int32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev_err.sts));
   TF_copy_u32(&packet[142], (uint32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].error_counter));
   TF_copy_u8(&packet[146], (uint8_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].stop_on_error));
   TF_copy_u8(&packet[147], (uint8_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].lockout));
@@ -69,7 +69,7 @@ static TF_TLM_FUNC_ACK Tlm_AOBC_AOBC_(uint8_t* packet, uint16_t* len, uint16_t m
   TF_copy_i32(&packet[165], (int32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_BC].prev.sts));
   TF_copy_u32(&packet[169], (uint32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_BC].prev_err.time.total_cycle));
   TF_copy_u16(&packet[173], (uint16_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_BC].prev_err.code));
-  TF_copy_i32(&packet[175], (int32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_BC].prev_err.sts));
+  // TF_copy_i32(&packet[175], (int32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_BC].prev_err.sts));
   TF_copy_u32(&packet[179], (uint32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_BC].error_counter));
   TF_copy_u8(&packet[183], (uint8_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_BC].stop_on_error));
   TF_copy_u8(&packet[184], (uint8_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_BC].lockout));
@@ -82,7 +82,7 @@ static TF_TLM_FUNC_ACK Tlm_AOBC_AOBC_(uint8_t* packet, uint16_t* len, uint16_t m
   TF_copy_i32(&packet[202], (int32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_TLM].prev.sts));
   TF_copy_u32(&packet[206], (uint32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_TLM].prev_err.time.total_cycle));
   TF_copy_u16(&packet[210], (uint16_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_TLM].prev_err.code));
-  TF_copy_i32(&packet[212], (int32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_TLM].prev_err.sts));
+  // TF_copy_i32(&packet[212], (int32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_TLM].prev_err.sts));
   TF_copy_u32(&packet[216], (uint32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_TLM].error_counter));
   TF_copy_u8(&packet[220], (uint8_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_TLM].stop_on_error));
   TF_copy_u8(&packet[221], (uint8_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_TLM].lockout));
@@ -116,14 +116,14 @@ static TF_TLM_FUNC_ACK Tlm_AOBC_HK_(uint8_t* packet, uint16_t* len, uint16_t max
   TF_copy_i8(&packet[52], (int8_t)(gs_command_dispatcher->prev.sts));
   TF_copy_u32(&packet[53], gs_command_dispatcher->prev_err.time.total_cycle);
   TF_copy_u16(&packet[57], (uint16_t)(gs_command_dispatcher->prev_err.code));
-  TF_copy_i8(&packet[59], (int8_t)(gs_command_dispatcher->prev_err.sts));
+  // TF_copy_i8(&packet[59], (int8_t)(gs_command_dispatcher->prev_err.sts));
   TF_copy_u32(&packet[60], PL_count_executed_nodes(&PH_rt_cmd_list));
   TF_copy_u32(&packet[64], (uint32_t)(realtime_command_dispatcher->prev.time.total_cycle));
   TF_copy_u16(&packet[68], (uint16_t)(realtime_command_dispatcher->prev.code));
   TF_copy_i32(&packet[70], (int32_t)(realtime_command_dispatcher->prev.sts));
   TF_copy_u32(&packet[74], (uint32_t)(realtime_command_dispatcher->prev_err.time.total_cycle));
   TF_copy_u16(&packet[78], (uint16_t)(realtime_command_dispatcher->prev_err.code));
-  TF_copy_i32(&packet[80], (int32_t)(realtime_command_dispatcher->prev_err.sts));
+  // TF_copy_i32(&packet[80], (int32_t)(realtime_command_dispatcher->prev_err.sts));
   TF_copy_u32(&packet[84], PL_count_executed_nodes(&PH_tl_cmd_list[TLCD_ID_FROM_GS]));
   TF_copy_u8(&packet[88], (uint8_t)(PL_count_active_nodes(&PH_tl_cmd_list[TLCD_ID_FROM_GS])));
   TF_copy_u32(&packet[89], timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev.time.total_cycle);
@@ -131,7 +131,7 @@ static TF_TLM_FUNC_ACK Tlm_AOBC_HK_(uint8_t* packet, uint16_t* len, uint16_t max
   TF_copy_i8(&packet[95], (int8_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev.sts));
   TF_copy_u32(&packet[96], timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev_err.time.total_cycle);
   TF_copy_u16(&packet[100], (uint16_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev_err.code));
-  TF_copy_i8(&packet[102], (int8_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev_err.sts));
+  // TF_copy_i8(&packet[102], (int8_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev_err.sts));
   TF_copy_u32(&packet[103], (PL_is_empty(&(PH_tl_cmd_list[TLCD_ID_FROM_GS])) ? 0 : (uint32_t)CCP_get_ti((const CommonCmdPacket*)(PL_get_head(&(PH_tl_cmd_list[TLCD_ID_FROM_GS]))->packet))));
   TF_copy_u16(&packet[107], (uint16_t)(PL_is_empty(&(PH_tl_cmd_list[TLCD_ID_FROM_GS])) ? 0 : CCP_get_id((const CommonCmdPacket*)(PL_get_head(&(PH_tl_cmd_list[TLCD_ID_FROM_GS]))->packet))));
   TF_copy_u32(&packet[109], PL_count_executed_nodes(&PH_tl_cmd_list[TLCD_ID_DEPLOY_BC]));

--- a/Examples/2nd_obc_user/src/src_user/TlmCmd/telemetry_definitions.c
+++ b/Examples/2nd_obc_user/src/src_user/TlmCmd/telemetry_definitions.c
@@ -36,7 +36,7 @@ static TF_TLM_FUNC_ACK Tlm_AOBC_AOBC_(uint8_t* packet, uint16_t* len, uint16_t m
   TF_copy_u32(&packet[61], PL_count_executed_nodes(&PH_gs_cmd_list));
   TF_copy_u32(&packet[65], (uint32_t)(gs_command_dispatcher->prev.time.total_cycle));
   TF_copy_u16(&packet[69], (uint16_t)(gs_command_dispatcher->prev.code));
-  TF_copy_i32(&packet[71], (int32_t)(gs_command_dispatcher->prev.sts));
+  // TF_copy_i32(&packet[71], (int32_t)(gs_command_dispatcher->prev.sts));
   TF_copy_u32(&packet[75], (uint32_t)(gs_command_dispatcher->prev_err.time.total_cycle));
   TF_copy_u16(&packet[79], (uint16_t)(gs_command_dispatcher->prev_err.code));
   // TF_copy_i32(&packet[81], (int32_t)(gs_command_dispatcher->prev_err.sts));
@@ -44,7 +44,7 @@ static TF_TLM_FUNC_ACK Tlm_AOBC_AOBC_(uint8_t* packet, uint16_t* len, uint16_t m
   TF_copy_u32(&packet[89], PL_count_executed_nodes(&PH_rt_cmd_list));
   TF_copy_u32(&packet[93], (uint32_t)(realtime_command_dispatcher->prev.time.total_cycle));
   TF_copy_u16(&packet[97], (uint16_t)(realtime_command_dispatcher->prev.code));
-  TF_copy_i32(&packet[99], (int32_t)(realtime_command_dispatcher->prev.sts));
+  // TF_copy_i32(&packet[99], (int32_t)(realtime_command_dispatcher->prev.sts));
   TF_copy_u32(&packet[103], (uint32_t)(realtime_command_dispatcher->prev_err.time.total_cycle));
   TF_copy_u16(&packet[107], (uint16_t)(realtime_command_dispatcher->prev_err.code));
   // TF_copy_i32(&packet[109], (int32_t)(realtime_command_dispatcher->prev_err.sts));
@@ -53,7 +53,7 @@ static TF_TLM_FUNC_ACK Tlm_AOBC_AOBC_(uint8_t* packet, uint16_t* len, uint16_t m
   TF_copy_u8(&packet[121], (uint8_t)(PL_count_active_nodes(&PH_tl_cmd_list[TLCD_ID_FROM_GS])));
   TF_copy_u32(&packet[122], (uint32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev.time.total_cycle));
   TF_copy_u16(&packet[126], (uint16_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev.code));
-  TF_copy_i32(&packet[128], (int32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev.sts));
+  // TF_copy_i32(&packet[128], (int32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev.sts));
   TF_copy_u32(&packet[132], (uint32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev_err.time.total_cycle));
   TF_copy_u16(&packet[136], (uint16_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev_err.code));
   // TF_copy_i32(&packet[138], (int32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev_err.sts));
@@ -66,7 +66,7 @@ static TF_TLM_FUNC_ACK Tlm_AOBC_AOBC_(uint8_t* packet, uint16_t* len, uint16_t m
   TF_copy_u8(&packet[158], (uint8_t)(PL_count_active_nodes(&PH_tl_cmd_list[TLCD_ID_DEPLOY_BC])));
   TF_copy_u32(&packet[159], (uint32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_BC].prev.time.total_cycle));
   TF_copy_u16(&packet[163], (uint16_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_BC].prev.code));
-  TF_copy_i32(&packet[165], (int32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_BC].prev.sts));
+  // TF_copy_i32(&packet[165], (int32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_BC].prev.sts));
   TF_copy_u32(&packet[169], (uint32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_BC].prev_err.time.total_cycle));
   TF_copy_u16(&packet[173], (uint16_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_BC].prev_err.code));
   // TF_copy_i32(&packet[175], (int32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_BC].prev_err.sts));
@@ -79,7 +79,7 @@ static TF_TLM_FUNC_ACK Tlm_AOBC_AOBC_(uint8_t* packet, uint16_t* len, uint16_t m
   TF_copy_u8(&packet[195], (uint8_t)(PL_count_active_nodes(&PH_tl_cmd_list[TLCD_ID_DEPLOY_TLM])));
   TF_copy_u32(&packet[196], (uint32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_TLM].prev.time.total_cycle));
   TF_copy_u16(&packet[200], (uint16_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_TLM].prev.code));
-  TF_copy_i32(&packet[202], (int32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_TLM].prev.sts));
+  // TF_copy_i32(&packet[202], (int32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_TLM].prev.sts));
   TF_copy_u32(&packet[206], (uint32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_TLM].prev_err.time.total_cycle));
   TF_copy_u16(&packet[210], (uint16_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_TLM].prev_err.code));
   // TF_copy_i32(&packet[212], (int32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_TLM].prev_err.sts));
@@ -113,14 +113,14 @@ static TF_TLM_FUNC_ACK Tlm_AOBC_HK_(uint8_t* packet, uint16_t* len, uint16_t max
   TF_copy_u32(&packet[42], PL_count_executed_nodes(&PH_gs_cmd_list));
   TF_copy_u32(&packet[46], gs_command_dispatcher->prev.time.total_cycle);
   TF_copy_u16(&packet[50], (uint16_t)(gs_command_dispatcher->prev.code));
-  TF_copy_i8(&packet[52], (int8_t)(gs_command_dispatcher->prev.sts));
+  // TF_copy_i8(&packet[52], (int8_t)(gs_command_dispatcher->prev.sts));
   TF_copy_u32(&packet[53], gs_command_dispatcher->prev_err.time.total_cycle);
   TF_copy_u16(&packet[57], (uint16_t)(gs_command_dispatcher->prev_err.code));
   // TF_copy_i8(&packet[59], (int8_t)(gs_command_dispatcher->prev_err.sts));
   TF_copy_u32(&packet[60], PL_count_executed_nodes(&PH_rt_cmd_list));
   TF_copy_u32(&packet[64], (uint32_t)(realtime_command_dispatcher->prev.time.total_cycle));
   TF_copy_u16(&packet[68], (uint16_t)(realtime_command_dispatcher->prev.code));
-  TF_copy_i32(&packet[70], (int32_t)(realtime_command_dispatcher->prev.sts));
+  // TF_copy_i32(&packet[70], (int32_t)(realtime_command_dispatcher->prev.sts));
   TF_copy_u32(&packet[74], (uint32_t)(realtime_command_dispatcher->prev_err.time.total_cycle));
   TF_copy_u16(&packet[78], (uint16_t)(realtime_command_dispatcher->prev_err.code));
   // TF_copy_i32(&packet[80], (int32_t)(realtime_command_dispatcher->prev_err.sts));
@@ -128,7 +128,7 @@ static TF_TLM_FUNC_ACK Tlm_AOBC_HK_(uint8_t* packet, uint16_t* len, uint16_t max
   TF_copy_u8(&packet[88], (uint8_t)(PL_count_active_nodes(&PH_tl_cmd_list[TLCD_ID_FROM_GS])));
   TF_copy_u32(&packet[89], timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev.time.total_cycle);
   TF_copy_u16(&packet[93], (uint16_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev.code));
-  TF_copy_i8(&packet[95], (int8_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev.sts));
+  // TF_copy_i8(&packet[95], (int8_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev.sts));
   TF_copy_u32(&packet[96], timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev_err.time.total_cycle);
   TF_copy_u16(&packet[100], (uint16_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev_err.code));
   // TF_copy_i8(&packet[102], (int8_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev_err.sts));

--- a/Examples/2nd_obc_user/src/src_user/TlmCmd/user_packet_handler.c
+++ b/Examples/2nd_obc_user/src/src_user/TlmCmd/user_packet_handler.c
@@ -26,13 +26,14 @@ PH_ACK PH_user_analyze_cmd(const CommonCmdPacket* packet)
 }
 
 
-CCP_EXEC_STS PH_user_cmd_router(const CommonCmdPacket* packet)
+CCP_CmdRet PH_user_cmd_router(const CommonCmdPacket* packet)
 {
-  switch (CCP_get_apid(packet))
+  APID apid = CCP_get_apid(packet);
+  switch (apid)
   {
   default:
-    // 該当する配送先が定義されていない場合。
-    return CCP_EXEC_ROUTING_FAILED;
+    // 該当する配送先が定義されていない場合
+    return CCP_make_cmd_ret(CCP_EXEC_ROUTING_FAILED, apid);
   }
 }
 

--- a/Examples/2nd_obc_user/src/src_user/TlmCmd/user_packet_handler.h
+++ b/Examples/2nd_obc_user/src/src_user/TlmCmd/user_packet_handler.h
@@ -7,6 +7,7 @@
 
 #include <src_core/TlmCmd/packet_list.h>
 #include <src_core/TlmCmd/common_tlm_cmd_packet.h>
+#include <src_core/TlmCmd/common_cmd_packet_util.h>
 #include <src_core/TlmCmd/packet_handler.h>
 
 /**
@@ -33,15 +34,15 @@ void PH_user_init(void);
 PH_ACK PH_user_analyze_cmd(const CommonCmdPacket* packet);
 
 /**
- * @brief  PH の cmd_router_ のユーザー処理関数
+ * @brief  PH の PH_dispatch_command のユーザー処理関数
  *
  *         C2A を搭載したコンポに Cmd が転送される．
  *         つまり，転送対象 OBC にとっては RTC 扱いになる
- *         ここから Driver を叩いて送信まで行うことになる（実行時間は cmdExec と同じだけ許容されているので OK）
+ *         ここから Driver を叩いて送信まで行うことになる（実行時間は CA_execute_cmd と同じだけ許容されているので OK）
  * @param  packet: CCP
- * @retval CCP_EXEC_SUCCESS など:   無事に転送された．転送先の結果を返す
- * @retval CCP_EXEC_ROUTING_FAILED: 転送失敗（詳細エラーは DriverSuper を参照）
+ * @retval CCP_CmdRet{CCP_EXEC_SUCCESS, *} など:   無事に転送された．転送先の結果を返す
+ * @retval CCP_CmdRet{CCP_EXEC_ROUTING_FAILED, *}: 転送失敗（詳細エラーは DriverSuper を参照）
  */
-CCP_EXEC_STS PH_user_cmd_router(const CommonCmdPacket* packet);
+CCP_CmdRet PH_user_cmd_router(const CommonCmdPacket* packet);
 
 #endif

--- a/Examples/minimum_user/src/src_user/Applications/DriverInstances/di_aobc.c
+++ b/Examples/minimum_user/src/src_user/Applications/DriverInstances/di_aobc.c
@@ -74,7 +74,7 @@ static void DI_AOBC_cmd_dispatcher_(void)
 }
 
 
-CCP_EXEC_STS DI_AOBC_dispatch_command(const CommonCmdPacket* packet)
+CCP_CmdRet DI_AOBC_dispatch_command(const CommonCmdPacket* packet)
 {
   DS_CMD_ERR_CODE ret;
   CommonCmdPacket* pckt = (CommonCmdPacket*)packet; // const_cast
@@ -97,7 +97,7 @@ CCP_EXEC_STS DI_AOBC_dispatch_command(const CommonCmdPacket* packet)
 
   ret = AOBC_send_cmd(&aobc_driver_, pckt);
   // FIXME: ここも一旦握りつぶす（後で直す）
-  return DS_conv_cmd_err_to_ccp_cmd_ret(ret).exec_sts;
+  return DS_conv_cmd_err_to_ccp_cmd_ret(ret);
 }
 
 

--- a/Examples/minimum_user/src/src_user/Applications/DriverInstances/di_aobc.h
+++ b/Examples/minimum_user/src/src_user/Applications/DriverInstances/di_aobc.h
@@ -35,10 +35,10 @@ AppInfo DI_AOBC_cmd_dispatcher(void);
  * @note   AOBC が自身のコマンドと解釈できるよう，Execution Type を上書きするため， packet を const cast する．[TODO] const cast やめたい
  * @note   この関数を呼んでも良いのは，user_packet_handler のみ！
  * @param  packet: CommonCmdPacket packet
- * @retval CCP_EXEC_SUCCESS: 無事に転送された
+ * @retval CCP_CmdRet{CCP_EXEC_SUCCESS, *}: 無事に転送された
  * @retval それ以外: 転送失敗（DS_CMD_ERR_CODE を CCP_EXEC_STS に変換して返す．詳細エラーは DriverSuper を参照）
  */
-CCP_EXEC_STS DI_AOBC_dispatch_command(const CommonCmdPacket* packet);
+CCP_CmdRet DI_AOBC_dispatch_command(const CommonCmdPacket* packet);
 
 CCP_CmdRet Cmd_DI_AOBC_CDIS_CLEAR_ALL_REALTIME(const CommonCmdPacket* packet);
 

--- a/Examples/minimum_user/src/src_user/Applications/UserDefined/debug_apps.c
+++ b/Examples/minimum_user/src/src_user/Applications/UserDefined/debug_apps.c
@@ -89,10 +89,13 @@ void APP_DBG_print_time_stamp_(void)
 void APP_DBG_print_cmd_status_(void)
 {
   VT100_erase_line();
-  Printf("CMD: GS %3d, RT %3d, Ack %3d, Code 0x%02x, Sts %3d\n",
+  Printf("CMD: GS %3d, RT %3d, Ack %2d, ID 0x%02x, Sts %1d, EC %d\n",
          (PL_count_executed_nodes(&PH_gs_cmd_list) & 0xff),
          (PL_count_executed_nodes(&PH_rt_cmd_list) & 0xff),
-         gs_driver->info[gs_driver->tlm_tx_port_type].rx.cmd_ack, gs_command_dispatcher->prev.code, gs_command_dispatcher->prev.sts);
+         gs_driver->info[gs_driver->tlm_tx_port_type].rx.cmd_ack,
+         gs_command_dispatcher->prev.code,
+         gs_command_dispatcher->prev.cmd_ret.exec_sts,
+         gs_command_dispatcher->prev.cmd_ret.err_code);
 }
 
 void APP_DBG_print_event_logger0_(void)

--- a/Examples/minimum_user/src/src_user/Test/test/src_core/System/EventManager/test_event_logger.py
+++ b/Examples/minimum_user/src/src_user/Test/test/src_core/System/EventManager/test_event_logger.py
@@ -760,7 +760,7 @@ def initialize_el():
     ret = wings.util.send_rt_cmd_and_confirm(
         ope,
         c2a_enum.Cmd_CODE_EL_DISABLE_LOGGING,
-        (c2a_enum.EL_CORE_GROUP_CDIS_EXEC_ERR,),
+        (c2a_enum.EL_CORE_GROUP_CDIS_EXEC_ERR_STS,),
         c2a_enum.Tlm_CODE_HK,
     )
     assert ret == "SUC"

--- a/Examples/minimum_user/src/src_user/Test/test/src_core/TlmCmd/test_command_dispatcher.py
+++ b/Examples/minimum_user/src/src_user/Test/test/src_core/TlmCmd/test_command_dispatcher.py
@@ -58,16 +58,16 @@ def test_cdis_exec_err():
         ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_EL
     )
     # GS_cmd_dispatcher
-    assert tlm_EL["EL.TLOGS.LOW.EVENTS3.GROUP"] == c2a_enum.EL_CORE_GROUP_CDIS_EXEC_ERR
-    assert tlm_EL["EL.TLOGS.LOW.EVENTS2.GROUP"] == c2a_enum.EL_CORE_GROUP_CDIS_EXEC_ERR
+    assert tlm_EL["EL.TLOGS.LOW.EVENTS3.GROUP"] == c2a_enum.EL_CORE_GROUP_CDIS_EXEC_ERR_STS
+    assert tlm_EL["EL.TLOGS.LOW.EVENTS2.GROUP"] == c2a_enum.EL_CORE_GROUP_CDIS_EXEC_ERR_STS
     assert tlm_EL["EL.TLOGS.LOW.EVENTS3.LOCAL"] == tlm_EL["EL.TLOGS.LOW.EVENTS2.LOCAL"]
     note = (c2a_enum.Cmd_CODE_TMGR_UPDATE_UNIXTIME << 16) | c2a_enum.CCP_EXEC_ILLEGAL_PARAMETER
     assert tlm_EL["EL.TLOGS.LOW.EVENTS3.NOTE"] == note
     note = (c2a_enum.Cmd_CODE_AM_SET_PAGE_FOR_TLM << 16) | c2a_enum.CCP_EXEC_ILLEGAL_PARAMETER
     assert tlm_EL["EL.TLOGS.LOW.EVENTS2.NOTE"] == note
     # TL_cmd_dispatcher
-    assert tlm_EL["EL.TLOGS.LOW.EVENTS1.GROUP"] == c2a_enum.EL_CORE_GROUP_CDIS_EXEC_ERR
-    assert tlm_EL["EL.TLOGS.LOW.EVENTS0.GROUP"] == c2a_enum.EL_CORE_GROUP_CDIS_EXEC_ERR
+    assert tlm_EL["EL.TLOGS.LOW.EVENTS1.GROUP"] == c2a_enum.EL_CORE_GROUP_CDIS_EXEC_ERR_STS
+    assert tlm_EL["EL.TLOGS.LOW.EVENTS0.GROUP"] == c2a_enum.EL_CORE_GROUP_CDIS_EXEC_ERR_STS
     assert tlm_EL["EL.TLOGS.LOW.EVENTS1.LOCAL"] == tlm_EL["EL.TLOGS.LOW.EVENTS0.LOCAL"]
     note = (c2a_enum.Cmd_CODE_TMGR_UPDATE_UNIXTIME << 16) | c2a_enum.CCP_EXEC_ILLEGAL_PARAMETER
     assert tlm_EL["EL.TLOGS.LOW.EVENTS1.NOTE"] == note

--- a/Examples/minimum_user/src/src_user/TlmCmd/telemetry_definitions.c
+++ b/Examples/minimum_user/src/src_user/TlmCmd/telemetry_definitions.c
@@ -90,7 +90,7 @@ static TF_TLM_FUNC_ACK Tlm_MOBC_(uint8_t* packet, uint16_t* len, uint16_t max_le
   TF_copy_u32(&packet[73], PL_count_executed_nodes(&PH_gs_cmd_list));
   TF_copy_u32(&packet[77], (uint32_t)(gs_command_dispatcher->prev.time.total_cycle));
   TF_copy_u16(&packet[81], (uint16_t)(gs_command_dispatcher->prev.code));
-  TF_copy_i32(&packet[83], (int32_t)(gs_command_dispatcher->prev.sts));
+  // TF_copy_i32(&packet[83], (int32_t)(gs_command_dispatcher->prev.sts));
   TF_copy_u32(&packet[87], (uint32_t)(gs_command_dispatcher->prev_err.time.total_cycle));
   TF_copy_u16(&packet[91], (uint16_t)(gs_command_dispatcher->prev_err.code));
   // TF_copy_i32(&packet[93], (int32_t)(gs_command_dispatcher->prev_err.sts));
@@ -98,7 +98,7 @@ static TF_TLM_FUNC_ACK Tlm_MOBC_(uint8_t* packet, uint16_t* len, uint16_t max_le
   TF_copy_u32(&packet[101], PL_count_executed_nodes(&PH_rt_cmd_list));
   TF_copy_u32(&packet[105], (uint32_t)(realtime_command_dispatcher->prev.time.total_cycle));
   TF_copy_u16(&packet[109], (uint16_t)(realtime_command_dispatcher->prev.code));
-  TF_copy_i32(&packet[111], (int32_t)(realtime_command_dispatcher->prev.sts));
+  // TF_copy_i32(&packet[111], (int32_t)(realtime_command_dispatcher->prev.sts));
   TF_copy_u32(&packet[115], (uint32_t)(realtime_command_dispatcher->prev_err.time.total_cycle));
   TF_copy_u16(&packet[119], (uint16_t)(realtime_command_dispatcher->prev_err.code));
   // TF_copy_i32(&packet[121], (int32_t)(realtime_command_dispatcher->prev_err.sts));
@@ -107,7 +107,7 @@ static TF_TLM_FUNC_ACK Tlm_MOBC_(uint8_t* packet, uint16_t* len, uint16_t max_le
   TF_copy_u8(&packet[133], (uint8_t)(PL_count_active_nodes(&PH_tl_cmd_list[TLCD_ID_FROM_GS])));
   TF_copy_u32(&packet[134], (uint32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev.time.total_cycle));
   TF_copy_u16(&packet[138], (uint16_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev.code));
-  TF_copy_i32(&packet[140], (int32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev.sts));
+  // TF_copy_i32(&packet[140], (int32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev.sts));
   TF_copy_u32(&packet[144], (uint32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev_err.time.total_cycle));
   TF_copy_u16(&packet[148], (uint16_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev_err.code));
   // TF_copy_i32(&packet[150], (int32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev_err.sts));
@@ -120,7 +120,7 @@ static TF_TLM_FUNC_ACK Tlm_MOBC_(uint8_t* packet, uint16_t* len, uint16_t max_le
   TF_copy_u8(&packet[170], (uint8_t)(PL_count_active_nodes(&PH_tl_cmd_list[TLCD_ID_DEPLOY_BC])));
   TF_copy_u32(&packet[171], (uint32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_BC].prev.time.total_cycle));
   TF_copy_u16(&packet[175], (uint16_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_BC].prev.code));
-  TF_copy_i32(&packet[177], (int32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_BC].prev.sts));
+  // TF_copy_i32(&packet[177], (int32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_BC].prev.sts));
   TF_copy_u32(&packet[181], (uint32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_BC].prev_err.time.total_cycle));
   TF_copy_u16(&packet[185], (uint16_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_BC].prev_err.code));
   // TF_copy_i32(&packet[187], (int32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_BC].prev_err.sts));
@@ -133,7 +133,7 @@ static TF_TLM_FUNC_ACK Tlm_MOBC_(uint8_t* packet, uint16_t* len, uint16_t max_le
   TF_copy_u8(&packet[207], (uint8_t)(PL_count_active_nodes(&PH_tl_cmd_list[TLCD_ID_DEPLOY_TLM])));
   TF_copy_u32(&packet[208], (uint32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_TLM].prev.time.total_cycle));
   TF_copy_u16(&packet[212], (uint16_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_TLM].prev.code));
-  TF_copy_i32(&packet[214], (int32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_TLM].prev.sts));
+  // TF_copy_i32(&packet[214], (int32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_TLM].prev.sts));
   TF_copy_u32(&packet[218], (uint32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_TLM].prev_err.time.total_cycle));
   TF_copy_u16(&packet[222], (uint16_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_TLM].prev_err.code));
   // TF_copy_i32(&packet[224], (int32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_TLM].prev_err.sts));
@@ -146,7 +146,7 @@ static TF_TLM_FUNC_ACK Tlm_MOBC_(uint8_t* packet, uint16_t* len, uint16_t max_le
   TF_copy_u8(&packet[244], (uint8_t)(PL_count_active_nodes(&PH_tl_cmd_list[TLCD_ID_FROM_GS_FOR_MISSION])));
   TF_copy_u32(&packet[245], (uint32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS_FOR_MISSION].prev.time.total_cycle));
   TF_copy_u16(&packet[249], (uint16_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS_FOR_MISSION].prev.code));
-  TF_copy_i32(&packet[251], (int32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS_FOR_MISSION].prev.sts));
+  // TF_copy_i32(&packet[251], (int32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS_FOR_MISSION].prev.sts));
   TF_copy_u32(&packet[255], (uint32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS_FOR_MISSION].prev_err.time.total_cycle));
   TF_copy_u16(&packet[259], (uint16_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS_FOR_MISSION].prev_err.code));
   // TF_copy_i32(&packet[261], (int32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS_FOR_MISSION].prev_err.sts));
@@ -3191,7 +3191,7 @@ static TF_TLM_FUNC_ACK Tlm_HK_(uint8_t* packet, uint16_t* len, uint16_t max_len)
   TF_copy_u32(&packet[48], PL_count_executed_nodes(&PH_gs_cmd_list));
   TF_copy_u32(&packet[52], gs_command_dispatcher->prev.time.total_cycle);
   TF_copy_u16(&packet[56], (uint16_t)(gs_command_dispatcher->prev.code));
-  TF_copy_i8(&packet[58], (int8_t)(gs_command_dispatcher->prev.sts));
+  // TF_copy_i8(&packet[58], (int8_t)(gs_command_dispatcher->prev.sts));
   TF_copy_u32(&packet[59], gs_command_dispatcher->prev_err.time.total_cycle);
   TF_copy_u16(&packet[63], (uint16_t)(gs_command_dispatcher->prev_err.code));
   // TF_copy_i8(&packet[65], (int8_t)(gs_command_dispatcher->prev_err.sts));
@@ -3199,7 +3199,7 @@ static TF_TLM_FUNC_ACK Tlm_HK_(uint8_t* packet, uint16_t* len, uint16_t max_len)
   TF_copy_u8(&packet[70], (uint8_t)(PL_count_active_nodes(&PH_tl_cmd_list[TLCD_ID_FROM_GS])));
   TF_copy_u32(&packet[71], timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev.time.total_cycle);
   TF_copy_u16(&packet[75], (uint16_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev.code));
-  TF_copy_i8(&packet[77], (int8_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev.sts));
+  // TF_copy_i8(&packet[77], (int8_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev.sts));
   TF_copy_u32(&packet[78], timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev_err.time.total_cycle);
   TF_copy_u16(&packet[82], (uint16_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev_err.code));
   // TF_copy_i8(&packet[84], (int8_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev_err.sts));
@@ -3213,7 +3213,7 @@ static TF_TLM_FUNC_ACK Tlm_HK_(uint8_t* packet, uint16_t* len, uint16_t max_len)
   TF_copy_u8(&packet[105], (uint8_t)(PL_count_active_nodes(&PH_tl_cmd_list[TLCD_ID_FROM_GS_FOR_MISSION])));
   TF_copy_u32(&packet[106], timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS_FOR_MISSION].prev.time.total_cycle);
   TF_copy_u16(&packet[110], (uint16_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS_FOR_MISSION].prev.code));
-  TF_copy_i8(&packet[112], (int8_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS_FOR_MISSION].prev.sts));
+  // TF_copy_i8(&packet[112], (int8_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS_FOR_MISSION].prev.sts));
   TF_copy_u32(&packet[113], timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS_FOR_MISSION].prev_err.time.total_cycle);
   TF_copy_u16(&packet[117], (uint16_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS_FOR_MISSION].prev_err.code));
   // TF_copy_i8(&packet[119], (int8_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS_FOR_MISSION].prev_err.sts));

--- a/Examples/minimum_user/src/src_user/TlmCmd/telemetry_definitions.c
+++ b/Examples/minimum_user/src/src_user/TlmCmd/telemetry_definitions.c
@@ -80,7 +80,7 @@ static TF_TLM_FUNC_ACK Tlm_MOBC_(uint8_t* packet, uint16_t* len, uint16_t max_le
   TF_copy_u32(&packet[50], (uint32_t)(TDSP_info->tskd.prev_err.time.total_cycle));
   TF_copy_u8(&packet[54], (uint8_t)(TDSP_info->tskd.prev_err.time.step));
   TF_copy_u16(&packet[55], (uint16_t)(TDSP_info->tskd.prev_err.code));
-  TF_copy_i32(&packet[57], (int32_t)(TDSP_info->tskd.prev_err.sts));
+  // TF_copy_i32(&packet[57], (int32_t)(TDSP_info->tskd.prev_err.sts));
   TF_copy_i32(&packet[61], (int32_t)gs_driver->latest_info->rx.ret_from_if_rx);
   TF_copy_u8(&packet[65], (uint8_t)gs_driver->latest_info->rx.rec_status);
   TF_copy_u32(&packet[66], (uint32_t)gs_driver->latest_info->rx.last_rec_time);
@@ -93,7 +93,7 @@ static TF_TLM_FUNC_ACK Tlm_MOBC_(uint8_t* packet, uint16_t* len, uint16_t max_le
   TF_copy_i32(&packet[83], (int32_t)(gs_command_dispatcher->prev.sts));
   TF_copy_u32(&packet[87], (uint32_t)(gs_command_dispatcher->prev_err.time.total_cycle));
   TF_copy_u16(&packet[91], (uint16_t)(gs_command_dispatcher->prev_err.code));
-  TF_copy_i32(&packet[93], (int32_t)(gs_command_dispatcher->prev_err.sts));
+  // TF_copy_i32(&packet[93], (int32_t)(gs_command_dispatcher->prev_err.sts));
   TF_copy_u32(&packet[97], (uint32_t)(gs_command_dispatcher->error_counter));
   TF_copy_u32(&packet[101], PL_count_executed_nodes(&PH_rt_cmd_list));
   TF_copy_u32(&packet[105], (uint32_t)(realtime_command_dispatcher->prev.time.total_cycle));
@@ -101,7 +101,7 @@ static TF_TLM_FUNC_ACK Tlm_MOBC_(uint8_t* packet, uint16_t* len, uint16_t max_le
   TF_copy_i32(&packet[111], (int32_t)(realtime_command_dispatcher->prev.sts));
   TF_copy_u32(&packet[115], (uint32_t)(realtime_command_dispatcher->prev_err.time.total_cycle));
   TF_copy_u16(&packet[119], (uint16_t)(realtime_command_dispatcher->prev_err.code));
-  TF_copy_i32(&packet[121], (int32_t)(realtime_command_dispatcher->prev_err.sts));
+  // TF_copy_i32(&packet[121], (int32_t)(realtime_command_dispatcher->prev_err.sts));
   TF_copy_u32(&packet[125], (uint32_t)(realtime_command_dispatcher->error_counter));
   TF_copy_u32(&packet[129], PL_count_executed_nodes(&PH_tl_cmd_list[TLCD_ID_FROM_GS]));
   TF_copy_u8(&packet[133], (uint8_t)(PL_count_active_nodes(&PH_tl_cmd_list[TLCD_ID_FROM_GS])));
@@ -110,7 +110,7 @@ static TF_TLM_FUNC_ACK Tlm_MOBC_(uint8_t* packet, uint16_t* len, uint16_t max_le
   TF_copy_i32(&packet[140], (int32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev.sts));
   TF_copy_u32(&packet[144], (uint32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev_err.time.total_cycle));
   TF_copy_u16(&packet[148], (uint16_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev_err.code));
-  TF_copy_i32(&packet[150], (int32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev_err.sts));
+  // TF_copy_i32(&packet[150], (int32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev_err.sts));
   TF_copy_u32(&packet[154], (uint32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].error_counter));
   TF_copy_u8(&packet[158], (uint8_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].stop_on_error));
   TF_copy_u8(&packet[159], (uint8_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].lockout));
@@ -123,7 +123,7 @@ static TF_TLM_FUNC_ACK Tlm_MOBC_(uint8_t* packet, uint16_t* len, uint16_t max_le
   TF_copy_i32(&packet[177], (int32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_BC].prev.sts));
   TF_copy_u32(&packet[181], (uint32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_BC].prev_err.time.total_cycle));
   TF_copy_u16(&packet[185], (uint16_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_BC].prev_err.code));
-  TF_copy_i32(&packet[187], (int32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_BC].prev_err.sts));
+  // TF_copy_i32(&packet[187], (int32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_BC].prev_err.sts));
   TF_copy_u32(&packet[191], (uint32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_BC].error_counter));
   TF_copy_u8(&packet[195], (uint8_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_BC].stop_on_error));
   TF_copy_u8(&packet[196], (uint8_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_BC].lockout));
@@ -136,7 +136,7 @@ static TF_TLM_FUNC_ACK Tlm_MOBC_(uint8_t* packet, uint16_t* len, uint16_t max_le
   TF_copy_i32(&packet[214], (int32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_TLM].prev.sts));
   TF_copy_u32(&packet[218], (uint32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_TLM].prev_err.time.total_cycle));
   TF_copy_u16(&packet[222], (uint16_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_TLM].prev_err.code));
-  TF_copy_i32(&packet[224], (int32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_TLM].prev_err.sts));
+  // TF_copy_i32(&packet[224], (int32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_TLM].prev_err.sts));
   TF_copy_u32(&packet[228], (uint32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_TLM].error_counter));
   TF_copy_u8(&packet[232], (uint8_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_TLM].stop_on_error));
   TF_copy_u8(&packet[233], (uint8_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_TLM].lockout));
@@ -149,7 +149,7 @@ static TF_TLM_FUNC_ACK Tlm_MOBC_(uint8_t* packet, uint16_t* len, uint16_t max_le
   TF_copy_i32(&packet[251], (int32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS_FOR_MISSION].prev.sts));
   TF_copy_u32(&packet[255], (uint32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS_FOR_MISSION].prev_err.time.total_cycle));
   TF_copy_u16(&packet[259], (uint16_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS_FOR_MISSION].prev_err.code));
-  TF_copy_i32(&packet[261], (int32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS_FOR_MISSION].prev_err.sts));
+  // TF_copy_i32(&packet[261], (int32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS_FOR_MISSION].prev_err.sts));
   TF_copy_u32(&packet[265], (uint32_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS_FOR_MISSION].error_counter));
   TF_copy_u8(&packet[269], (uint8_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS_FOR_MISSION].stop_on_error));
   TF_copy_u8(&packet[270], (uint8_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS_FOR_MISSION].lockout));
@@ -3194,7 +3194,7 @@ static TF_TLM_FUNC_ACK Tlm_HK_(uint8_t* packet, uint16_t* len, uint16_t max_len)
   TF_copy_i8(&packet[58], (int8_t)(gs_command_dispatcher->prev.sts));
   TF_copy_u32(&packet[59], gs_command_dispatcher->prev_err.time.total_cycle);
   TF_copy_u16(&packet[63], (uint16_t)(gs_command_dispatcher->prev_err.code));
-  TF_copy_i8(&packet[65], (int8_t)(gs_command_dispatcher->prev_err.sts));
+  // TF_copy_i8(&packet[65], (int8_t)(gs_command_dispatcher->prev_err.sts));
   TF_copy_u32(&packet[66], PL_count_executed_nodes(&PH_tl_cmd_list[TLCD_ID_FROM_GS]));
   TF_copy_u8(&packet[70], (uint8_t)(PL_count_active_nodes(&PH_tl_cmd_list[TLCD_ID_FROM_GS])));
   TF_copy_u32(&packet[71], timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev.time.total_cycle);
@@ -3202,7 +3202,7 @@ static TF_TLM_FUNC_ACK Tlm_HK_(uint8_t* packet, uint16_t* len, uint16_t max_len)
   TF_copy_i8(&packet[77], (int8_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev.sts));
   TF_copy_u32(&packet[78], timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev_err.time.total_cycle);
   TF_copy_u16(&packet[82], (uint16_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev_err.code));
-  TF_copy_i8(&packet[84], (int8_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev_err.sts));
+  // TF_copy_i8(&packet[84], (int8_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].prev_err.sts));
   TF_copy_u32(&packet[85], (PL_is_empty(&(PH_tl_cmd_list[TLCD_ID_FROM_GS])) ? 0 : (uint32_t)CCP_get_ti((const CommonCmdPacket*)(PL_get_head(&(PH_tl_cmd_list[TLCD_ID_FROM_GS]))->packet))));
   TF_copy_u16(&packet[89], (uint16_t)(PL_is_empty(&(PH_tl_cmd_list[TLCD_ID_FROM_GS])) ? 0 : CCP_get_id((const CommonCmdPacket*)(PL_get_head(&(PH_tl_cmd_list[TLCD_ID_FROM_GS]))->packet))));
   TF_copy_u32(&packet[91], PL_count_executed_nodes(&PH_tl_cmd_list[TLCD_ID_DEPLOY_BC]));
@@ -3216,7 +3216,7 @@ static TF_TLM_FUNC_ACK Tlm_HK_(uint8_t* packet, uint16_t* len, uint16_t max_len)
   TF_copy_i8(&packet[112], (int8_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS_FOR_MISSION].prev.sts));
   TF_copy_u32(&packet[113], timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS_FOR_MISSION].prev_err.time.total_cycle);
   TF_copy_u16(&packet[117], (uint16_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS_FOR_MISSION].prev_err.code));
-  TF_copy_i8(&packet[119], (int8_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS_FOR_MISSION].prev_err.sts));
+  // TF_copy_i8(&packet[119], (int8_t)(timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS_FOR_MISSION].prev_err.sts));
   TF_copy_u32(&packet[120], (PL_is_empty(&(PH_tl_cmd_list[TLCD_ID_FROM_GS_FOR_MISSION])) ? 0 : (uint32_t)CCP_get_ti((const CommonCmdPacket*)(PL_get_head(&(PH_tl_cmd_list[TLCD_ID_FROM_GS_FOR_MISSION]))->packet))));
   TF_copy_u16(&packet[124], (uint16_t)(PL_is_empty(&(PH_tl_cmd_list[TLCD_ID_FROM_GS_FOR_MISSION])) ? 0 : CCP_get_id((const CommonCmdPacket*)(PL_get_head(&(PH_tl_cmd_list[TLCD_ID_FROM_GS_FOR_MISSION]))->packet))));
   TF_copy_u8(&packet[126], (uint8_t)(((uint8_t)timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].stop_on_error << 7 & 0x80) | ((uint8_t)timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS].lockout << 6 & 0x40) | ((uint8_t)timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_BC].stop_on_error << 5 & 0x20) | ((uint8_t)timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_BC].lockout << 4 & 0x10) | ((uint8_t)timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_TLM].stop_on_error << 3 & 0x08) | ((uint8_t)timeline_command_dispatcher->dispatcher[TLCD_ID_DEPLOY_TLM].lockout << 2 & 0x04) | ((uint8_t)timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS_FOR_MISSION].stop_on_error << 1 & 0x02) | ((uint8_t)timeline_command_dispatcher->dispatcher[TLCD_ID_FROM_GS_FOR_MISSION].lockout & 0x01) ));

--- a/Examples/minimum_user/src/src_user/TlmCmd/user_packet_handler.c
+++ b/Examples/minimum_user/src/src_user/TlmCmd/user_packet_handler.c
@@ -48,9 +48,10 @@ PH_ACK PH_user_analyze_cmd(const CommonCmdPacket* packet)
 }
 
 
-CCP_EXEC_STS PH_user_cmd_router(const CommonCmdPacket* packet)
+CCP_CmdRet PH_user_cmd_router(const CommonCmdPacket* packet)
 {
-  switch (CCP_get_apid(packet))
+  APID apid = CCP_get_apid(packet);
+  switch (apid)
   {
   case APID_AOBC_CMD:
     // AOBCに配送
@@ -59,8 +60,8 @@ CCP_EXEC_STS PH_user_cmd_router(const CommonCmdPacket* packet)
     // TOBCに配送
     // return DI_TOBC_dispatch_command(packet);
   default:
-    // 該当する配送先が定義されていない場合。
-    return CCP_EXEC_ROUTING_FAILED;
+    // 該当する配送先が定義されていない場合
+    return CCP_make_cmd_ret(CCP_EXEC_ROUTING_FAILED, apid);
   }
 }
 

--- a/Examples/minimum_user/src/src_user/TlmCmd/user_packet_handler.h
+++ b/Examples/minimum_user/src/src_user/TlmCmd/user_packet_handler.h
@@ -7,6 +7,7 @@
 
 #include <src_core/TlmCmd/packet_list.h>
 #include <src_core/TlmCmd/common_tlm_cmd_packet.h>
+#include <src_core/TlmCmd/common_cmd_packet_util.h>
 #include <src_core/TlmCmd/packet_handler.h>
 
 extern PacketList PH_aobc_cmd_list;
@@ -36,15 +37,15 @@ void PH_user_init(void);
 PH_ACK PH_user_analyze_cmd(const CommonCmdPacket* packet);
 
 /**
- * @brief  PH の cmd_router_ のユーザー処理関数
+ * @brief  PH の PH_dispatch_command のユーザー処理関数
  *
  *         C2A を搭載したコンポに Cmd が転送される．
  *         つまり，転送対象 OBC にとっては RTC 扱いになる
- *         ここから Driver を叩いて送信まで行うことになる（実行時間は cmdExec と同じだけ許容されているので OK）
+ *         ここから Driver を叩いて送信まで行うことになる（実行時間は CA_execute_cmd と同じだけ許容されているので OK）
  * @param  packet: CCP
- * @retval CCP_EXEC_SUCCESS など:   無事に転送された．転送先の結果を返す
- * @retval CCP_EXEC_ROUTING_FAILED: 転送失敗（詳細エラーは DriverSuper を参照）
+ * @retval CCP_CmdRet{CCP_EXEC_SUCCESS, *} など:   無事に転送された．転送先の結果を返す
+ * @retval CCP_CmdRet{CCP_EXEC_ROUTING_FAILED, *}: 転送失敗（詳細エラーは DriverSuper を参照）
  */
-CCP_EXEC_STS PH_user_cmd_router(const CommonCmdPacket* packet);
+CCP_CmdRet PH_user_cmd_router(const CommonCmdPacket* packet);
 
 #endif

--- a/System/EventManager/event_handler.c
+++ b/System/EventManager/event_handler.c
@@ -648,23 +648,24 @@ static EH_CKECK_RULE_ACK EH_check_cumulative_rule_(EH_RULE_ID rule_id, const EL_
 static void EH_respond_(EH_RULE_ID rule_id)
 {
   EH_Rule* rule = &event_handler_.rule_table.rules[rule_id];
-  CCP_EXEC_STS ack;
+  CCP_CmdRet cmd_ret;
 
-  ack = CCP_form_and_exec_block_deploy_cmd(TLCD_ID_DEPLOY_BC, rule->settings.deploy_bct_id);
-  if (ack != CCP_EXEC_SUCCESS)
+  cmd_ret = CCP_form_and_exec_block_deploy_cmd(TLCD_ID_DEPLOY_BC, rule->settings.deploy_bct_id);
+  if (cmd_ret.exec_sts != CCP_EXEC_SUCCESS)
   {
     EL_record_event((EL_GROUP)EL_CORE_GROUP_EVENT_HANDLER,
                     EH_EL_LOCAL_ID_FAIL_FORM_CTCP,
                     EL_ERROR_LEVEL_HIGH,
-                    ack);
+                    cmd_ret.exec_sts);
   }
 
   EH_inactivate_rule_for_multi_level(rule_id);
 
-  EH_record_responded_log_(rule_id, ack);
+  EH_record_responded_log_(rule_id, cmd_ret.exec_sts);
 }
 
 
+// FIXME: CCP_EXEC_STS -> CCP_CmdRet にしてもいいかも？
 static void EH_record_responded_log_(EH_RULE_ID rule_id, CCP_EXEC_STS deploy_cmd_ack)
 {
   EH_LogTable* log_table = &event_handler_.log_table;

--- a/System/EventManager/event_logger.h
+++ b/System/EventManager/event_logger.h
@@ -216,7 +216,8 @@ typedef enum
   EL_CORE_GROUP_EH_RESPOND_WITH_HIGHER_LEVEL_RULE,  //!< EH_Rule でマッチしたが，そのルールで対応せずに，上位のルールで対応させた（詳細は event_handler.h 参照）
   EL_CORE_GROUP_COMMAND_ANALYZE,
   EL_CORE_GROUP_CDIS_INTERNAL_ERR,
-  EL_CORE_GROUP_CDIS_EXEC_ERR,
+  EL_CORE_GROUP_CDIS_EXEC_ERR_STS,
+  EL_CORE_GROUP_CDIS_EXEC_ERR_CODE,
   // TODO: Driver Super
 #ifdef EL_IS_ENABLE_EL_ERROR_LEVEL
   EL_CORE_GROUP_EL_DROP_CLOG1,        //!< EL CLogs で古いエラーを上書きするとき (group, err_level を保存)

--- a/System/TaskManager/task_dispatcher.c
+++ b/System/TaskManager/task_dispatcher.c
@@ -109,7 +109,7 @@ void TDSP_execute_pl_as_task_list(void)
       // 実行時刻が過ぎている、もしくは実行時刻ピッタリの場合はコマンドを実行
       CDIS_dispatch_command(&(TDSP_info_.tskd));
 
-      if (TDSP_info_.tskd.prev.sts != CCP_EXEC_SUCCESS)
+      if (TDSP_info_.tskd.prev.cmd_ret.exec_sts != CCP_EXEC_SUCCESS)
       {
         // コマンド実行時に異常が発生した場合はアノマリを登録。
 #ifndef AL_DISALBE_AT_C2A_CORE
@@ -118,7 +118,7 @@ void TDSP_execute_pl_as_task_list(void)
         EL_record_event((EL_GROUP)EL_CORE_GROUP_TASK_DISPATCHER,
                       TDSP_TASK_EXEC_FAILED,
                       EL_ERROR_LEVEL_HIGH,
-                      TDSP_info_.tskd.prev.sts);
+                      TDSP_info_.tskd.prev.cmd_ret.exec_sts);
       }
 
       break;
@@ -211,11 +211,12 @@ AppInfo print_tdsp_status(void)
 void print_tdsp_status_(void)
 {
   VT100_erase_line();
-  Printf("TASK: BC %d, ERR (TOTAL, STEP, STS) = (%10u, %3u, %d)\n",
+  Printf("TASK: BC %d, ERR (TOTAL, STEP, STS, CODE) = (%10u, %3u, %d, %d)\n",
          TDSP_info->task_list_id,
          TDSP_info->tskd.prev_err.time.total_cycle,
          TDSP_info->tskd.prev_err.time.step,
-         TDSP_info->tskd.prev_err.sts);
+         TDSP_info->tskd.prev_err.cmd_ret.exec_sts,
+         TDSP_info->tskd.prev_err.cmd_ret.err_code);
 }
 
 #pragma section

--- a/System/TaskManager/task_dispatcher.h
+++ b/System/TaskManager/task_dispatcher.h
@@ -59,7 +59,7 @@ TDSP_ACK TDSP_set_task_list_id(bct_id_t id);
  *        展開されているタスクリストの実行時刻 (cycle レベル) を比較し, task_list_ に登録されているタスクを順番に実行する．
  *        1つタスクを消化すると return する． (while(1) で回っているのですぐ戻ってくる．)
  *        実行 cycle が現在だった場合, 各タスクの step によって実行する, しないを switch に合わせて処理する．
- *        実際にタスクを処理する場合, CDIS_dispatch_command -> PH_dispatch_command -> cmdExec の順に実行される(真の Executer は cmdExec)．
+ *        実際にタスクを処理する場合, CDIS_dispatch_command -> PH_dispatch_command -> CA_execute_cmd の順に実行される(真の Executer は CA_execute_cmd)．
  */
 void TDSP_execute_pl_as_task_list(void);
 

--- a/TlmCmd/command_analyze.h
+++ b/TlmCmd/command_analyze.h
@@ -6,6 +6,7 @@
 #define COMMAND_ANALYZE_H_
 
 #include "common_cmd_packet.h"
+#include "common_cmd_packet_util.h"
 #include <src_user/TlmCmd/command_definitions.h>
 
 #define CA_TLM_PAGE_SIZE      (32)                                  //!< コマンドテーブルの1テレメトリパケット(=1ページ)に格納されるコマンド数（ページネーション用）
@@ -94,9 +95,9 @@ void CA_initialize(void);
 /**
  * @brief  コマンド実行の本体
  * @param  packet: 実行するコマンド
- * @return CCP_EXEC_STS
+ * @return CCP_CmdRet
  */
-CCP_EXEC_STS CA_execute_cmd(const CommonCmdPacket* packet);
+CCP_CmdRet CA_execute_cmd(const CommonCmdPacket* packet);
 
 /**
  * @brief  コマンドパラメタ数を取得する

--- a/TlmCmd/command_dispatcher.c
+++ b/TlmCmd/command_dispatcher.c
@@ -4,7 +4,6 @@
  * @brief 各種コマンドの実行管理
  */
 #include "command_dispatcher.h"
-
 #include <src_user/TlmCmd/command_definitions.h>
 #include "../System/TimeManager/time_manager.h"
 #include "../System/EventManager/event_logger.h"

--- a/TlmCmd/command_dispatcher.c
+++ b/TlmCmd/command_dispatcher.c
@@ -80,7 +80,7 @@ static void CDIS_clear_exec_info_(CDIS_ExecInfo* exec_info)
 {
   OBCT_clear(&(exec_info->time));
   exec_info->code = (CMD_CODE)0;
-  exec_info->sts = CCP_EXEC_SUCCESS;
+  exec_info->cmd_ret = CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
 }
 
 
@@ -95,7 +95,7 @@ void CDIS_dispatch_command(CommandDispatcher* cdis)
   if (cdis->pl == NULL) return;       // TODO: PL 側で NULL チェックに対応したら消す
   if (PL_is_empty(cdis->pl)) return;
 
-  if (cdis->prev.sts != CCP_EXEC_SUCCESS)
+  if (cdis->prev.cmd_ret.exec_sts != CCP_EXEC_SUCCESS)
   {
     // 直前コマンドが異常終了した場合は実行前に情報を保存
     // 実行前にコピーすることで次コマンドが異常終了した場合は
@@ -119,21 +119,25 @@ void CDIS_dispatch_command(CommandDispatcher* cdis)
   */
 
   // 実行時情報を記録しつつコマンドを実行
-  cdis->prev.time = TMGR_get_master_clock();
-  cdis->prev.code = CCP_get_id(&packet_);
-  cdis->prev.sts  = PH_dispatch_command(&packet_);
+  cdis->prev.time    = TMGR_get_master_clock();
+  cdis->prev.code    = CCP_get_id(&packet_);
+  cdis->prev.cmd_ret = PH_dispatch_command(&packet_);
 
   // 実行したコマンドをリストから破棄
   PL_drop_executed(cdis->pl);
 
-  if (cdis->prev.sts != CCP_EXEC_SUCCESS)
+  if (cdis->prev.cmd_ret.exec_sts != CCP_EXEC_SUCCESS)
   {
     // 実行時エラー情報をELにも記録. エラー発生場所(GSCD,TLCDなど)はcdisのポインタアドレスで区別
-    uint32_t note = ((0x0000ffff & cdis->prev.code) << 16) | (0x0000ffff & cdis->prev.sts);
-    EL_record_event((EL_GROUP)EL_CORE_GROUP_CDIS_EXEC_ERR,
+    uint32_t note = ((0x0000ffff & cdis->prev.code) << 16) | (0x0000ffff & cdis->prev.cmd_ret.exec_sts);
+    EL_record_event((EL_GROUP)EL_CORE_GROUP_CDIS_EXEC_ERR_STS,
                     (uint32_t)cdis,
                     EL_ERROR_LEVEL_LOW,
                     note);
+    EL_record_event((EL_GROUP)EL_CORE_GROUP_CDIS_EXEC_ERR_CODE,
+                    (uint32_t)cdis,
+                    EL_ERROR_LEVEL_LOW,
+                    cdis->prev.cmd_ret.err_code);
 
     // 実行したコマンドが実行異常ステータスを返した場合
     // エラー発生カウンタをカウントアップ

--- a/TlmCmd/command_dispatcher.c
+++ b/TlmCmd/command_dispatcher.c
@@ -127,16 +127,18 @@ void CDIS_dispatch_command(CommandDispatcher* cdis)
 
   if (cdis->prev.cmd_ret.exec_sts != CCP_EXEC_SUCCESS)
   {
+    uint32_t note;
     // 実行時エラー情報をELにも記録. エラー発生場所(GSCD,TLCDなど)はcdisのポインタアドレスで区別
-    uint32_t note = ((0x0000ffff & cdis->prev.code) << 16) | (0x0000ffff & cdis->prev.cmd_ret.exec_sts);
-    EL_record_event((EL_GROUP)EL_CORE_GROUP_CDIS_EXEC_ERR_STS,
-                    (uint32_t)cdis,
-                    EL_ERROR_LEVEL_LOW,
-                    note);
+    // より重要な EL_CORE_GROUP_CDIS_EXEC_ERR_STS があとに来るように EL 発行
     EL_record_event((EL_GROUP)EL_CORE_GROUP_CDIS_EXEC_ERR_CODE,
                     (uint32_t)cdis,
                     EL_ERROR_LEVEL_LOW,
                     cdis->prev.cmd_ret.err_code);
+    note = ((0x0000ffff & cdis->prev.code) << 16) | (0x0000ffff & cdis->prev.cmd_ret.exec_sts);
+    EL_record_event((EL_GROUP)EL_CORE_GROUP_CDIS_EXEC_ERR_STS,
+                    (uint32_t)cdis,
+                    EL_ERROR_LEVEL_LOW,
+                    note);
 
     // 実行したコマンドが実行異常ステータスを返した場合
     // エラー発生カウンタをカウントアップ

--- a/TlmCmd/command_dispatcher.h
+++ b/TlmCmd/command_dispatcher.h
@@ -9,6 +9,7 @@
 #include "common_cmd_packet.h"
 #include "packet_list.h"
 #include <src_user/TlmCmd/command_definitions.h>
+#include "common_cmd_packet_util.h"
 
 /**
  * @struct CDIS_ExecInfo
@@ -16,9 +17,9 @@
  */
 typedef struct
 {
-  ObcTime time;       //!< 実行時刻
-  CMD_CODE code;      //!< 実行コマンドID
-  CCP_EXEC_STS sts;   //!< 実行結果
+  ObcTime time;         //!< 実行時刻
+  CMD_CODE code;        //!< 実行コマンドID
+  CCP_CmdRet cmd_ret;   //!< 実行結果
 } CDIS_ExecInfo;
 
 /**

--- a/TlmCmd/command_dispatcher.h
+++ b/TlmCmd/command_dispatcher.h
@@ -5,11 +5,11 @@
 #ifndef COMMAND_DISPATCHER_H_
 #define COMMAND_DISPATCHER_H_
 
-#include "../System/TimeManager/obc_time.h"
+#include "common_cmd_packet_util.h"
 #include "common_cmd_packet.h"
 #include "packet_list.h"
+#include "../System/TimeManager/obc_time.h"
 #include <src_user/TlmCmd/command_definitions.h>
-#include "common_cmd_packet_util.h"
 
 /**
  * @struct CDIS_ExecInfo

--- a/TlmCmd/common_cmd_packet.h
+++ b/TlmCmd/common_cmd_packet.h
@@ -43,8 +43,8 @@ typedef enum
   CCP_EXEC_ILLEGAL_LENGTH,      //!< コマンド実行時のコマンド引数長エラー
   CCP_EXEC_ILLEGAL_PARAMETER,   //!< コマンド実行時のパラメタエラー
   CCP_EXEC_ILLEGAL_CONTEXT,     //!< コマンド実行時のその他のエラー
-  CCP_EXEC_CMD_NOT_DEFINED,     //!< cmdExec で用いる
-  CCP_EXEC_ROUTING_FAILED,      //!< command router で用いる
+  CCP_EXEC_CMD_NOT_DEFINED,     //!< CA_execute_cmd で用いる
+  CCP_EXEC_ROUTING_FAILED,      //!< PH_dispatch_command, PH_user_cmd_router で用いる
   CCP_EXEC_PACKET_FMT_ERR,      //!< packet handler, ccp util で用いる
   CCP_EXEC_UNKNOWN              //!< 内部処理用．使わない．
 } CCP_EXEC_STS;

--- a/TlmCmd/common_cmd_packet_util.c
+++ b/TlmCmd/common_cmd_packet_util.c
@@ -333,21 +333,25 @@ PH_ACK CCP_register_tlc_asap(cycle_t ti, TLCD_ID tlcd_id, CMD_CODE cmd_id, const
 }
 
 
-CCP_EXEC_STS CCP_form_and_exec_rtc(CMD_CODE cmd_id, const uint8_t* param, uint16_t len)
+CCP_CmdRet CCP_form_and_exec_rtc(CMD_CODE cmd_id, const uint8_t* param, uint16_t len)
 {
-  CCP_UTIL_ACK ret;
-  ret = CCP_form_rtc(&CCP_util_packet_, cmd_id, param, len);
-  if (ret != CCP_UTIL_ACK_OK) return CCP_EXEC_PACKET_FMT_ERR;
+  CCP_UTIL_ACK ret = CCP_form_rtc(&CCP_util_packet_, cmd_id, param, len);
+  if (ret != CCP_UTIL_ACK_OK)
+  {
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_PACKET_FMT_ERR);
+  }
 
   return PH_dispatch_command(&CCP_util_packet_);
 }
 
 
-CCP_EXEC_STS CCP_form_and_exec_block_deploy_cmd(TLCD_ID tl_no, bct_id_t block_no)
+CCP_CmdRet CCP_form_and_exec_block_deploy_cmd(TLCD_ID tl_no, bct_id_t block_no)
 {
-  CCP_UTIL_ACK ret;
-  ret = CCP_form_block_deploy_cmd(&CCP_util_packet_, tl_no, block_no);
-  if (ret != CCP_UTIL_ACK_OK) return CCP_EXEC_PACKET_FMT_ERR;
+  CCP_UTIL_ACK ret = CCP_form_block_deploy_cmd(&CCP_util_packet_, tl_no, block_no);
+  if (ret != CCP_UTIL_ACK_OK)
+  {
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_PACKET_FMT_ERR);
+  }
 
   return PH_dispatch_command(&CCP_util_packet_);
 }

--- a/TlmCmd/common_cmd_packet_util.h
+++ b/TlmCmd/common_cmd_packet_util.h
@@ -158,19 +158,19 @@ PH_ACK CCP_register_tlc_asap(cycle_t ti, TLCD_ID tlcd_id, CMD_CODE cmd_id, const
  * @param[in]     cmd_id: CMD_CODE
  * @param[in]     param:  パラメタ
  * @param[in]     len:    パラメタ長
- * @retval CCP_EXEC_PACKET_FMT_ERR: 引数が不正なとき
+ * @retval CCP_CmdRet{CCP_EXEC_PACKET_FMT_ERR, *}: 引数が不正なとき
  * @retval それ以外: PH_dispatch_command の返り値
  */
-CCP_EXEC_STS CCP_form_and_exec_rtc(CMD_CODE cmd_id, const uint8_t* param, uint16_t len);
+CCP_CmdRet CCP_form_and_exec_rtc(CMD_CODE cmd_id, const uint8_t* param, uint16_t len);
 
 /**
  * @brief BC展開 command を生成し，即時実行する
  * @param[in]     tl_no:    Timeline no
  * @param[in]     block_no: BC ID
- * @retval CCP_EXEC_PACKET_FMT_ERR: 引数が不正なとき
+ * @retval CCP_CmdRet{CCP_EXEC_PACKET_FMT_ERR, *}: 引数が不正なとき
  * @retval それ以外: PH_dispatch_command の返り値
  */
-CCP_EXEC_STS CCP_form_and_exec_block_deploy_cmd(TLCD_ID tl_no, bct_id_t block_no);
+CCP_CmdRet CCP_form_and_exec_block_deploy_cmd(TLCD_ID tl_no, bct_id_t block_no);
 
 /**
  * @brief TLCD ID から CCP_EXEC_TYPE を取得する

--- a/TlmCmd/packet_handler.c
+++ b/TlmCmd/packet_handler.c
@@ -219,9 +219,12 @@ PH_ACK PH_analyze_tlm_packet(const CommonTlmPacket* packet)
 }
 
 
-CCP_EXEC_STS PH_dispatch_command(const CommonCmdPacket* packet)
+CCP_CmdRet PH_dispatch_command(const CommonCmdPacket* packet)
 {
-  if (!CCP_is_valid_packet(packet)) return CCP_EXEC_UNKNOWN;    // FIXME: 返り値変えたい
+  if (!CCP_is_valid_packet(packet))
+  {
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_UNKNOWN);    // FIXME: 返り値変えたい
+  }
 
   // FIXME: CTCP, SpacePacket 整理で直す
   if (CCP_get_apid(packet) == CCP_APID_TO_ME)

--- a/TlmCmd/packet_handler.h
+++ b/TlmCmd/packet_handler.h
@@ -102,9 +102,9 @@ PH_ACK PH_analyze_cmd_packet(const CommonCmdPacket* packet);
 /**
  * @brief  CCP をコマンドとして解釈して実行，ないしは別機器へ配送する
  * @param  packet: 実行 or 配送するコマンドパケット
- * @return CCP_EXEC_STS
+ * @return CCP_CmdRet
  */
-CCP_EXEC_STS PH_dispatch_command(const CommonCmdPacket* packet);
+CCP_CmdRet PH_dispatch_command(const CommonCmdPacket* packet);
 
 /**
  * @brief CCP_EXEC_TYPE から PacketList を取得する

--- a/TlmCmd/packet_handler.h
+++ b/TlmCmd/packet_handler.h
@@ -48,7 +48,7 @@ typedef enum
   PH_ACK_TLC_SUCCESS,         //!< TL に登録された
   PH_ACK_TLC_PAST_TIME,       //!< 既に実行時間を過ぎている
   PH_ACK_TLC_ALREADY_EXISTS,  //!< 同 TI に既に packet がいる
-  PH_ACK_BC_SUCCESS,         //!< BC 展開に成功した
+  PH_ACK_BC_SUCCESS,          //!< BC 展開に成功した
   PH_ACK_BC_INVALID_BLOCK_NO, //!< 無効な BC 番号だった
   PH_ACK_BC_ISORATED_CMD,     //!< 飛ばして BC 登録しようとした
   PH_ACK_BC_CMD_TOO_LONG,     //!< CMD が BC には長すぎる


### PR DESCRIPTION
## 概要
Cmd の返り値を CCP_EXEC_STS から CCP_CmdRet に（つづき）

## Issue
- https://github.com/ut-issl/c2a-core/issues/376


## 詳細
- https://github.com/ut-issl/c2a-core/pull/417 の `別 PR でやる部分` 

## 検証結果
- ここでは tlm db の修正までは行わない（コメントアウトしてる）
- したがってテストも通らない
- テストなどは https://github.com/ut-issl/c2a-core/pull/426 で行う