### PR TITLE
DriverSuper のバッファサイズを可変にする 

### DIFF
--- a/Drivers/Super/driver_super.c
+++ b/Drivers/Super/driver_super.c
@@ -1706,6 +1706,16 @@ void DSSC_set_data_analyzer(DS_StreamConfig* p_stream_config,
   p_stream_config->internal.is_validation_needed_for_rec_ = 1;
 }
 
+void DSSC_set_rx_buffer(DS_StreamConfig* p_stream_config,
+                        uint8_t* rx_frame_buffer,
+                        const uint16_t rx_frame_buffer_size,
+                        uint8_t* rx_carry_over_buffer,
+                        const uint16_t rx_carry_over_buffer_size)
+{
+  DSSC_set_rx_frame_buffer(p_stream_config, rx_frame_buffer, rx_frame_buffer_size);
+  DSSC_set_rx_carry_over_buffer(p_stream_config, rx_carry_over_buffer, rx_carry_over_buffer_size);
+}
+
 
 // ###### DS_StreamConfig Getter/Setter of Info ######
 const DS_StreamSendStatus* DSSC_get_send_status(const DS_StreamConfig* p_stream_config)

--- a/Drivers/Super/driver_super.c
+++ b/Drivers/Super/driver_super.c
@@ -610,7 +610,7 @@ static void DS_analyze_rx_buffer_(DriverSuper* p_super,
 {
   // 解析用受信バッファ
   // 巨大なデータなので，staticで予め確保しておき，実行時のスタック枯渇を避ける
-  static uint8_t rx_buffer[DS_RX_BUFFER_SIZE_MAX * 2];
+  static uint8_t rx_buffer[DS_RX_PROCESSING_BUFFER_SIZE];
   DS_StreamConfig* p_stream_config = &(p_super->stream_config[stream]);
   uint16_t total_processed_data_len;
 

--- a/Drivers/Super/driver_super.c
+++ b/Drivers/Super/driver_super.c
@@ -297,6 +297,9 @@ DS_ERR_CODE DS_validate_config(DriverSuper* p_super)
   if (p_super->interface < 0 || p_super->interface >= IF_LIST_MAX) return DS_ERR_CODE_ERR;
   if (p_super->if_config == NULL) return DS_ERR_CODE_ERR;
 
+  if (p_super->config.settings.rx_buffer_ == NULL) return DS_ERR_CODE_ERR;
+  if (p_super->config.settings.rx_buffer_size_ == 0) return DS_ERR_CODE_ERR;
+
   for (stream = 0; stream < DS_STREAM_MAX; ++stream)
   {
     DS_ERR_CODE ret = DS_validate_stream_config_(p_super, &p_super->stream_config[stream]);
@@ -1418,6 +1421,10 @@ static DS_ERR_CODE DS_validate_stream_config_(const DriverSuper* p_super, DS_Str
   }
 
   // バッファ
+  if (p_stream_config->settings.rx_frame_buffer_ == NULL) return DS_ERR_CODE_ERR;
+  if (p_stream_config->settings.rx_frame_buffer_size_ == 0) return DS_ERR_CODE_ERR;
+  if (p_stream_config->settings.rx_carry_over_buffer_ == NULL) return DS_ERR_CODE_ERR;
+  if (p_stream_config->settings.rx_carry_over_buffer_size_ == 0) return DS_ERR_CODE_ERR;
   if (p_stream_config->settings.rx_carry_over_buffer_size_ < p_stream_config->settings.rx_frame_buffer_size_) return DS_ERR_CODE_ERR;
   if (p_super->config.settings.rx_buffer_size_ + p_stream_config->settings.rx_carry_over_buffer_size_ > DS_RX_PROCESSING_BUFFER_SIZE)
   {

--- a/Drivers/Super/driver_super.c
+++ b/Drivers/Super/driver_super.c
@@ -679,6 +679,8 @@ static uint16_t DS_analyze_rx_buffer_pickup_(DS_StreamConfig* p_stream_config,
                           uint16_t rec_data_len);
   p_stream_config->internal.rx_frame_head_pos_of_frame_candidate_ = 0;
 
+  if (p_stream_config->settings.rx_frame_size_ == 0) return 0;
+
   // TODO: ビッグデータ対応
   if (p_stream_config->settings.rx_frame_size_ > 0 && p_stream_config->settings.rx_frame_size_ < DS_RX_FRAME_SIZE_MAX)
   {
@@ -690,7 +692,7 @@ static uint16_t DS_analyze_rx_buffer_pickup_(DS_StreamConfig* p_stream_config,
     pickup_func = NULL;
     return rec_data_len;
   }
-  else if (p_stream_config->settings.rx_frame_size_ < 0 && p_stream_config->settings.rx_frame_size_ < DS_RX_FRAME_SIZE_MAX)
+  else if (p_stream_config->settings.rx_frame_size_ < 0)
   {
     // フレームにフレーム長データが含まれているか？
     if (p_stream_config->settings.rx_framelength_pos_ >= 0)

--- a/Drivers/Super/driver_super.h
+++ b/Drivers/Super/driver_super.h
@@ -39,10 +39,6 @@
                                                        uint8_t を想定          */
 #define DS_RX_PROCESSING_BUFFER_SIZE  (1024 * 2)  //!< DS 内での処理のためのバッファサイズ．@note 参照
 
-// FIXME: 消す
-#define DS_RX_BUFFER_SIZE_MAX  (1024)      //!< 受信データバッファの最大長
-#define DS_RX_FRAME_SIZE_MAX   (1024)      //!< 受信データフレームの最大長
-
 #include <src_user/Settings/DriverSuper/driver_super_params.h>
 
 typedef struct DriverSuper DriverSuper;

--- a/Drivers/Super/driver_super.h
+++ b/Drivers/Super/driver_super.h
@@ -6,6 +6,26 @@
  *         各制御センサ・アクチュエータ等とのインターフェースを実現し，
  *         初期化，コマンド発行，テレメトリリクエスト，テレメトリ受信，テレメトリ解析などを行う，ドライバ群のスーパークラスです．
  *         個々の機器のインターフェースドライバに継承させて使用します．
+ * @note   バッファのサイズ設定について
+ *         rx_buffer_size:
+ *           - IF_RX から受信できる最大数を規定する
+ *           - OBC の物理的な信号ラインのバッファサイズと同サイズにしておくともっともパフォーマンスが出る
+ *           - Driver ごとに定義
+ *         rx_frame_buffer_size:
+ *           - 受信フレームバッファサイズ
+ *           - 受信フレームはこのサイズよりも小さくないといけない（TODO: 将来的にこの制約を無くす可能性はある）
+ *           - Driver Stream ごとに定義
+ *         rx_frame_carry_over_buffer_size:
+ *           - フレーム確定中に次のフレームが受信された時などの繰越用バッファ
+ *           - rx_frame_buffer_size 以上を要求
+ *           - 大きければ大きいほど，バースト的なテレメ受信への耐性が大きくなる
+ *           - このサイズが溢れた時，このバッファは一旦全てクリアされる（バッファが詰まってるため，古いものが削除される）
+ *           - Driver Stream ごとに定義
+ *         DS_RX_PROCESSING_BUFFER_SIZE:
+ *           - 様々なバッファをハンドリングするための一次メモリ
+ *           - すべての Driver Stream で以下を満たす必要がある
+ *             - rx_buffer_size + rx_frame_carry_over_buffer_size < DS_RX_PROCESSING_BUFFER_SIZE
+ *           - C2A 全体で 1 つ定義
  */
 #ifndef DRIVER_SUPER_H_
 #define DRIVER_SUPER_H_
@@ -15,10 +35,9 @@
 #include "../../Library/endian.h"        // パスが不定な自動生成コード類で使えるように
 #include "../../System/TimeManager/time_manager.h"
 
-#define DS_STREAM_MAX          (3)         /*!< DS_StreamConfigの最大数
-                                                uint8_t を想定          */
-#define DS_RX_BUFFER_SIZE_MAX  (1024)      //!< 受信データバッファの最大長
-#define DS_RX_FRAME_SIZE_MAX   (1024)      //!< 受信データフレームの最大長
+#define DS_STREAM_MAX                 (3)         /*!< DS_StreamConfigの最大数
+                                                       uint8_t を想定          */
+#define DS_RX_PROCESSING_BUFFER_SIZE  (1024 * 2)  //!< DS 内での処理のためのバッファサイズ．@note 参照
 
 #include <src_user/Settings/DriverSuper/driver_super_params.h>
 

--- a/Drivers/Super/driver_super.h
+++ b/Drivers/Super/driver_super.h
@@ -300,6 +300,12 @@ struct DS_StreamConfig
                                                                    未指定の場合は負数とする
                                                                    初期値: -1 */
 
+    uint8_t* rx_frame_buffer_;                                /*!< データ受信フレームバッファ
+                                                                   driver_super.h の @note 参照
+                                                                   初期値: NULL */
+    uint16_t rx_frame_buffer_size_;                           /*!< データ受信フレームバッファサイズ
+                                                                   driver_super.h の @note 参照
+                                                                   初期値: 0 */
     const uint8_t* rx_header_;                                /*!< 受信データのヘッダ
                                                                    初期値: NULL */
     uint16_t rx_header_size_;                                 /*!< 受信データのヘッダサイズ
@@ -369,10 +375,6 @@ struct DS_StreamConfig
     ObcTime  general_cmd_tx_time_;                            //!< 通常コマンド最終送信時刻
     ObcTime  req_tlm_cmd_tx_time_;                            //!< テレメ要求コマンド最終送信時刻
     ObcTime  rx_frame_fix_time_;                              //!< フレーム確定時刻
-
-    uint8_t  rx_frame_[DS_RX_FRAME_SIZE_MAX];                 /*!< データ受信フレームバッファ
-                                                                   DS_RX_FRAME_SIZE_MAX を超えるような巨大なフレーム（ビッグデータ）には未対応（将来実装予定）
-                                                                   対応させる場合，この配列変数を外部の大きな配列のポインタに上書きする必要がある． */
 
     DS_ERR_CODE ret_from_data_analyzer_;                      //!< data_analyzer_ の返り値
   } info;           //!< 取得値（メトリクス）
@@ -558,6 +560,10 @@ void DSSC_set_tx_frame_buffer_size(DS_StreamConfig* p_stream_config,
                                    const int16_t tx_frame_buffer_size);
 int16_t DSSC_get_tx_frame_buffer_size(DS_StreamConfig* p_stream_config);
 
+void DSSC_set_rx_frame_buffer(DS_StreamConfig* p_stream_config,
+                              uint8_t* rx_frame_buffer,
+                              const uint16_t rx_frame_buffer_size);
+const uint8_t* DSSC_get_rx_frame(const DS_StreamConfig* p_stream_config);
 void DSSC_set_rx_header(DS_StreamConfig* p_stream_config,
                         const uint8_t* rx_header,
                         const uint16_t rx_header_size);
@@ -601,8 +607,6 @@ uint32_t DSSC_get_rx_frame_fix_count(const DS_StreamConfig* p_stream_config);
 const ObcTime* DSSC_get_general_cmd_tx_time(const DS_StreamConfig* p_stream_config);
 const ObcTime* DSSC_get_req_tlm_cmd_tx_time(const DS_StreamConfig* p_stream_config);
 const ObcTime* DSSC_get_rx_frame_fix_time(const DS_StreamConfig* p_stream_config);
-
-const uint8_t* DSSC_get_rx_frame(const DS_StreamConfig* p_stream_config);
 
 DS_STREAM_TLM_DISRUPTION_STATUS_CODE DSSC_get_tlm_disruption_status(const DS_StreamConfig* p_stream_config);
 

--- a/Drivers/Super/driver_super.h
+++ b/Drivers/Super/driver_super.h
@@ -400,8 +400,8 @@ struct DS_StreamConfig
                                                                    再度フレームを探索できるようにするために使う */
 
     uint8_t  is_rx_buffer_carry_over_;                        //!< 繰越する受信データがあるか？
-    uint16_t carry_over_buffer_size_;                         //!< 繰越する受信データのサイズ
-    uint16_t carry_over_buffer_next_pos_;                     //!< 次回探索を始めるバッファ位置（0 起算）
+    uint16_t rx_carry_over_size_;                             //!< 繰越する受信データのサイズ
+    uint16_t rx_carry_over_buffer_next_pos_;                  //!< 次回探索を始めるバッファ位置（0 起算）
   } internal;       //!< 内部処理用
 };
 // TODO: Protocol 用に data_link_layer_ を追加

--- a/Drivers/Super/driver_super.h
+++ b/Drivers/Super/driver_super.h
@@ -605,6 +605,13 @@ void DSSC_set_time_threshold_for_tlm_disruption(DS_StreamConfig* p_stream_config
 void DSSC_set_data_analyzer(DS_StreamConfig* p_stream_config,
                             DS_ERR_CODE (*data_analyzer)(DS_StreamConfig* p_stream_config, void* p_driver));
 
+// DSSC_set_rx_frame_buffer と DSSC_set_rx_carry_over_buffer のセット
+void DSSC_set_rx_buffer(DS_StreamConfig* p_stream_config,
+                        uint8_t* rx_frame_buffer,
+                        const uint16_t rx_frame_buffer_size,
+                        uint8_t* rx_carry_over_buffer,
+                        const uint16_t rx_carry_over_buffer_size);
+
 // ###### DS_StreamConfig Getter/Setter of Info ######
 const DS_StreamSendStatus* DSSC_get_send_status(const DS_StreamConfig* p_stream_config);
 const DS_StreamRecStatus* DSSC_get_rec_status(const DS_StreamConfig* p_stream_config);

--- a/Drivers/Super/driver_super.h
+++ b/Drivers/Super/driver_super.h
@@ -24,7 +24,7 @@
  *         DS_RX_PROCESSING_BUFFER_SIZE:
  *           - 様々なバッファをハンドリングするための一次メモリ
  *           - すべての Driver Stream で以下を満たす必要がある
- *             - rx_buffer_size_ + rx_carry_over_buffer_size_ < DS_RX_PROCESSING_BUFFER_SIZE
+ *             - rx_buffer_size_ + rx_carry_over_buffer_size_ <= DS_RX_PROCESSING_BUFFER_SIZE
  *           - C2A 全体で 1 つ定義
  */
 #ifndef DRIVER_SUPER_H_

--- a/Examples/2nd_obc_user/src/src_user/Drivers/Etc/mobc.c
+++ b/Examples/2nd_obc_user/src/src_user/Drivers/Etc/mobc.c
@@ -55,7 +55,7 @@ static DS_ERR_CODE MOBC_load_driver_super_init_settings_(DriverSuper* p_super)
 
   p_super->interface = UART;
 
-  DSC_set_rx_buffer(p_super, MOBC_rx_buffer_, DS_RX_BUFFER_SIZE_MAX);
+  DSC_set_rx_buffer(p_super, MOBC_rx_buffer_, DS_RX_BUFFER_SIZE_UART);
 
   // stream は 0 のみ
   p_stream_config = &(p_super->stream_config[MOBC_STREAM_TLM_CMD]);

--- a/Examples/2nd_obc_user/src/src_user/Drivers/Etc/mobc.c
+++ b/Examples/2nd_obc_user/src/src_user/Drivers/Etc/mobc.c
@@ -21,6 +21,7 @@ static uint8_t MOBC_tx_frame_[EB90_FRAME_HEADER_SIZE +
 
 // バッファ
 static uint8_t MOBC_rx_buffer_[DS_RX_BUFFER_SIZE_UART];
+static uint8_t MOBC_rx_frame_buffer_[DS_RX_FRAME_BUFFER_SIZE_DEFAULT];
 
 static DS_ERR_CODE MOBC_load_driver_super_init_settings_(DriverSuper* p_super);
 static DS_ERR_CODE MOBC_analyze_rec_data_(DS_StreamConfig* p_stream_config,
@@ -59,6 +60,7 @@ static DS_ERR_CODE MOBC_load_driver_super_init_settings_(DriverSuper* p_super)
   p_stream_config = &(p_super->stream_config[MOBC_STREAM_TLM_CMD]);
 
   CTCP_init_dssc(p_stream_config, MOBC_tx_frame_, sizeof(MOBC_tx_frame_), MOBC_analyze_rec_data_);
+  DSSC_set_rx_frame_buffer(p_stream_config, MOBC_rx_frame_buffer_, DS_RX_FRAME_BUFFER_SIZE_DEFAULT);
 
   // 定期 TLM の監視機能の有効化しない → ので設定上書きなし
 

--- a/Examples/2nd_obc_user/src/src_user/Drivers/Etc/mobc.c
+++ b/Examples/2nd_obc_user/src/src_user/Drivers/Etc/mobc.c
@@ -22,6 +22,7 @@ static uint8_t MOBC_tx_frame_[EB90_FRAME_HEADER_SIZE +
 // バッファ
 static uint8_t MOBC_rx_buffer_[DS_RX_BUFFER_SIZE_UART];
 static uint8_t MOBC_rx_frame_buffer_[DS_RX_FRAME_BUFFER_SIZE_DEFAULT];
+static uint8_t MOBC_rx_carry_over_buffer_[DS_RX_CARRY_OVER_BUFFER_SIZE_DEFAULT];
 
 static DS_ERR_CODE MOBC_load_driver_super_init_settings_(DriverSuper* p_super);
 static DS_ERR_CODE MOBC_analyze_rec_data_(DS_StreamConfig* p_stream_config,
@@ -60,7 +61,9 @@ static DS_ERR_CODE MOBC_load_driver_super_init_settings_(DriverSuper* p_super)
   p_stream_config = &(p_super->stream_config[MOBC_STREAM_TLM_CMD]);
 
   CTCP_init_dssc(p_stream_config, MOBC_tx_frame_, sizeof(MOBC_tx_frame_), MOBC_analyze_rec_data_);
-  DSSC_set_rx_frame_buffer(p_stream_config, MOBC_rx_frame_buffer_, DS_RX_FRAME_BUFFER_SIZE_DEFAULT);
+  DSSC_set_rx_buffer(p_stream_config,
+                     MOBC_rx_frame_buffer_, DS_RX_FRAME_BUFFER_SIZE_DEFAULT,
+                     MOBC_rx_carry_over_buffer_, DS_RX_CARRY_OVER_BUFFER_SIZE_DEFAULT);
 
   // 定期 TLM の監視機能の有効化しない → ので設定上書きなし
 

--- a/Examples/2nd_obc_user/src/src_user/Drivers/Etc/mobc.c
+++ b/Examples/2nd_obc_user/src/src_user/Drivers/Etc/mobc.c
@@ -11,12 +11,16 @@
 #include <src_core/Drivers/Protocol/eb90_frame_for_driver_super.h>
 #include <src_core/Drivers/Protocol/common_tlm_cmd_packet_for_driver_super.h>
 #include <string.h>
+#include "../../Settings/DriverSuper/driver_buffer_define.h"
 
 #define MOBC_STREAM_TLM_CMD   (0)   //!< テレコマで使うストリーム
 
 static uint8_t MOBC_tx_frame_[EB90_FRAME_HEADER_SIZE +
                               CTCP_MAX_LEN +
                               EB90_FRAME_FOOTER_SIZE];
+
+// バッファ
+static uint8_t MOBC_rx_buffer_[DS_RX_BUFFER_SIZE_UART];
 
 static DS_ERR_CODE MOBC_load_driver_super_init_settings_(DriverSuper* p_super);
 static DS_ERR_CODE MOBC_analyze_rec_data_(DS_StreamConfig* p_stream_config,
@@ -48,6 +52,8 @@ static DS_ERR_CODE MOBC_load_driver_super_init_settings_(DriverSuper* p_super)
   DS_StreamConfig* p_stream_config;
 
   p_super->interface = UART;
+
+  DSC_set_rx_buffer(p_super, MOBC_rx_buffer_, DS_RX_BUFFER_SIZE_MAX);
 
   // stream は 0 のみ
   p_stream_config = &(p_super->stream_config[MOBC_STREAM_TLM_CMD]);

--- a/Examples/2nd_obc_user/src/src_user/Settings/DriverSuper/driver_buffer_define.h
+++ b/Examples/2nd_obc_user/src/src_user/Settings/DriverSuper/driver_buffer_define.h
@@ -5,8 +5,8 @@
 #ifndef DRIVER_BUFFER_DEFINE_H_
 #define DRIVER_BUFFER_DEFINE_H_
 
-#define DS_RX_BUFFER_SIZE_UART                      (1024)    //!< UART ラインの物理バッファサイズ
-#define DS_RX_FRAME_BUFFER_SIZE_DEFAULT             (1024)    //!< rx_frame_buffer_size_ のデフォルト値
-#define DS_RX_FRAME_CARRY_OVER_BUFFER_SIZE_DEFAULT  (1024)    //!< rx_frame_carry_over_buffer_size_ のデフォルト値
+#define DS_RX_BUFFER_SIZE_UART                  (1024)    //!< UART ラインの物理バッファサイズ
+#define DS_RX_FRAME_BUFFER_SIZE_DEFAULT         (1024)    //!< rx_frame_buffer_size_ のデフォルト値
+#define DS_RX_CARRY_OVER_BUFFER_SIZE_DEFAULT    (1024)    //!< rx_frame_carry_over_buffer_size_ のデフォルト値
 
 #endif

--- a/Examples/2nd_obc_user/src/src_user/Settings/DriverSuper/driver_buffer_define.h
+++ b/Examples/2nd_obc_user/src/src_user/Settings/DriverSuper/driver_buffer_define.h
@@ -1,0 +1,12 @@
+/**
+ * @file
+ * @brief  Driver の各種バッファサイズなどの定義
+ */
+#ifndef DRIVER_BUFFER_DEFINE_H_
+#define DRIVER_BUFFER_DEFINE_H_
+
+#define DS_RX_BUFFER_SIZE_UART                      (1024)    //!< UART ラインの物理バッファサイズ
+#define DS_RX_FRAME_BUFFER_SIZE_DEFAULT             (1024)    //!< rx_frame_buffer_size_ のデフォルト値
+#define DS_RX_FRAME_CARRY_OVER_BUFFER_SIZE_DEFAULT  (1024)    //!< rx_frame_carry_over_buffer_size_ のデフォルト値
+
+#endif

--- a/Examples/2nd_obc_user/sync_with_minimum_user.bat
+++ b/Examples/2nd_obc_user/sync_with_minimum_user.bat
@@ -19,6 +19,7 @@ call :sync_file ".\src\src_user\IfWrapper\Sils\wdt_sils.cpp" "..\minimum_user\sr
 call :sync_file ".\src\src_user\IfWrapper\SilsMockup\README.md" "..\minimum_user\src\src_user\IfWrapper\SilsMockup\README.md"
 call :sync_file ".\src\src_user\IfWrapper\SilsMockup\uart_sils.c" "..\minimum_user\src\src_user\IfWrapper\SilsMockup\uart_sils.c"
 call :sync_file ".\src\src_user\IfWrapper\SilsMockup\wdt_sils.c" "..\minimum_user\src\src_user\IfWrapper\SilsMockup\wdt_sils.c"
+call :sync_file ".\src\src_user\Settings\DriverSuper\driver_buffer_define.h" "..\minimum_user\src\src_user\Settings\DriverSuper\driver_buffer_define.h"
 call :sync_file ".\src\src_user\Settings\TlmCmd\common_cmd_packet_define.c" "..\minimum_user\src\src_user\Settings\TlmCmd\common_cmd_packet_define.c"
 call :sync_file ".\src\src_user\Settings\TlmCmd\common_tlm_cmd_packet_define.h" "..\minimum_user\src\src_user\Settings\TlmCmd\common_tlm_cmd_packet_define.h"
 call :sync_file ".\src\src_user\TlmCmd\block_command_user_settings.c" "..\minimum_user\src\src_user\TlmCmd\block_command_user_settings.c"

--- a/Examples/minimum_user/src/src_user/Drivers/Aocs/aobc.c
+++ b/Examples/minimum_user/src/src_user/Drivers/Aocs/aobc.c
@@ -23,6 +23,7 @@ static uint8_t AOBC_tx_frame_[EB90_FRAME_HEADER_SIZE +
 // バッファ
 static uint8_t AOBC_rx_buffer_[DS_RX_BUFFER_SIZE_UART];
 static uint8_t AOBC_rx_frame_buffer_[DS_RX_FRAME_BUFFER_SIZE_DEFAULT];
+static uint8_t AOBC_rx_carry_over_buffer_[DS_RX_CARRY_OVER_BUFFER_SIZE_DEFAULT];
 
 static DS_ERR_CODE AOBC_load_driver_super_init_settings_(DriverSuper* p_super);
 static DS_ERR_CODE AOBC_analyze_rec_data_(DS_StreamConfig* p_stream_config,
@@ -61,7 +62,9 @@ static DS_ERR_CODE AOBC_load_driver_super_init_settings_(DriverSuper* p_super)
   p_stream_config = &(p_super->stream_config[AOBC_STREAM_TLM_CMD]);
 
   CTCP_init_dssc(p_stream_config, AOBC_tx_frame_, sizeof(AOBC_tx_frame_), AOBC_analyze_rec_data_);
-  DSSC_set_rx_frame_buffer(p_stream_config, AOBC_rx_frame_buffer_, DS_RX_FRAME_BUFFER_SIZE_DEFAULT);
+  DSSC_set_rx_buffer(p_stream_config,
+                     AOBC_rx_frame_buffer_, DS_RX_FRAME_BUFFER_SIZE_DEFAULT,
+                     AOBC_rx_carry_over_buffer_, DS_RX_CARRY_OVER_BUFFER_SIZE_DEFAULT);
 
   // 定期 TLM の監視機能の有効化しない → ので設定上書きなし
 

--- a/Examples/minimum_user/src/src_user/Drivers/Aocs/aobc.c
+++ b/Examples/minimum_user/src/src_user/Drivers/Aocs/aobc.c
@@ -22,6 +22,7 @@ static uint8_t AOBC_tx_frame_[EB90_FRAME_HEADER_SIZE +
 
 // バッファ
 static uint8_t AOBC_rx_buffer_[DS_RX_BUFFER_SIZE_UART];
+static uint8_t AOBC_rx_frame_buffer_[DS_RX_FRAME_BUFFER_SIZE_DEFAULT];
 
 static DS_ERR_CODE AOBC_load_driver_super_init_settings_(DriverSuper* p_super);
 static DS_ERR_CODE AOBC_analyze_rec_data_(DS_StreamConfig* p_stream_config,
@@ -60,6 +61,7 @@ static DS_ERR_CODE AOBC_load_driver_super_init_settings_(DriverSuper* p_super)
   p_stream_config = &(p_super->stream_config[AOBC_STREAM_TLM_CMD]);
 
   CTCP_init_dssc(p_stream_config, AOBC_tx_frame_, sizeof(AOBC_tx_frame_), AOBC_analyze_rec_data_);
+  DSSC_set_rx_frame_buffer(p_stream_config, AOBC_rx_frame_buffer_, DS_RX_FRAME_BUFFER_SIZE_DEFAULT);
 
   // 定期 TLM の監視機能の有効化しない → ので設定上書きなし
 

--- a/Examples/minimum_user/src/src_user/Drivers/Aocs/aobc.c
+++ b/Examples/minimum_user/src/src_user/Drivers/Aocs/aobc.c
@@ -56,7 +56,7 @@ static DS_ERR_CODE AOBC_load_driver_super_init_settings_(DriverSuper* p_super)
 
   p_super->interface = UART;
 
-  DSC_set_rx_buffer(p_super, AOBC_rx_buffer_, DS_RX_BUFFER_SIZE_MAX);
+  DSC_set_rx_buffer(p_super, AOBC_rx_buffer_, DS_RX_BUFFER_SIZE_UART);
 
   // stream は 0 のみ
   p_stream_config = &(p_super->stream_config[AOBC_STREAM_TLM_CMD]);

--- a/Examples/minimum_user/src/src_user/Drivers/Aocs/aobc.c
+++ b/Examples/minimum_user/src/src_user/Drivers/Aocs/aobc.c
@@ -12,17 +12,20 @@
 #include <src_core/Drivers/Protocol/eb90_frame_for_driver_super.h>
 #include <src_core/Drivers/Protocol/common_tlm_cmd_packet_for_driver_super.h>
 #include <string.h>
+#include "../../Settings/DriverSuper/driver_buffer_define.h"
 
 #define AOBC_STREAM_TLM_CMD   (0)   //!< テレコマで使うストリーム
-
-static DS_ERR_CODE AOBC_load_driver_super_init_settings_(DriverSuper* p_super);
-static DS_ERR_CODE AOBC_analyze_rec_data_(DS_StreamConfig* p_stream_config,
-                                          void* p_driver);
 
 static uint8_t AOBC_tx_frame_[EB90_FRAME_HEADER_SIZE +
                               CTCP_MAX_LEN +
                               EB90_FRAME_FOOTER_SIZE];
 
+// バッファ
+static uint8_t AOBC_rx_buffer_[DS_RX_BUFFER_SIZE_UART];
+
+static DS_ERR_CODE AOBC_load_driver_super_init_settings_(DriverSuper* p_super);
+static DS_ERR_CODE AOBC_analyze_rec_data_(DS_StreamConfig* p_stream_config,
+                                          void* p_driver);
 
 DS_INIT_ERR_CODE AOBC_init(AOBC_Driver* aobc_driver, uint8_t ch)
 {
@@ -50,6 +53,8 @@ static DS_ERR_CODE AOBC_load_driver_super_init_settings_(DriverSuper* p_super)
   DS_StreamConfig* p_stream_config;
 
   p_super->interface = UART;
+
+  DSC_set_rx_buffer(p_super, AOBC_rx_buffer_, DS_RX_BUFFER_SIZE_MAX);
 
   // stream は 0 のみ
   p_stream_config = &(p_super->stream_config[AOBC_STREAM_TLM_CMD]);

--- a/Examples/minimum_user/src/src_user/Drivers/Com/gs.c
+++ b/Examples/minimum_user/src/src_user/Drivers/Com/gs.c
@@ -141,7 +141,7 @@ static void GS_load_default_driver_super_init_settings_(DriverSuper* p_super)
   DS_StreamConfig* p_stream_config;
   int stream;
 
-  DSC_set_rx_buffer(p_super, GS_rx_buffer_, DS_RX_BUFFER_SIZE_MAX);
+  DSC_set_rx_buffer(p_super, GS_rx_buffer_, DS_RX_BUFFER_SIZE_UART);
 
   for (stream = 0; stream < GS_RX_HEADER_NUM; ++stream)
   {

--- a/Examples/minimum_user/src/src_user/Drivers/Com/gs.c
+++ b/Examples/minimum_user/src/src_user/Drivers/Com/gs.c
@@ -31,6 +31,7 @@ static uint8_t GS_tx_frame_[VCDU_LEN];
 
 // バッファ
 static uint8_t GS_rx_buffer_[DS_RX_BUFFER_SIZE_UART];
+static uint8_t GS_rx_frame_buffer_[GS_RX_HEADER_NUM][DS_RX_FRAME_BUFFER_SIZE_DEFAULT];
 
 /**
  * @brief CCSDS 側 Driver の DS 上での初期化設定
@@ -156,6 +157,8 @@ static void GS_load_default_driver_super_init_settings_(DriverSuper* p_super)
     DSSC_set_rx_framelength_type_size(p_stream_config, GS_RX_FRAMELENGTH_TYPE_SIZE);
     DSSC_set_rx_framelength_offset(p_stream_config, 1); // TCTF の framelength は 0 起算
     DSSC_set_data_analyzer(p_stream_config, GS_analyze_rec_data_);
+
+    DSSC_set_rx_frame_buffer(p_stream_config, GS_rx_frame_buffer_[stream], DS_RX_FRAME_BUFFER_SIZE_DEFAULT);
   }
 }
 

--- a/Examples/minimum_user/src/src_user/Drivers/Com/gs.c
+++ b/Examples/minimum_user/src/src_user/Drivers/Com/gs.c
@@ -32,6 +32,7 @@ static uint8_t GS_tx_frame_[VCDU_LEN];
 // バッファ
 static uint8_t GS_rx_buffer_[DS_RX_BUFFER_SIZE_UART];
 static uint8_t GS_rx_frame_buffer_[GS_RX_HEADER_NUM][DS_RX_FRAME_BUFFER_SIZE_DEFAULT];
+static uint8_t GS_rx_carry_over_buffer_[GS_RX_HEADER_NUM][DS_RX_CARRY_OVER_BUFFER_SIZE_DEFAULT];
 
 /**
  * @brief CCSDS 側 Driver の DS 上での初期化設定
@@ -158,7 +159,9 @@ static void GS_load_default_driver_super_init_settings_(DriverSuper* p_super)
     DSSC_set_rx_framelength_offset(p_stream_config, 1); // TCTF の framelength は 0 起算
     DSSC_set_data_analyzer(p_stream_config, GS_analyze_rec_data_);
 
-    DSSC_set_rx_frame_buffer(p_stream_config, GS_rx_frame_buffer_[stream], DS_RX_FRAME_BUFFER_SIZE_DEFAULT);
+    DSSC_set_rx_buffer(p_stream_config,
+                       GS_rx_frame_buffer_[stream], DS_RX_FRAME_BUFFER_SIZE_DEFAULT,
+                       GS_rx_carry_over_buffer_[stream], DS_RX_CARRY_OVER_BUFFER_SIZE_DEFAULT);
   }
 }
 

--- a/Examples/minimum_user/src/src_user/Drivers/Com/gs.c
+++ b/Examples/minimum_user/src/src_user/Drivers/Com/gs.c
@@ -13,6 +13,7 @@
 #include <src_core/TlmCmd/packet_handler.h>
 #include <src_core/TlmCmd/Ccsds/space_packet_typedef.h>
 #include "../../Library/stdint.h"
+#include "../../Settings/DriverSuper/driver_buffer_define.h"
 
 #define GS_RX_HEADER_SIZE (2)
 #define GS_RX_FRAMELENGTH_TYPE_SIZE (2)
@@ -27,6 +28,9 @@
 // それぞれ AD, BD, BC
 static uint8_t GS_rx_header_[GS_RX_HEADER_NUM][GS_RX_HEADER_SIZE];
 static uint8_t GS_tx_frame_[VCDU_LEN];
+
+// バッファ
+static uint8_t GS_rx_buffer_[DS_RX_BUFFER_SIZE_UART];
 
 /**
  * @brief CCSDS 側 Driver の DS 上での初期化設定
@@ -134,6 +138,8 @@ static void GS_load_default_driver_super_init_settings_(DriverSuper* p_super)
 {
   DS_StreamConfig* p_stream_config;
   int stream;
+
+  DSC_set_rx_buffer(p_super, GS_rx_buffer_, DS_RX_BUFFER_SIZE_MAX);
 
   for (stream = 0; stream < GS_RX_HEADER_NUM; ++stream)
   {

--- a/Examples/minimum_user/src/src_user/Drivers/Etc/uart_test.c
+++ b/Examples/minimum_user/src/src_user/Drivers/Etc/uart_test.c
@@ -10,12 +10,12 @@
 #include "../../Settings/sils_define.h"
 #include "string.h"   // for memcpy
 #include <stdio.h>    // SILSでのprint
-
+#include "../../Settings/DriverSuper/driver_buffer_define.h"
 
 // ヘッダーフッター
-#define UART_TEST_HEADER_SIZE        8
-#define UART_TEST_FOOTER_SIZE        2
-#define UART_TEST_TX_FRAME_SIZE_MAX  16
+#define UART_TEST_HEADER_SIZE        (8)
+#define UART_TEST_FOOTER_SIZE        (2)
+#define UART_TEST_TX_FRAME_SIZE_MAX  (16)
 
 
 static const uint8_t UART_TEST_header_[UART_TEST_HEADER_SIZE] = {0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xA6, 0xA7};
@@ -24,12 +24,13 @@ static const uint8_t UART_TEST_footer_[UART_TEST_FOOTER_SIZE] = {0xBF, 0xBE};
 #define UART_TEST_STREAM_FIX   (0)   //!< 固定長
 #define UART_TEST_STREAM_VAR   (1)   //!< 可変長
 
+static uint8_t UART_TEST_tx_frame_[UART_TEST_TX_FRAME_SIZE_MAX];
+
+// バッファ
+static uint8_t UART_TEST_rx_buffer_[DS_RX_BUFFER_SIZE_UART];
 
 static DS_ERR_CODE UART_TEST_load_driver_super_init_settings_(DriverSuper* p_super);
 static DS_ERR_CODE UART_TEST_analyze_rec_data_(DS_StreamConfig* p_stream_config, void* p_driver);
-
-static uint8_t UART_TEST_tx_frame_[UART_TEST_TX_FRAME_SIZE_MAX];
-
 
 
 DS_INIT_ERR_CODE UART_TEST_init(UART_TEST_Driver* uart_test_instance, unsigned char ch)
@@ -53,6 +54,8 @@ static DS_ERR_CODE UART_TEST_load_driver_super_init_settings_(DriverSuper* p_sup
   DS_StreamConfig* p_stream_config;
 
   p_super->interface = UART;
+
+    DSC_set_rx_buffer(p_super, UART_TEST_rx_buffer_, DS_RX_BUFFER_SIZE_MAX);
 
   // stream0の設定
   p_stream_config = &(p_super->stream_config[UART_TEST_STREAM_FIX]);

--- a/Examples/minimum_user/src/src_user/Drivers/Etc/uart_test.c
+++ b/Examples/minimum_user/src/src_user/Drivers/Etc/uart_test.c
@@ -30,6 +30,8 @@ static uint8_t UART_TEST_tx_frame_[UART_TEST_TX_FRAME_SIZE_MAX];
 static uint8_t UART_TEST_rx_buffer_[DS_RX_BUFFER_SIZE_UART];
 static uint8_t UART_TEST_rx_frame_buffer0_[DS_RX_FRAME_BUFFER_SIZE_DEFAULT];
 static uint8_t UART_TEST_rx_frame_buffer1_[DS_RX_FRAME_BUFFER_SIZE_DEFAULT];
+static uint8_t UART_TEST_rx_carry_over_buffer0_[DS_RX_CARRY_OVER_BUFFER_SIZE_DEFAULT];
+static uint8_t UART_TEST_rx_carry_over_buffer1_[DS_RX_CARRY_OVER_BUFFER_SIZE_DEFAULT];
 
 static DS_ERR_CODE UART_TEST_load_driver_super_init_settings_(DriverSuper* p_super);
 static DS_ERR_CODE UART_TEST_analyze_rec_data_(DS_StreamConfig* p_stream_config, void* p_driver);
@@ -74,7 +76,9 @@ static DS_ERR_CODE UART_TEST_load_driver_super_init_settings_(DriverSuper* p_sup
   DSSC_set_rx_frame_size(p_stream_config, 12);
   DSSC_set_data_analyzer(p_stream_config, UART_TEST_analyze_rec_data_);
 
-  DSSC_set_rx_frame_buffer(p_stream_config, UART_TEST_rx_frame_buffer0_, DS_RX_FRAME_BUFFER_SIZE_DEFAULT);
+  DSSC_set_rx_buffer(p_stream_config,
+                     UART_TEST_rx_frame_buffer0_, DS_RX_FRAME_BUFFER_SIZE_DEFAULT,
+                     UART_TEST_rx_carry_over_buffer0_, DS_RX_CARRY_OVER_BUFFER_SIZE_DEFAULT);
 
   // stream1の設定
   p_stream_config = &(p_super->stream_config[UART_TEST_STREAM_VAR]);
@@ -92,7 +96,9 @@ static DS_ERR_CODE UART_TEST_load_driver_super_init_settings_(DriverSuper* p_sup
   DSSC_set_rx_framelength_offset(p_stream_config, UART_TEST_HEADER_SIZE + UART_TEST_FOOTER_SIZE);
   DSSC_set_data_analyzer(p_stream_config, UART_TEST_analyze_rec_data_);
 
-  DSSC_set_rx_frame_buffer(p_stream_config, UART_TEST_rx_frame_buffer1_, DS_RX_FRAME_BUFFER_SIZE_DEFAULT);
+  DSSC_set_rx_buffer(p_stream_config,
+                     UART_TEST_rx_frame_buffer1_, DS_RX_FRAME_BUFFER_SIZE_DEFAULT,
+                     UART_TEST_rx_carry_over_buffer1_, DS_RX_CARRY_OVER_BUFFER_SIZE_DEFAULT);
 
   // 定期TLMの監視機能の有効化しない → ので設定上書きなし
 

--- a/Examples/minimum_user/src/src_user/Drivers/Etc/uart_test.c
+++ b/Examples/minimum_user/src/src_user/Drivers/Etc/uart_test.c
@@ -59,7 +59,7 @@ static DS_ERR_CODE UART_TEST_load_driver_super_init_settings_(DriverSuper* p_sup
 
   p_super->interface = UART;
 
-    DSC_set_rx_buffer(p_super, UART_TEST_rx_buffer_, DS_RX_BUFFER_SIZE_MAX);
+  DSC_set_rx_buffer(p_super, UART_TEST_rx_buffer_, DS_RX_BUFFER_SIZE_UART);
 
   // stream0の設定
   p_stream_config = &(p_super->stream_config[UART_TEST_STREAM_FIX]);

--- a/Examples/minimum_user/src/src_user/Drivers/Etc/uart_test.c
+++ b/Examples/minimum_user/src/src_user/Drivers/Etc/uart_test.c
@@ -28,6 +28,8 @@ static uint8_t UART_TEST_tx_frame_[UART_TEST_TX_FRAME_SIZE_MAX];
 
 // バッファ
 static uint8_t UART_TEST_rx_buffer_[DS_RX_BUFFER_SIZE_UART];
+static uint8_t UART_TEST_rx_frame_buffer0_[DS_RX_FRAME_BUFFER_SIZE_DEFAULT];
+static uint8_t UART_TEST_rx_frame_buffer1_[DS_RX_FRAME_BUFFER_SIZE_DEFAULT];
 
 static DS_ERR_CODE UART_TEST_load_driver_super_init_settings_(DriverSuper* p_super);
 static DS_ERR_CODE UART_TEST_analyze_rec_data_(DS_StreamConfig* p_stream_config, void* p_driver);
@@ -72,6 +74,7 @@ static DS_ERR_CODE UART_TEST_load_driver_super_init_settings_(DriverSuper* p_sup
   DSSC_set_rx_frame_size(p_stream_config, 12);
   DSSC_set_data_analyzer(p_stream_config, UART_TEST_analyze_rec_data_);
 
+  DSSC_set_rx_frame_buffer(p_stream_config, UART_TEST_rx_frame_buffer0_, DS_RX_FRAME_BUFFER_SIZE_DEFAULT);
 
   // stream1の設定
   p_stream_config = &(p_super->stream_config[UART_TEST_STREAM_VAR]);
@@ -88,6 +91,8 @@ static DS_ERR_CODE UART_TEST_load_driver_super_init_settings_(DriverSuper* p_sup
   DSSC_set_rx_framelength_type_size(p_stream_config, 2);
   DSSC_set_rx_framelength_offset(p_stream_config, UART_TEST_HEADER_SIZE + UART_TEST_FOOTER_SIZE);
   DSSC_set_data_analyzer(p_stream_config, UART_TEST_analyze_rec_data_);
+
+  DSSC_set_rx_frame_buffer(p_stream_config, UART_TEST_rx_frame_buffer1_, DS_RX_FRAME_BUFFER_SIZE_DEFAULT);
 
   // 定期TLMの監視機能の有効化しない → ので設定上書きなし
 

--- a/Examples/minimum_user/src/src_user/Settings/DriverSuper/driver_buffer_define.h
+++ b/Examples/minimum_user/src/src_user/Settings/DriverSuper/driver_buffer_define.h
@@ -5,8 +5,8 @@
 #ifndef DRIVER_BUFFER_DEFINE_H_
 #define DRIVER_BUFFER_DEFINE_H_
 
-#define DS_RX_BUFFER_SIZE_UART                      (1024)    //!< UART ラインの物理バッファサイズ
-#define DS_RX_FRAME_BUFFER_SIZE_DEFAULT             (1024)    //!< rx_frame_buffer_size_ のデフォルト値
-#define DS_RX_FRAME_CARRY_OVER_BUFFER_SIZE_DEFAULT  (1024)    //!< rx_frame_carry_over_buffer_size_ のデフォルト値
+#define DS_RX_BUFFER_SIZE_UART                  (1024)    //!< UART ラインの物理バッファサイズ
+#define DS_RX_FRAME_BUFFER_SIZE_DEFAULT         (1024)    //!< rx_frame_buffer_size_ のデフォルト値
+#define DS_RX_CARRY_OVER_BUFFER_SIZE_DEFAULT    (1024)    //!< rx_frame_carry_over_buffer_size_ のデフォルト値
 
 #endif

--- a/Examples/minimum_user/src/src_user/Settings/DriverSuper/driver_buffer_define.h
+++ b/Examples/minimum_user/src/src_user/Settings/DriverSuper/driver_buffer_define.h
@@ -1,0 +1,12 @@
+/**
+ * @file
+ * @brief  Driver の各種バッファサイズなどの定義
+ */
+#ifndef DRIVER_BUFFER_DEFINE_H_
+#define DRIVER_BUFFER_DEFINE_H_
+
+#define DS_RX_BUFFER_SIZE_UART                      (1024)    //!< UART ラインの物理バッファサイズ
+#define DS_RX_FRAME_BUFFER_SIZE_DEFAULT             (1024)    //!< rx_frame_buffer_size_ のデフォルト値
+#define DS_RX_FRAME_CARRY_OVER_BUFFER_SIZE_DEFAULT  (1024)    //!< rx_frame_carry_over_buffer_size_ のデフォルト値
+
+#endif

--- a/Examples/minimum_user/src/src_user/Settings/DriverSuper/driver_super_params.h
+++ b/Examples/minimum_user/src/src_user/Settings/DriverSuper/driver_super_params.h
@@ -6,11 +6,9 @@
 #define DRIVER_SUPER_PARAMS_H_
 
 #undef DS_STREAM_MAX
-#undef DS_RX_BUFFER_SIZE_MAX
-#undef DS_RX_FRAME_SIZE_MAX
+#undef DS_RX_PROCESSING_BUFFER_SIZE
 
-#define DS_STREAM_MAX          (3)
-#define DS_RX_BUFFER_SIZE_MAX  (1024)
-#define DS_RX_FRAME_SIZE_MAX   (1024)
+#define DS_STREAM_MAX                 (3)
+#define DS_RX_PROCESSING_BUFFER_SIZE  (1024 * 2)
 
 #endif


### PR DESCRIPTION
## 概要
DriverSuper のバッファサイズを可変にする 

## Issue
- https://github.com/ut-issl/c2a-core/issues/443

## 詳細
- DS のバッファサイズを可変にして，メモリ使用量をへらす．
- ここでは，全Driverで共通値だったフレームサイズの制限をなくすことが主眼
- その後のパフォーマンス改善や整理は https://github.com/ut-issl/c2a-core/issues/449 で

## 検証結果
すべてのテストが通った

## 影響範囲
これからは，Driverが自身でbufferを準備し，DSに食わせないとだめ

## その他
- 深く関わるので，user側の core update は https://github.com/ut-issl/c2a-core/pull/453 と一緒にやると良い