### PR TITLE
Pre Release (v3.8.0-beta.2): Release ルールの更新と Core の機能更新の累積に伴う update (Driver Super, I2C)

### DIFF
--- a/Docs/General/release.md
+++ b/Docs/General/release.md
@@ -58,6 +58,7 @@
     - release には以下を含める．
         - 非互換となった Tools の新しい バージョン (Release) へのリンク
         - `develop` にマージしたときの PR のリンク
+1. Bug fix や 大きな機能更新などで，本 Release 前に User サイドで最新の Core が必要になった際にも， Pre-release を行うことができる．
 
 
 ## バージョニング

--- a/c2a_core_main.h
+++ b/c2a_core_main.h
@@ -10,6 +10,6 @@ void C2A_core_main(void);
 #define C2A_CORE_VER_MAJOR (3)
 #define C2A_CORE_VER_MINOR (8)
 #define C2A_CORE_VER_PATCH (0)
-#define C2A_CORE_VER_PRE   ("beta.1")
+#define C2A_CORE_VER_PRE   ("beta.2")
 
 #endif


### PR DESCRIPTION
## 概要
Pre Release (v3.8.0-beta.2): Core の機能更新の累積に伴う update (Driver Super, I2C)

なお，**今回の PR に合わせて Release ルールを更新している**．
この更新で，Pre Release の条件が

- Tool 類の非互換が生じた時のみ
 
だったものを，

- Tool 類の非互換が生じた
- Bug fix や 大きな機能更新などで，本 Release 前に User サイドで最新の Core が必要になった（User 側の core update をしやすいように）

の or 条件に変更している．

## 詳細
以下の update などで， user サイドでの早急な取り込みが必要になったことによる pre release

- https://github.com/ut-issl/c2a-core/pull/469
- https://github.com/ut-issl/c2a-core/pull/453

## 検証結果
すべてのテストが通った

## 影響範囲
とくになし
