### PR TITLE
MOBC経由でのパケット配送時に，2nd OBC での Cmd 実行種別のバグを修正

### DIFF
--- a/Docs/Core/communication.md
+++ b/Docs/Core/communication.md
@@ -148,7 +148,7 @@ https://github.com/ut-issl/c2a-core/blob/b84c3d051a1e15ab62c8f1a9744957daa4a62a3
 - コマンドの最終的な配送先，つまり実行されるボードは APID によって規定される
     - https://github.com/ut-issl/c2a-core/blob/5d7a9d9b878cf5ddcad4de919e77dcae13df7407/Examples/minimum_user_for_s2e/src/src_user/Settings/TlmCmd/Ccsds/apid_define.h#L9-L13
 - 一方で， BC や TLC などでのキューイングは， Destination Type によって決定される
-    - https://github.com/ut-issl/c2a-core/blob/5d7a9d9b878cf5ddcad4de919e77dcae13df7407/Examples/minimum_user_for_s2e/src/src_user/Settings/TlmCmd/common_cmd_packet_define.h#L19-L25
+    - https://github.com/ut-issl/c2a-core/blob/6d71249dcdb3aefa1d67ffe8ce946e8d8d8b2a33/Examples/minimum_user/src/src_user/Settings/TlmCmd/common_cmd_packet_define.h#L20-L27
 - 具体例（GS と接続される OBC は MOBC とし，AOBC は MOBC にぶら下がってるものとする）
     - APID: MOBC, Destination Type: TO_ME or MOBC
         - GSC: GS から MOBC に届き， MOBC で GSC としてエンキューされる．デキューした後， MOBC 内で GSC として実行される．

--- a/Docs/Core/communication.md
+++ b/Docs/Core/communication.md
@@ -149,19 +149,19 @@ https://github.com/ut-issl/c2a-core/blob/b84c3d051a1e15ab62c8f1a9744957daa4a62a3
     - https://github.com/ut-issl/c2a-core/blob/5d7a9d9b878cf5ddcad4de919e77dcae13df7407/Examples/minimum_user_for_s2e/src/src_user/Settings/TlmCmd/Ccsds/apid_define.h#L9-L13
 - 一方で， BC や TLC などでのキューイングは， Destination Type によって決定される
     - https://github.com/ut-issl/c2a-core/blob/5d7a9d9b878cf5ddcad4de919e77dcae13df7407/Examples/minimum_user_for_s2e/src/src_user/Settings/TlmCmd/common_cmd_packet_define.h#L19-L25
-- 具体例
-    - APID: MOBC, Destination Type: TO_ME
+- 具体例（GS と接続される OBC は MOBC とし，AOBC は MOBC にぶら下がってるものとする）
+    - APID: MOBC, Destination Type: TO_ME or MOBC
         - GSC: GS から MOBC に届き， MOBC で GSC としてエンキューされる．デキューした後， MOBC 内で GSC として実行される．
         - TLC: GS から MOBC に届き， MOBC で TLC としてエンキューされる．デキューした後， MOBC 内で RTC として実行される．
         - BC: GS から MOBC に届き， MOBC で BC 登録される．BC 展開した後， TL にエンキューされ，デキューした後， MOBC 内で RTC として実行される．
-    - APID: AOBC, Destination Type: TO_ME
-        - GSC: GS から MOBC に届き， MOBC で GSC としてエンキューされる．デキューした後， APID を元に， AOBC へ配送される．配送時， Destination Type は自分宛に上書きされ， AOBC で GSC としてキューイング & 実行される．
-        - TLC: GS から MOBC に届き， MOBC で TLC としてエンキューされる．デキューした後， APID を元に， AOBC へ配送される．配送時， Destination Type は自分宛に上書きされ， AOBC で RTC としてキューイング & 実行される．
-        - BC: GS から MOBC に届き， MOBC で BC 登録される．BC 展開した後， TL にエンキューされ，デキューした後， APID を元に， AOBC へ配送される．配送時， Destination Type は自分宛に上書きされ， AOBC で RTC としてキューイング & 実行される．
+    - APID: AOBC, Destination Type: TO_ME or MOBC
+        - GSC: GS から MOBC に届き， MOBC で GSC としてエンキューされる．デキューした後， APID を元に， AOBC へ配送される．配送時， Destination Type は自分宛 (TO_ME) に上書きされ， AOBC で RTC としてキューイング & 実行される．
+        - TLC: GS から MOBC に届き， MOBC で TLC としてエンキューされる．デキューした後， APID を元に， AOBC へ配送される．配送時， Destination Type は自分宛 (TO_ME) に上書きされ， AOBC で RTC としてキューイング & 実行される．
+        - BC: GS から MOBC に届き， MOBC で BC 登録される．BC 展開した後， TL にエンキューされ，デキューした後， APID を元に， AOBC へ配送される．配送時， Destination Type は自分宛 (TO_ME) に上書きされ， AOBC で RTC としてキューイング & 実行される．
     - APID: AOBC, Destination Type: AOBC
-        - GSC: GS から MOBC に届き， MOBC でエンキューされずに，そのまま AOBC へ配送される．配送時， Destination Type は自分宛に上書きされ， AOBC で RTC としてキューイング & 実行される．
-        - TLC: GS から MOBC に届き， MOBC でエンキューされずに，そのまま AOBC へ配送される．配送時， Destination Type は自分宛に上書きされ， AOBC で TLC としてキューイング & 実行される．
-        - BC: GS から MOBC に届き， MOBC で BC 登録されずに，そのまま AOBC へ配送される．配送時， Destination Type は自分宛に上書きされ， AOBC で BC として登録 & 実行される．
+        - GSC: GS から MOBC に届き， MOBC でエンキューされずに，そのまま AOBC へ配送される．配送時， Destination Type は自分宛 (TO_ME) に上書きされ， AOBC で GSC としてキューイング & 実行される．
+        - TLC: GS から MOBC に届き， MOBC でエンキューされずに，そのまま AOBC へ配送される．配送時， Destination Type は自分宛 (TO_ME) に上書きされ， AOBC で TLC としてキューイング & 実行される．
+        - BC: GS から MOBC に届き， MOBC で BC 登録されずに，そのまま AOBC へ配送される．配送時， Destination Type は自分宛 (TO_ME) に上書きされ， AOBC で BC として登録 & 実行される．
 - 地上局 SW での実装まとめ
     - MOBC 宛
         - APID: APID_MOBC_CMD

--- a/Examples/2nd_obc_user/src/src_user/Settings/TlmCmd/common_cmd_packet_define.h
+++ b/Examples/2nd_obc_user/src/src_user/Settings/TlmCmd/common_cmd_packet_define.h
@@ -22,6 +22,7 @@ typedef CmdSpacePacket CommonCmdPacket;
  * @brief  コマンドの解釈の宛先を規定
  * @note   TO_ME: 自分自身 → 自分自身の TLC や BC として解釈．コマンド実行時に必要に応じて別 OBC へ配送 （この定義は C2A Core で使うため，どんな C2A でも必須）
  * @note   TO_*:  転送先の TL や BC として解釈 （直接指定 OBC へ配送． GS から来たコマンドを自身のキューにいれない）
+ *         なお，自分自身宛だった場合は，キューに入れる
  * @note   4bit を想定
  */
 typedef enum

--- a/Examples/minimum_user/src/src_user/Settings/TlmCmd/common_cmd_packet_define.h
+++ b/Examples/minimum_user/src/src_user/Settings/TlmCmd/common_cmd_packet_define.h
@@ -22,6 +22,7 @@ typedef CmdSpacePacket CommonCmdPacket;
  * @brief  コマンドの解釈の宛先を規定
  * @note   TO_ME: 自分自身 → 自分自身の TLC や BC として解釈．コマンド実行時に必要に応じて別 OBC へ配送 （この定義は C2A Core で使うため，どんな C2A でも必須）
  * @note   TO_*:  転送先の TL や BC として解釈 （直接指定 OBC へ配送． GS から来たコマンドを自身のキューにいれない）
+ *         なお，自分自身宛だった場合は，キューに入れる
  * @note   4bit を想定
  */
 typedef enum

--- a/TlmCmd/packet_handler.c
+++ b/TlmCmd/packet_handler.c
@@ -129,6 +129,13 @@ PH_ACK PH_analyze_cmd_packet(const CommonCmdPacket* packet)
     return ack;
   }
 
+  // ここまで来たら自分宛て
+  // 例えば以下のどちらか
+  //   - CCP_DEST_TYPE_TO_ME
+  //   - CCP_DEST_TYPE_TO_MOBC （自分）
+  // 統一するため上書きする
+  CCP_set_dest_type((CommonCmdPacket*)packet, CCP_DEST_TYPE_TO_ME);   // const_cast
+
   switch (CCP_get_exec_type(packet))
   {
   case CCP_EXEC_TYPE_GS:


### PR DESCRIPTION
## 概要
MOBC経由でのパケット配送時に，2nd OBC での Cmd 実行種別のバグを修正

## Issue
- https://github.com/ut-issl/c2a-core/issues/458

## 詳細
Issue 参照

## 検証結果
既存のテストが全て通った（2nd obc も）
