### PR TITLE
Pre Release (v3.8.0-beta.3): Add simple bsearch, memchr implementation

### DIFF
--- a/Library/CMakeLists.txt
+++ b/Library/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.13)
 
 project(C2A_CORE_LIB)
 
-option(C2A_USE_SIMPLE_LIBC "use C2A-core hosted simple libc implementation" ON)
+option(C2A_USE_SIMPLE_LIBC "use C2A-core hosted simple libc implementation" OFF)
 
 if(C2A_USE_SIMPLE_LIBC)
   message("use simple libc!!!")

--- a/Library/CMakeLists.txt
+++ b/Library/CMakeLists.txt
@@ -2,9 +2,9 @@ cmake_minimum_required(VERSION 3.13)
 
 project(C2A_CORE_LIB)
 
-option(USE_SIMPLE_LIBC "use C2A-core hosted simple libc implementation" ON)
+option(C2A_USE_SIMPLE_LIBC "use C2A-core hosted simple libc implementation" ON)
 
-if(USE_SIMPLE_LIBC)
+if(C2A_USE_SIMPLE_LIBC)
   message("use simple libc!!!")
   set(C2A_LIBC_SRC
     libc/memchr.c

--- a/Library/CMakeLists.txt
+++ b/Library/CMakeLists.txt
@@ -2,12 +2,25 @@ cmake_minimum_required(VERSION 3.13)
 
 project(C2A_CORE_LIB)
 
+option(USE_SIMPLE_LIBC "use C2A-core hosted simple libc implementation" OFF)
+
+if(USE_SIMPLE_LIBC)
+  message("use simple libc!!!")
+  set(C2A_LIBC_SRC
+    libc/memchr.c
+    libc/bsearch.c
+  )
+else()
+  set(C2A_LIBC_SRC "")
+endif()
+
 set(C2A_SRCS
   ascii_conv.c
   c2a_round.c
   crc.c
   endian.c
   majority_vote_for3.c
+  ${C2A_LIBC_SRC}
 )
 
 if(BUILD_C2A_AS_CXX)

--- a/Library/CMakeLists.txt
+++ b/Library/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.13)
 
 project(C2A_CORE_LIB)
 
-option(USE_SIMPLE_LIBC "use C2A-core hosted simple libc implementation" OFF)
+option(USE_SIMPLE_LIBC "use C2A-core hosted simple libc implementation" ON)
 
 if(USE_SIMPLE_LIBC)
   message("use simple libc!!!")

--- a/Library/libc/bsearch.c
+++ b/Library/libc/bsearch.c
@@ -1,6 +1,11 @@
+/**
+ * @file
+ * @brief C2A が依存するいくつかの libc 関数 bsearch を自前実装し，c2a-core から提供することで，C2A の移植性を高める．
+ *        これにより，ベアメタル環境でも C2A を libc 無しに（newlib などを持ち出してくることなく）ビルド・動作させることができる．
+ * @note  https://github.com/ut-issl/c2a-core/pull/485
+ * @note  https://linuxjm.osdn.jp/html/LDP_man-pages/man3/bsearch.3.html
+ */
 #include <stdlib.h>
-
-// https://linuxjm.osdn.jp/html/LDP_man-pages/man3/bsearch.3.html
 
 // compare func(key, base[i])
 // key < b: compr_func(key, b) < 0

--- a/Library/libc/bsearch.c
+++ b/Library/libc/bsearch.c
@@ -21,7 +21,7 @@ void *bsearch(const void* key, const void* base, size_t nmemb, size_t size, comp
   while (min < max)
   {
     size_t index = (min + max) / 2;
-    void* current = (void*) (base + (size * index));
+    void* current = (void*) ((char*)base + (size * index));
 
     int result = compr(key, current);
     if (result == 0)

--- a/Library/libc/bsearch.c
+++ b/Library/libc/bsearch.c
@@ -6,21 +6,22 @@
 // key < b: compr_func(key, b) < 0
 // key = b: compr_func(key, b) = 0
 // key > b: compr_func(key, b) > 0
-typedef int (* compr_func)(const void *, const void *);
+typedef int (*compr_func)(const void*, const void*);
 
-void *bsearch(const void *key, const void *base, size_t nmemb, size_t size, compr_func compr)
+void *bsearch(const void* key, const void* base, size_t nmemb, size_t size, compr_func compr)
 {
   size_t min = 0;
   size_t max = nmemb;
 
-  if (nmemb == 0 || size == 0){
+  if (nmemb == 0 || size == 0)
+  {
     return NULL;
   }
 
-  while(min < max)
+  while (min < max)
   {
     size_t index = (min + max) / 2;
-    void *current = (void*) (base + (size * index));
+    void* current = (void*) (base + (size * index));
 
     int result = compr(key, current);
     if (result == 0)

--- a/Library/libc/bsearch.c
+++ b/Library/libc/bsearch.c
@@ -1,6 +1,6 @@
 /**
  * @file
- * @brief C2A が依存するいくつかの libc 関数 bsearch を自前実装し，c2a-core から提供することで，C2A の移植性を高める．
+ * @brief C2A が依存する libc 関数 bsearch を自前実装し，c2a-core から提供することで，C2A の移植性を高める．
  *        これにより，ベアメタル環境でも C2A を libc 無しに（newlib などを持ち出してくることなく）ビルド・動作させることができる．
  * @note  https://github.com/ut-issl/c2a-core/pull/485
  * @note  https://linuxjm.osdn.jp/html/LDP_man-pages/man3/bsearch.3.html

--- a/Library/libc/bsearch.c
+++ b/Library/libc/bsearch.c
@@ -1,0 +1,45 @@
+#include <stdlib.h>
+
+// https://linuxjm.osdn.jp/html/LDP_man-pages/man3/bsearch.3.html
+
+// compare func(key, base[i])
+// key < b: compr_func(key, b) < 0
+// key = b: compr_func(key, b) = 0
+// key > b: compr_func(key, b) > 0
+typedef int (* compr_func)(const void *, const void *);
+
+void *bsearch(const void *key, const void *base, size_t nmemb, size_t size, compr_func compr)
+{
+  size_t min = 0;
+  size_t max = nmemb;
+
+  if (nmemb == 0 || size == 0){
+    return NULL;
+  }
+
+  while(min < max)
+  {
+    size_t index = (min + max) / 2;
+    void *current = (void*) (base + (size * index));
+
+    int result = compr(key, current);
+    if (result == 0)
+    {
+      // found
+      return current;
+    }
+    else if (result < 0)
+    {
+      // key < current
+      max = index - 1;
+    }
+    else // result > 0
+    {
+      // current < key
+      min = index + 1;
+    }
+  }
+
+  // not found
+  return NULL;
+}

--- a/Library/libc/bsearch.c
+++ b/Library/libc/bsearch.c
@@ -32,7 +32,7 @@ void *bsearch(const void* key, const void* base, size_t nmemb, size_t size, comp
     else if (result < 0)
     {
       // key < current
-      max = index - 1;
+      max = index;
     }
     else // result > 0
     {

--- a/Library/libc/memchr.c
+++ b/Library/libc/memchr.c
@@ -1,6 +1,11 @@
+/**
+ * @file
+ * @brief C2A が依存するいくつかの libc 関数 memchr を自前実装し，c2a-core から提供することで，C2A の移植性を高める．
+ *        これにより，ベアメタル環境でも C2A を libc 無しに（newlib などを持ち出してくることなく）ビルド・動作させることができる．
+ * @note  https://github.com/ut-issl/c2a-core/pull/485
+ * @note  https://linuxjm.osdn.jp/html/LDP_man-pages/man3/memchr.3.html
+ */
 #include <string.h>
-
-// https://linuxjm.osdn.jp/html/LDP_man-pages/man3/memchr.3.html
 
 void* memchr(const void* buf, int c, size_t n)
 {

--- a/Library/libc/memchr.c
+++ b/Library/libc/memchr.c
@@ -2,7 +2,7 @@
 
 // https://linuxjm.osdn.jp/html/LDP_man-pages/man3/memchr.3.html
 
-void* memchr(const void *buf, int c, size_t n)
+void* memchr(const void* buf, int c, size_t n)
 {
   const unsigned char* s = (const unsigned char*) buf;
 

--- a/Library/libc/memchr.c
+++ b/Library/libc/memchr.c
@@ -1,0 +1,19 @@
+#include <string.h>
+
+// https://linuxjm.osdn.jp/html/LDP_man-pages/man3/memchr.3.html
+
+void *memchr(const void *buf, int c, size_t n)
+{
+  const unsigned char *s = (const unsigned char*) buf;
+
+  while (n--)
+  {
+    if (*s == (unsigned char)c)
+    {
+      return (void*)s;
+    }
+    s++;
+  }
+
+  return NULL;
+}

--- a/Library/libc/memchr.c
+++ b/Library/libc/memchr.c
@@ -1,6 +1,6 @@
 /**
  * @file
- * @brief C2A が依存するいくつかの libc 関数 memchr を自前実装し，c2a-core から提供することで，C2A の移植性を高める．
+ * @brief C2A が依存する libc 関数 memchr を自前実装し，c2a-core から提供することで，C2A の移植性を高める．
  *        これにより，ベアメタル環境でも C2A を libc 無しに（newlib などを持ち出してくることなく）ビルド・動作させることができる．
  * @note  https://github.com/ut-issl/c2a-core/pull/485
  * @note  https://linuxjm.osdn.jp/html/LDP_man-pages/man3/memchr.3.html

--- a/Library/libc/memchr.c
+++ b/Library/libc/memchr.c
@@ -2,9 +2,9 @@
 
 // https://linuxjm.osdn.jp/html/LDP_man-pages/man3/memchr.3.html
 
-void *memchr(const void *buf, int c, size_t n)
+void* memchr(const void *buf, int c, size_t n)
 {
-  const unsigned char *s = (const unsigned char*) buf;
+  const unsigned char* s = (const unsigned char*) buf;
 
   while (n--)
   {

--- a/c2a_core_main.h
+++ b/c2a_core_main.h
@@ -10,6 +10,6 @@ void C2A_core_main(void);
 #define C2A_CORE_VER_MAJOR (3)
 #define C2A_CORE_VER_MINOR (8)
 #define C2A_CORE_VER_PATCH (0)
-#define C2A_CORE_VER_PRE   ("beta.2")
+#define C2A_CORE_VER_PRE   ("beta.3")
 
 #endif


### PR DESCRIPTION
## 概要
- Library に `libc` ディレクトリを追加し，`bsearch()`, `memchr` を提供する
- これらの関数を使うための CMake option `USE_SIMPLE_LIBC` を追加する（デフォルトOFF）

## Issue
- 関連する issue

## 詳細
C2A が依存するいくつかの libc 関数を自前実装し，c2a-core から提供することで，C2A の移植性を高める．
これにより，ベアメタル環境でも C2A を libc 無しに（newlib などを持ち出してくることなく）ビルド・動作させることができる．

## 備考
本 core を使いたい user があるため，pre release を打つ
