### PR TITLE
I2C の ヘッダを C89 に対応

### DIFF
--- a/IfWrapper/i2c.h
+++ b/IfWrapper/i2c.h
@@ -43,7 +43,7 @@ typedef enum
   I2C_ALREADY_ERR     = -3,   //!< チャンネルオープン済み
   I2C_FREQUENCY_ERR   = -2,   //!< 周波数異常
   I2C_CH_ERR          = -1,   //!< チャンネル異常 (Port_configに無い)
-  I2C_OK              = 0,    //!< OKは0を踏襲
+  I2C_OK              = 0     //!< OKは0を踏襲
 } I2C_ERR_CODE;
 
 /**


### PR DESCRIPTION
## 概要
I2C の ヘッダを C89 に対応

## Issue
NA


## 検証結果
CI が通れば良し