### PR TITLE
EH 対応時の BC 展開時の EL がうるさいことを直す（時間調整時は LOW にした）

### DIFF
--- a/Applications/timeline_command_dispatcher.c
+++ b/Applications/timeline_command_dispatcher.c
@@ -280,7 +280,7 @@ CCP_CmdRet Cmd_TLCD_DEPLOY_BLOCK(const CommonCmdPacket* packet)
                     (uint32_t)ack,
                     EL_ERROR_LEVEL_LOW,
                     (uint32_t)id);
-    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
+    return CCP_make_cmd_ret(CCP_EXEC_ILLEGAL_CONTEXT, (uint32_t)ack);
   }
 
   return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);

--- a/Applications/timeline_command_dispatcher.c
+++ b/Applications/timeline_command_dispatcher.c
@@ -279,7 +279,7 @@ CCP_CmdRet Cmd_TLCD_DEPLOY_BLOCK(const CommonCmdPacket* packet)
     EL_record_event((EL_GROUP)EL_CORE_GROUP_TLCD_DEPLOY_BLOCK,
                     (uint32_t)ack,
                     EL_ERROR_LEVEL_LOW,
-                    (uint32_t)id);
+                    (uint32_t)( ((0x000000ff & id) << 24) | (0x00ffffff & block_no) );
     return CCP_make_cmd_ret(CCP_EXEC_ILLEGAL_CONTEXT, (uint32_t)ack);
   }
 

--- a/Applications/timeline_command_dispatcher.c
+++ b/Applications/timeline_command_dispatcher.c
@@ -279,7 +279,7 @@ CCP_CmdRet Cmd_TLCD_DEPLOY_BLOCK(const CommonCmdPacket* packet)
     EL_record_event((EL_GROUP)EL_CORE_GROUP_TLCD_DEPLOY_BLOCK,
                     (uint32_t)ack,
                     EL_ERROR_LEVEL_LOW,
-                    (uint32_t)( ((0x000000ff & id) << 24) | (0x00ffffff & block_no) );
+                    (uint32_t)( ((0x000000ff & id) << 24) | (0x00ffffff & block_no) ));
     return CCP_make_cmd_ret(CCP_EXEC_ILLEGAL_CONTEXT, (uint32_t)ack);
   }
 


### PR DESCRIPTION
## 概要
EH 対応時の BC 展開時の EL がうるさいことを直す（時間調整時は LOW にした）

## Issue
- https://github.com/ut-issl/c2a-core/issues/389

## 詳細
- BC 展開が時間調整でワーニングになった場合は， エラーレベルを HIGH ではなく LOW にした

## 検証結果
minimum uer の test が全て通った
