### PR TITLE
SPI_CS_STATE_AFTER_TXの値変更

### DIFF
--- a/IfWrapper/spi.h
+++ b/IfWrapper/spi.h
@@ -32,8 +32,8 @@ typedef enum
  */
 typedef enum
 {
-  SPI_CS_STATE_AFTER_TX_LOW  = 0,   //!< 送信後にCSをLowのままにし、そのまま受信動作などを行う
-  SPI_CS_STATE_AFTER_TX_HIGH = 1    //!< 送信後にCSをHighにする
+  SPI_CS_STATE_AFTER_TX_HIGH = 0,   //!< 送信後にCSをHighにする
+  SPI_CS_STATE_AFTER_TX_LOW  = 1    //!< 送信後にCSをLowのままにし、そのまま受信動作などを行う
 } SPI_CS_STATE_AFTER_TX;
 
 /**


### PR DESCRIPTION
## 概要
SPI_CS_STATE_AFTER_TXの値変更

## Issue
NA
## 詳細
`SPI_CS_STATE_AFTER_TX_LOW`と`SPI_CS_STATE_AFTER_TX_HIGH`を入れ替え、
送信後Highにする動きがデフォルトであることを明確にする

## 検証結果
CIがとおればOK

## 影響範囲
SPI通信を使っている箇所

## 補足
SPI_init()にてSPI_Config.cs_state_after_txを明示的に初期化することを推奨

## 注意
上記初期化を行っておらず、SPI_CS_STATE_AFTER_TXを使った分岐を実装しているuserだと
本改修を取り込むと初期化直後の挙動が変わる可能性がある
