### PR TITLE
I2Cのread/write関数追加

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ set(C2A_SRCS
   Drivers/Protocol/eb90_frame_for_driver_super.c
   Drivers/Protocol/eb90_packet_for_driver_super.c
   Drivers/Super/driver_super.c
+  IfWrapper/Common/i2c_common.c
   # System/AnomalyLogger/anomaly_logger.c    # deprecated. 使いたい場合は， user 側でビルドターゲットに入れる．
   System/ApplicationManager/app_info.c
   System/ApplicationManager/app_manager.c

--- a/Examples/2nd_obc_user/src/src_user/IfWrapper/CMakeLists.txt
+++ b/Examples/2nd_obc_user/src/src_user/IfWrapper/CMakeLists.txt
@@ -12,12 +12,14 @@ if(USE_SILS_MOCKUP)
 
   #target_sources(${PROJECT_NAME} PRIVATE
   list(APPEND C2A_SRCS
+    SilsMockup/i2c_sils.c
     SilsMockup/uart_sils.c
     SilsMockup/wdt_sils.c
   )
 else()
   #target_sources(${PROJECT_NAME} PUBLIC
   list(APPEND C2A_SRCS
+    Sils/i2c_sils.cpp  
     Sils/uart_sils.cpp
     Sils/wdt_sils.cpp
   )

--- a/Examples/2nd_obc_user/src/src_user/IfWrapper/Sils/i2c_sils.cpp
+++ b/Examples/2nd_obc_user/src/src_user/IfWrapper/Sils/i2c_sils.cpp
@@ -1,0 +1,47 @@
+#pragma section REPRO
+#include <src_core/IfWrapper/i2c.h>
+
+int I2C_init(void* my_i2c_v)
+{
+  (void)my_i2c_v;
+  return 0;
+}
+
+int I2C_rx(void* my_i2c_v, void* data_v, int buffer_size)
+{
+  (void*)my_i2c_v;
+  (void*)data_v;
+  (void)buffer_size;
+  return 0;
+}
+
+int I2C_tx(void* my_i2c_v, void* data_v, int data_size)
+{
+  (void*)my_i2c_v;
+  (void*)data_v;
+  (void)data_size;
+  return 0;
+}
+
+int I2C_reopen(void* my_i2c_v, int reason)
+{
+  (void*)my_i2c_v;
+  (void)reason;
+  return 0;
+}
+
+void I2C_set_stop_flag(void* my_i2c_v, const unsigned char stop_flag)
+{
+  (void*)my_i2c_v;
+  (void)stop_flag;
+  return;
+}
+
+void I2C_set_rx_length(void* my_i2c_v, const uint32_t rx_length)
+{
+  (void*)my_i2c_v;
+  (void)rx_length;
+  return;
+}
+
+#pragma section

--- a/Examples/2nd_obc_user/src/src_user/IfWrapper/SilsMockup/i2c_sils.c
+++ b/Examples/2nd_obc_user/src/src_user/IfWrapper/SilsMockup/i2c_sils.c
@@ -1,0 +1,47 @@
+#pragma section REPRO
+#include <src_core/IfWrapper/i2c.h>
+
+int I2C_init(void* my_i2c_v)
+{
+  (void)my_i2c_v;
+  return 0;
+}
+
+int I2C_rx(void* my_i2c_v, void* data_v, int buffer_size)
+{
+  (void)my_i2c_v;
+  (void)data_v;
+  (void)buffer_size;
+  return 0;
+}
+
+int I2C_tx(void* my_i2c_v, void* data_v, int data_size)
+{
+  (void)my_i2c_v;
+  (void)data_v;
+  (void)data_size;
+  return 0;
+}
+
+int I2C_reopen(void* my_i2c_v, int reason)
+{
+  (void)my_i2c_v;
+  (void)reason;
+  return 0;
+}
+
+void I2C_set_stop_flag(void* my_i2c_v, const unsigned char stop_flag)
+{
+  (void)my_i2c_v;
+  (void)stop_flag;
+  return;
+}
+
+void I2C_set_rx_length(void* my_i2c_v, const uint32_t rx_length)
+{
+  (void)my_i2c_v;
+  (void)rx_length;
+  return;
+}
+
+#pragma section

--- a/Examples/minimum_user/src/src_user/IfWrapper/CMakeLists.txt
+++ b/Examples/minimum_user/src/src_user/IfWrapper/CMakeLists.txt
@@ -13,6 +13,7 @@ if(USE_SILS_MOCKUP)
   #target_sources(${PROJECT_NAME} PRIVATE
   list(APPEND C2A_SRCS
     SilsMockup/ccsds_sils.c
+    SilsMockup/i2c_sils.c
     SilsMockup/uart_sils.c
     SilsMockup/wdt_sils.c
   )
@@ -20,6 +21,7 @@ else()
   #target_sources(${PROJECT_NAME} PUBLIC
   list(APPEND C2A_SRCS
     Sils/ccsds_sils.cpp
+    Sils/i2c_sils.cpp
     Sils/uart_sils.cpp
     Sils/wdt_sils.cpp
   )

--- a/Examples/minimum_user/src/src_user/IfWrapper/Sils/i2c_sils.cpp
+++ b/Examples/minimum_user/src/src_user/IfWrapper/Sils/i2c_sils.cpp
@@ -1,0 +1,47 @@
+#pragma section REPRO
+#include <src_core/IfWrapper/i2c.h>
+
+int I2C_init(void* my_i2c_v)
+{
+  (void)my_i2c_v;
+  return 0;
+}
+
+int I2C_rx(void* my_i2c_v, void* data_v, int buffer_size)
+{
+  (void*)my_i2c_v;
+  (void*)data_v;
+  (void)buffer_size;
+  return 0;
+}
+
+int I2C_tx(void* my_i2c_v, void* data_v, int data_size)
+{
+  (void*)my_i2c_v;
+  (void*)data_v;
+  (void)data_size;
+  return 0;
+}
+
+int I2C_reopen(void* my_i2c_v, int reason)
+{
+  (void*)my_i2c_v;
+  (void)reason;
+  return 0;
+}
+
+void I2C_set_stop_flag(void* my_i2c_v, const unsigned char stop_flag)
+{
+  (void*)my_i2c_v;
+  (void)stop_flag;
+  return;
+}
+
+void I2C_set_rx_length(void* my_i2c_v, const uint32_t rx_length)
+{
+  (void*)my_i2c_v;
+  (void)rx_length;
+  return;
+}
+
+#pragma section

--- a/Examples/minimum_user/src/src_user/IfWrapper/SilsMockup/i2c_sils.c
+++ b/Examples/minimum_user/src/src_user/IfWrapper/SilsMockup/i2c_sils.c
@@ -1,0 +1,47 @@
+#pragma section REPRO
+#include <src_core/IfWrapper/i2c.h>
+
+int I2C_init(void* my_i2c_v)
+{
+  (void)my_i2c_v;
+  return 0;
+}
+
+int I2C_rx(void* my_i2c_v, void* data_v, int buffer_size)
+{
+  (void)my_i2c_v;
+  (void)data_v;
+  (void)buffer_size;
+  return 0;
+}
+
+int I2C_tx(void* my_i2c_v, void* data_v, int data_size)
+{
+  (void)my_i2c_v;
+  (void)data_v;
+  (void)data_size;
+  return 0;
+}
+
+int I2C_reopen(void* my_i2c_v, int reason)
+{
+  (void)my_i2c_v;
+  (void)reason;
+  return 0;
+}
+
+void I2C_set_stop_flag(void* my_i2c_v, const unsigned char stop_flag)
+{
+  (void)my_i2c_v;
+  (void)stop_flag;
+  return;
+}
+
+void I2C_set_rx_length(void* my_i2c_v, const uint32_t rx_length)
+{
+  (void)my_i2c_v;
+  (void)rx_length;
+  return;
+}
+
+#pragma section

--- a/IfWrapper/Common/i2c_common.c
+++ b/IfWrapper/Common/i2c_common.c
@@ -1,0 +1,71 @@
+#pragma section REPRO
+/**
+* @file
+* @brief I2C通信関連の一般 IO 以外の公開関数
+* @note  レジスタの読み書き等，ハードウェアに依存しない関数群を定義する
+*/
+
+#include "../i2c.h"
+#include <string.h>
+
+#define I2C_MAX_TX_BYTE_COUNT (3)
+
+static I2C_ERR_CODE I2C_write_bytes(void* my_i2c_v, uint8_t cmd_byte, void* data_v, uint8_t buffer_size);
+static I2C_ERR_CODE I2C_read_bytes(void* my_i2c_v, uint8_t cmd_byte, void* data_v, uint8_t buffer_size);
+
+I2C_ERR_CODE I2C_write_byte(void* my_i2c_v, uint8_t cmd_byte, void* data_v)
+{
+  return I2C_write_bytes(my_i2c_v, cmd_byte, data_v, 1);
+}
+
+I2C_ERR_CODE I2C_write_2bytes(void* my_i2c_v, uint8_t cmd_byte, void* data_v)
+{
+  return I2C_write_bytes(my_i2c_v, cmd_byte, data_v, 2);
+}
+
+static I2C_ERR_CODE I2C_write_bytes(void* my_i2c_v, uint8_t cmd_byte, void* data_v, uint8_t buffer_size)
+{
+  uint8_t tx_data[I2C_MAX_TX_BYTE_COUNT];
+
+  tx_data[0] = cmd_byte;
+  memcpy(tx_data + sizeof(cmd_byte), data_v, buffer_size);
+  I2C_set_stop_flag(my_i2c_v, 1);
+  return (I2C_ERR_CODE)I2C_tx(my_i2c_v, tx_data, buffer_size);
+}
+
+I2C_ERR_CODE I2C_read_byte(void* my_i2c_v, uint8_t cmd_byte, void* data_v)
+{
+  return I2C_read_bytes(my_i2c_v, cmd_byte, data_v, 1);
+}
+
+I2C_ERR_CODE I2C_read_2bytes(void* my_i2c_v, uint8_t cmd_byte, void* data_v)
+{
+  return I2C_read_bytes(my_i2c_v, cmd_byte, data_v, 2);
+}
+
+static I2C_ERR_CODE I2C_read_bytes(void* my_i2c_v, uint8_t cmd_byte, void* data_v, uint8_t buffer_size)
+{
+  I2C_ERR_CODE ret = I2C_OK;
+  I2C_Config* my_i2c = (I2C_Config*)my_i2c_v;
+
+  // read setting
+  I2C_set_rx_length(my_i2c_v, buffer_size);
+  // send
+  I2C_set_stop_flag(my_i2c_v, 0);
+  ret = (I2C_ERR_CODE)I2C_tx(my_i2c_v, &cmd_byte, sizeof(cmd_byte));
+  if (ret != I2C_OK)
+  {
+    return ret;
+  }
+  // read
+  I2C_set_stop_flag(my_i2c_v, 1);
+  ret = (I2C_ERR_CODE)I2C_rx(my_i2c_v, data_v, buffer_size);
+  if (ret > 0)
+  {
+    ret = I2C_OK;
+  }
+
+  return ret;
+}
+
+#pragma section

--- a/IfWrapper/Common/i2c_common.c
+++ b/IfWrapper/Common/i2c_common.c
@@ -5,69 +5,74 @@
 * @note  レジスタの読み書き等，ハードウェアに依存しない関数群を定義する
 */
 
-#include "../i2c.h"
+#include "i2c_common.h"
+#include "../../Library/endian.h"
 #include <string.h>
-#include <src_core/Library/endian.h>
 
-static I2C_ERR_CODE I2C_write_bytes(void* my_i2c_v, uint8_t cmd_byte, void* data_v, uint8_t buffer_size);
-static I2C_ERR_CODE I2C_read_bytes(void* my_i2c_v, uint8_t cmd_byte, void* data_v, uint8_t buffer_size);
+static DS_ERR_CODE I2C_write_bytes_(DriverSuper* p_super, uint8_t stream, void* my_i2c_v, uint8_t cmd_byte, void* data_v, uint8_t buffer_size);
+static DS_ERR_CODE I2C_read_bytes_(DriverSuper* p_super, uint8_t stream, void* my_i2c_v, uint8_t cmd_byte, void* data_v, uint8_t buffer_size);
 
-I2C_ERR_CODE I2C_write_byte(void* my_i2c_v, uint8_t cmd_byte, uint8_t data)
+DS_ERR_CODE I2C_write_byte(DriverSuper* p_super, uint8_t stream, void* my_i2c_v, uint8_t cmd_byte, uint8_t data)
 {
-  return I2C_write_bytes(my_i2c_v, cmd_byte, &data, sizeof(data));
+  return I2C_write_bytes_(p_super, stream, my_i2c_v, cmd_byte, &data, sizeof(data));
 }
 
-I2C_ERR_CODE I2C_write_2bytes(void* my_i2c_v, uint8_t cmd_byte, uint16_t data)
+DS_ERR_CODE I2C_write_2bytes(DriverSuper* p_super, uint8_t stream, void* my_i2c_v, uint8_t cmd_byte, uint16_t data)
 {
-  return I2C_write_bytes(my_i2c_v, cmd_byte, &data, sizeof(data));
+  return I2C_write_bytes_(p_super, stream, my_i2c_v, cmd_byte, &data, sizeof(data));
 }
 
-static I2C_ERR_CODE I2C_write_bytes(void* my_i2c_v, uint8_t cmd_byte, void* data_v, uint8_t buffer_size)
+static DS_ERR_CODE I2C_write_bytes_(DriverSuper* p_super, uint8_t stream, void* my_i2c_v, uint8_t cmd_byte, void* data_v, uint8_t buffer_size)
 {
   uint8_t tx_data[sizeof(cmd_byte) + sizeof(uint16_t)];
+  DS_StreamConfig* stream_config = &(p_super->stream_config[stream]);
 
   tx_data[0] = cmd_byte;
   ENDIAN_memcpy(tx_data + sizeof(cmd_byte), data_v, buffer_size);
   I2C_set_stop_flag(my_i2c_v, 1);
-  return (I2C_ERR_CODE)I2C_tx(my_i2c_v, tx_data, sizeof(cmd_byte) + buffer_size);
+  DSSC_set_tx_frame(stream_config, tx_data);
+  DSSC_set_tx_frame_size(stream_config, sizeof(cmd_byte) + buffer_size);
+
+  return DS_send_general_cmd(p_super, stream);
 }
 
-I2C_ERR_CODE I2C_read_byte(void* my_i2c_v, uint8_t cmd_byte, uint8_t* data)
+DS_ERR_CODE I2C_read_byte(DriverSuper* p_super, uint8_t stream, void* my_i2c_v, uint8_t cmd_byte, uint8_t* data)
 {
-  return I2C_read_bytes(my_i2c_v, cmd_byte, data, sizeof(uint8_t));
+  return I2C_read_bytes_(p_super, stream, my_i2c_v, cmd_byte, data, sizeof(uint8_t));
 }
 
-I2C_ERR_CODE I2C_read_2bytes(void* my_i2c_v, uint8_t cmd_byte, uint16_t* data)
+DS_ERR_CODE I2C_read_2bytes(DriverSuper* p_super, uint8_t stream, void* my_i2c_v, uint8_t cmd_byte, uint16_t* data)
 {
-  uint8_t rx_data[sizeof(uint16_t)];
-  I2C_ERR_CODE ret = I2C_OK;
-
-  ret = I2C_read_bytes(my_i2c_v, cmd_byte, rx_data, sizeof(uint16_t));
-  ENDIAN_memcpy(data, rx_data, sizeof(uint16_t));
-
-  return ret;
+  return I2C_read_bytes_(p_super, stream, my_i2c_v, cmd_byte, data, sizeof(uint8_t));
 }
 
-static I2C_ERR_CODE I2C_read_bytes(void* my_i2c_v, uint8_t cmd_byte, void* data_v, uint8_t buffer_size)
+static DS_ERR_CODE I2C_read_bytes_(DriverSuper* p_super, uint8_t stream, void* my_i2c_v, uint8_t cmd_byte, void* data_v, uint8_t buffer_size)
 {
-  I2C_ERR_CODE ret = I2C_OK;
+  DS_ERR_CODE ret = DS_ERR_CODE_OK;
+  const uint8_t* rx_data;
+  DS_StreamConfig* stream_config = &(p_super->stream_config[stream]);
 
   // read setting
+  DSSC_set_rx_frame_size(stream_config, buffer_size);
   I2C_set_rx_length(my_i2c_v, buffer_size);
+  DS_clear_rx_buffer(p_super);
   // send
   I2C_set_stop_flag(my_i2c_v, 0);
-  ret = (I2C_ERR_CODE)I2C_tx(my_i2c_v, &cmd_byte, sizeof(cmd_byte));
-  if (ret != I2C_OK)
-  {
-    return ret;
-  }
+  DSSC_set_tx_frame(stream_config, &cmd_byte);
+  DSSC_set_tx_frame_size(stream_config, sizeof(cmd_byte));
+  ret = DS_send_req_tlm_cmd(p_super, stream);
+  if (ret != DS_ERR_CODE_OK) return ret;
   // read
   I2C_set_stop_flag(my_i2c_v, 1);
-  ret = (I2C_ERR_CODE)I2C_rx(my_i2c_v, data_v, buffer_size);
-  if (ret > 0)
+  ret = DS_receive(p_super);
+  if (ret != DS_ERR_CODE_OK) return ret;
+  if (DSSC_get_rec_status(stream_config)->status_code != DS_STREAM_REC_STATUS_FIXED_FRAME)
   {
-    ret = I2C_OK;
+    return DS_ERR_CODE_ERR;
   }
+
+  rx_data = DSSC_get_rx_frame(stream_config);
+  ENDIAN_memcpy(data_v, rx_data, buffer_size);
 
   return ret;
 }

--- a/IfWrapper/Common/i2c_common.c
+++ b/IfWrapper/Common/i2c_common.c
@@ -46,7 +46,6 @@ I2C_ERR_CODE I2C_read_2bytes(void* my_i2c_v, uint8_t cmd_byte, void* data_v)
 static I2C_ERR_CODE I2C_read_bytes(void* my_i2c_v, uint8_t cmd_byte, void* data_v, uint8_t buffer_size)
 {
   I2C_ERR_CODE ret = I2C_OK;
-  I2C_Config* my_i2c = (I2C_Config*)my_i2c_v;
 
   // read setting
   I2C_set_rx_length(my_i2c_v, buffer_size);

--- a/IfWrapper/Common/i2c_common.c
+++ b/IfWrapper/Common/i2c_common.c
@@ -30,7 +30,7 @@ static I2C_ERR_CODE I2C_write_bytes(void* my_i2c_v, uint8_t cmd_byte, void* data
   tx_data[0] = cmd_byte;
   memcpy(tx_data + sizeof(cmd_byte), data_v, buffer_size);
   I2C_set_stop_flag(my_i2c_v, 1);
-  return (I2C_ERR_CODE)I2C_tx(my_i2c_v, tx_data, buffer_size);
+  return (I2C_ERR_CODE)I2C_tx(my_i2c_v, tx_data, sizeof(cmd_byte) + buffer_size);
 }
 
 I2C_ERR_CODE I2C_read_byte(void* my_i2c_v, uint8_t cmd_byte, void* data_v)

--- a/IfWrapper/Common/i2c_common.c
+++ b/IfWrapper/Common/i2c_common.c
@@ -30,7 +30,7 @@ static DS_ERR_CODE I2C_write_bytes_(DriverSuper* p_super, uint8_t stream, I2C_Co
  * @param[in] register_address : 読み込むレジスタのアドレス
  * @param[out] data_v  : データ格納先へのポインタ
  * @param[in] buffer_size : 読み込むデータの長さ．
- * @retval DS_ERR_CODE (DS_send_general_cmd の返り値)
+ * @retval DS_ERR_CODE
  */
 static DS_ERR_CODE I2C_read_bytes_(DriverSuper* p_super, uint8_t stream, I2C_Config* p_i2c_config,
                                    uint8_t register_address, void* data_v, uint8_t buffer_size);

--- a/IfWrapper/Common/i2c_common.c
+++ b/IfWrapper/Common/i2c_common.c
@@ -9,49 +9,70 @@
 #include "../../Library/endian.h"
 #include <string.h>
 
-static DS_ERR_CODE I2C_write_bytes_(DriverSuper* p_super, uint8_t stream, void* my_i2c_v,
-                                    uint8_t register_address, void* data_v, uint8_t buffer_size);
-static DS_ERR_CODE I2C_read_bytes_(DriverSuper* p_super, uint8_t stream, void* my_i2c_v,
+/**
+ * @brief I2C_Config 構造体にて指定されたデバイスのレジスタへ書き込み
+ * @param[in] p_super  : DriverSuper 構造体へのポインタ
+ * @param[in] stream   : 使用する stream_config の番号
+ * @param[in] p_i2c_config : 対象とする I2C_Config 構造体へのポインタ
+ * @param[in] register_address : 書き込むレジスタのアドレス
+ * @param[in] data_v   : 書き込むデータを格納している場所のポインタ
+ * @param[in] data_len : 書き込むデータの長さ．1 or 2 [byte] のみ指定可
+ * @retval DS_ERR_CODE (DS_send_general_cmd の返り値)
+ */
+static DS_ERR_CODE I2C_write_bytes_(DriverSuper* p_super, uint8_t stream, I2C_Config* p_i2c_config,
+                                    uint8_t register_address, void* data_v, uint8_t data_len);
+
+/**
+ * @brief I2C_Config 構造体にて指定されたデバイスのレジスタへ読み込み
+ * @param[in] p_super  : DriverSuper 構造体へのポインタ
+ * @param[in] stream   : 使用する stream_config の番号
+ * @param[in] p_i2c_config : 対象とする I2C_Config 構造体へのポインタ
+ * @param[in] register_address : 読み込むレジスタのアドレス
+ * @param[out] data_v  : データ格納先へのポインタ
+ * @param[in] buffer_size : 読み込むデータの長さ．
+ * @retval DS_ERR_CODE (DS_send_general_cmd の返り値)
+ */
+static DS_ERR_CODE I2C_read_bytes_(DriverSuper* p_super, uint8_t stream, I2C_Config* p_i2c_config,
                                    uint8_t register_address, void* data_v, uint8_t buffer_size);
 
-DS_ERR_CODE I2C_write_byte(DriverSuper* p_super, uint8_t stream, void* my_i2c_v, uint8_t register_address, uint8_t data)
+DS_ERR_CODE I2C_write_byte(DriverSuper* p_super, uint8_t stream, I2C_Config* p_i2c_config, uint8_t register_address, uint8_t data)
 {
-  return I2C_write_bytes_(p_super, stream, my_i2c_v, register_address, &data, sizeof(data));
+  return I2C_write_bytes_(p_super, stream, p_i2c_config, register_address, &data, sizeof(data));
 }
 
-DS_ERR_CODE I2C_write_2bytes(DriverSuper* p_super, uint8_t stream, void* my_i2c_v, uint8_t register_address, uint16_t data)
+DS_ERR_CODE I2C_write_2bytes(DriverSuper* p_super, uint8_t stream, I2C_Config* p_i2c_config, uint8_t register_address, uint16_t data)
 {
-  return I2C_write_bytes_(p_super, stream, my_i2c_v, register_address, &data, sizeof(data));
+  return I2C_write_bytes_(p_super, stream, p_i2c_config, register_address, &data, sizeof(data));
 }
 
-static DS_ERR_CODE I2C_write_bytes_(DriverSuper* p_super, uint8_t stream, void* my_i2c_v,
-                                    uint8_t register_address, void* data_v, uint8_t buffer_size)
+static DS_ERR_CODE I2C_write_bytes_(DriverSuper* p_super, uint8_t stream, I2C_Config* p_i2c_config,
+                                    uint8_t register_address, void* data_v, uint8_t data_len)
 {
   uint8_t tx_data[sizeof(register_address) + sizeof(uint16_t)];
   DS_StreamConfig* stream_config = &(p_super->stream_config[stream]);
 
   tx_data[0] = register_address;
-  ENDIAN_memcpy(tx_data + sizeof(register_address), data_v, buffer_size);
-  I2C_set_stop_flag(my_i2c_v, 1);
+  ENDIAN_memcpy(tx_data + sizeof(register_address), data_v, data_len);
+  I2C_set_stop_flag(p_i2c_config, 1);
   DSSC_set_tx_frame(stream_config, tx_data);
-  DSSC_set_tx_frame_size(stream_config, sizeof(register_address) + buffer_size);
+  DSSC_set_tx_frame_size(stream_config, sizeof(register_address) + data_len);
 
   return DS_send_general_cmd(p_super, stream);
 }
 
-DS_ERR_CODE I2C_read_byte(DriverSuper* p_super, uint8_t stream, void* my_i2c_v,
+DS_ERR_CODE I2C_read_byte(DriverSuper* p_super, uint8_t stream, I2C_Config* p_i2c_config,
                           uint8_t register_address, uint8_t* data)
 {
-  return I2C_read_bytes_(p_super, stream, my_i2c_v, register_address, data, sizeof(uint8_t));
+  return I2C_read_bytes_(p_super, stream, p_i2c_config, register_address, data, sizeof(*data));
 }
 
-DS_ERR_CODE I2C_read_2bytes(DriverSuper* p_super, uint8_t stream, void* my_i2c_v,
+DS_ERR_CODE I2C_read_2bytes(DriverSuper* p_super, uint8_t stream, I2C_Config* p_i2c_config,
                             uint8_t register_address, uint16_t* data)
 {
-  return I2C_read_bytes_(p_super, stream, my_i2c_v, register_address, data, sizeof(uint8_t));
+  return I2C_read_bytes_(p_super, stream, p_i2c_config, register_address, data, sizeof(*data));
 }
 
-static DS_ERR_CODE I2C_read_bytes_(DriverSuper* p_super, uint8_t stream, void* my_i2c_v,
+static DS_ERR_CODE I2C_read_bytes_(DriverSuper* p_super, uint8_t stream, I2C_Config* p_i2c_config,
                                    uint8_t register_address, void* data_v, uint8_t buffer_size)
 {
   DS_ERR_CODE ret = DS_ERR_CODE_OK;
@@ -60,16 +81,16 @@ static DS_ERR_CODE I2C_read_bytes_(DriverSuper* p_super, uint8_t stream, void* m
 
   // read setting
   DSSC_set_rx_frame_size(stream_config, buffer_size);
-  I2C_set_rx_length(my_i2c_v, buffer_size);
+  I2C_set_rx_length(p_i2c_config, buffer_size);
   DS_clear_rx_buffer(p_super);
   // send
-  I2C_set_stop_flag(my_i2c_v, 0);
+  I2C_set_stop_flag(p_i2c_config, 0);
   DSSC_set_tx_frame(stream_config, &register_address);
   DSSC_set_tx_frame_size(stream_config, sizeof(register_address));
   ret = DS_send_req_tlm_cmd(p_super, stream);
   if (ret != DS_ERR_CODE_OK) return ret;
   // read
-  I2C_set_stop_flag(my_i2c_v, 1);
+  I2C_set_stop_flag(p_i2c_config, 1);
   ret = DS_receive(p_super);
   if (ret != DS_ERR_CODE_OK) return ret;
   if (DSSC_get_rec_status(stream_config)->status_code != DS_STREAM_REC_STATUS_FIXED_FRAME)

--- a/IfWrapper/Common/i2c_common.c
+++ b/IfWrapper/Common/i2c_common.c
@@ -10,7 +10,7 @@
 #include <string.h>
 
 /**
- * @brief I2C_Config 構造体にて指定されたデバイスのレジスタへ書き込み
+ * @brief I2C_Config 構造体にて指定されたデバイスのレジスタへ書き込む
  * @param[in] p_super  : DriverSuper 構造体へのポインタ
  * @param[in] stream   : 使用する stream_config の番号
  * @param[in] p_i2c_config : 対象とする I2C_Config 構造体へのポインタ
@@ -23,7 +23,7 @@ static DS_ERR_CODE I2C_write_bytes_(DriverSuper* p_super, uint8_t stream, I2C_Co
                                     uint8_t register_address, void* data_v, uint8_t data_len);
 
 /**
- * @brief I2C_Config 構造体にて指定されたデバイスのレジスタへ読み込み
+ * @brief I2C_Config 構造体にて指定されたデバイスのレジスタへ読み込む
  * @param[in] p_super  : DriverSuper 構造体へのポインタ
  * @param[in] stream   : 使用する stream_config の番号
  * @param[in] p_i2c_config : 対象とする I2C_Config 構造体へのポインタ

--- a/IfWrapper/Common/i2c_common.h
+++ b/IfWrapper/Common/i2c_common.h
@@ -1,0 +1,10 @@
+/**
+ * @file
+ * @brief I2C通信関連の一般IO以外の公開関数
+ * @note レジスタの読み書き等，ハードウェアに依存しない関数群を定義する
+ */
+
+#ifndef I2C_COMMON_H_
+#define I2C_COMMON_H_
+
+#endif

--- a/IfWrapper/Common/i2c_common.h
+++ b/IfWrapper/Common/i2c_common.h
@@ -7,4 +7,51 @@
 #ifndef I2C_COMMON_H_
 #define I2C_COMMON_H_
 
+#include "../i2c.h"
+#include "../../Drivers/Super/driver_super.h"
+
+/**
+ * @brief I2C_Config 構造体にて指定されたchから1バイトデータを書き込みます
+ * @param[in] p_super  : DriverSuper 構造体へのポインタ
+ * @param[in] stream   : 使用する stream_config の番号
+ * @param[in] my_i2c_v : 対象とする I2C_Config 構造体へのポインタ
+ * @param[in] cmd_byte : コマンド
+ * @param[in] data     : 書き込むデータ
+ * @retval DS_ERR_CODE
+ */
+DS_ERR_CODE I2C_write_byte(DriverSuper* p_super, uint8_t stream, void* my_i2c_v, uint8_t cmd_byte, uint8_t data);
+
+/**
+ * @brief I2C_Config 構造体にて指定されたchから2バイトデータを書き込みます
+ * @param[in] p_super  : DriverSuper 構造体へのポインタ
+ * @param[in] stream   : 使用する stream_config の番号
+ * @param[in] my_i2c_v : 対象とする I2C_Config 構造体へのポインタ
+ * @param[in] cmd_byte : コマンド
+ * @param[in] data     : 書き込むデータ
+ * @retval DS_ERR_CODE
+ */
+DS_ERR_CODE I2C_write_2bytes(DriverSuper* p_super, uint8_t stream, void* my_i2c_v, uint8_t cmd_byte, uint16_t data);
+
+/**
+ * @brief I2C_Config 構造体にて指定されたchから1バイトデータを読み込みます
+ * @param[in] p_super  : DriverSuper 構造体へのポインタ
+ * @param[in] stream   : 使用する stream_config の番号
+ * @param[in] my_i2c_v : 対象とする I2C_Config 構造体へのポインタ
+ * @param[in] cmd_byte : コマンド
+ * @param[out] data_v  : データ格納先へのポインタ
+ * @retval DS_ERR_CODE
+ */
+DS_ERR_CODE I2C_read_byte(DriverSuper* p_super, uint8_t stream, void* my_i2c_v, uint8_t cmd_byte, uint8_t* data_v);
+
+/**
+ * @brief I2C_Config 構造体にて指定されたchから2バイトデータを読み込みます
+ * @param[in] p_super  : DriverSuper 構造体へのポインタ
+ * @param[in] stream   : 使用する stream_config の番号
+ * @param[in] my_i2c_v : 対象とする I2C_Config 構造体へのポインタ
+ * @param[in] cmd_byte : コマンド
+ * @param[out] data_v  : データ格納先へのポインタ
+ * @retval DS_ERR_CODE
+ */
+DS_ERR_CODE I2C_read_2bytes(DriverSuper* p_super, uint8_t stream, void* my_i2c_v, uint8_t cmd_byte, uint16_t* data_v);
+
 #endif

--- a/IfWrapper/Common/i2c_common.h
+++ b/IfWrapper/Common/i2c_common.h
@@ -11,7 +11,7 @@
 #include "../i2c.h"
 
 /**
- * @brief I2C_Config 構造体にて指定されたデバイスのレジスタへ 1 バイトデータを書き込みます
+ * @brief I2C_Config 構造体にて指定されたデバイスのレジスタへ 1 バイトデータを書き込む
  * @param[in] p_super  : DriverSuper 構造体へのポインタ
  * @param[in] stream   : 使用する stream_config の番号
  * @param[in] p_i2c_config : 対象とする I2C_Config 構造体へのポインタ
@@ -23,7 +23,7 @@ DS_ERR_CODE I2C_write_byte(DriverSuper* p_super, uint8_t stream, I2C_Config* p_i
                            uint8_t register_address, uint8_t data);
 
 /**
- * @brief I2C_Config 構造体にて指定されたデバイスのレジスタへ 2 バイトデータを書き込みます
+ * @brief I2C_Config 構造体にて指定されたデバイスのレジスタへ 2 バイトデータを書き込む
  * @param[in] p_super  : DriverSuper 構造体へのポインタ
  * @param[in] stream   : 使用する stream_config の番号
  * @param[in] p_i2c_config : 対象とする I2C_Config 構造体へのポインタ
@@ -35,7 +35,7 @@ DS_ERR_CODE I2C_write_2bytes(DriverSuper* p_super, uint8_t stream, I2C_Config* p
                              uint8_t register_address, uint16_t data);
 
 /**
- * @brief I2C_Config 構造体にて指定されたデバイスのレジスタから 1 バイトデータを読み込みます
+ * @brief I2C_Config 構造体にて指定されたデバイスのレジスタから 1 バイトデータを読み込む
  * @param[in] p_super  : DriverSuper 構造体へのポインタ
  * @param[in] stream   : 使用する stream_config の番号
  * @param[in] p_i2c_config : 対象とする I2C_Config 構造体へのポインタ
@@ -47,7 +47,7 @@ DS_ERR_CODE I2C_read_byte(DriverSuper* p_super, uint8_t stream, I2C_Config* p_i2
                           uint8_t register_address, uint8_t* data_v);
 
 /**
- * @brief I2C_Config 構造体にて指定されたデバイスのレジスタから 2 バイトデータを読み込みます
+ * @brief I2C_Config 構造体にて指定されたデバイスのレジスタから 2 バイトデータを読み込む
  * @param[in] p_super  : DriverSuper 構造体へのポインタ
  * @param[in] stream   : 使用する stream_config の番号
  * @param[in] p_i2c_config : 対象とする I2C_Config 構造体へのポインタ

--- a/IfWrapper/Common/i2c_common.h
+++ b/IfWrapper/Common/i2c_common.h
@@ -1,57 +1,61 @@
 /**
  * @file
- * @brief I2C通信関連の一般IO以外の公開関数
+ * @brief I2C 通信関連の一般 IO 以外の公開関数
  * @note レジスタの読み書き等，ハードウェアに依存しない関数群を定義する
  */
 
 #ifndef I2C_COMMON_H_
 #define I2C_COMMON_H_
 
-#include "../i2c.h"
 #include "../../Drivers/Super/driver_super.h"
+#include "../i2c.h"
 
 /**
- * @brief I2C_Config 構造体にて指定されたchから1バイトデータを書き込みます
+ * @brief I2C_Config 構造体にて指定されたデバイスのレジスタへ 1 バイトデータを書き込みます
  * @param[in] p_super  : DriverSuper 構造体へのポインタ
  * @param[in] stream   : 使用する stream_config の番号
  * @param[in] my_i2c_v : 対象とする I2C_Config 構造体へのポインタ
- * @param[in] cmd_byte : コマンド
+ * @param[in] register_address : 書き込むレジスタのアドレス
  * @param[in] data     : 書き込むデータ
  * @retval DS_ERR_CODE
  */
-DS_ERR_CODE I2C_write_byte(DriverSuper* p_super, uint8_t stream, void* my_i2c_v, uint8_t cmd_byte, uint8_t data);
+DS_ERR_CODE I2C_write_byte(DriverSuper* p_super, uint8_t stream, void* my_i2c_v,
+                           uint8_t register_address, uint8_t data);
 
 /**
- * @brief I2C_Config 構造体にて指定されたchから2バイトデータを書き込みます
+ * @brief I2C_Config 構造体にて指定されたデバイスのレジスタへ 2 バイトデータを書き込みます
  * @param[in] p_super  : DriverSuper 構造体へのポインタ
  * @param[in] stream   : 使用する stream_config の番号
  * @param[in] my_i2c_v : 対象とする I2C_Config 構造体へのポインタ
- * @param[in] cmd_byte : コマンド
+ * @param[in] register_address : 書き込むレジスタのアドレス
  * @param[in] data     : 書き込むデータ
  * @retval DS_ERR_CODE
  */
-DS_ERR_CODE I2C_write_2bytes(DriverSuper* p_super, uint8_t stream, void* my_i2c_v, uint8_t cmd_byte, uint16_t data);
+DS_ERR_CODE I2C_write_2bytes(DriverSuper* p_super, uint8_t stream, void* my_i2c_v,
+                             uint8_t register_address, uint16_t data);
 
 /**
- * @brief I2C_Config 構造体にて指定されたchから1バイトデータを読み込みます
+ * @brief I2C_Config 構造体にて指定されたデバイスのレジスタから 1 バイトデータを読み込みます
  * @param[in] p_super  : DriverSuper 構造体へのポインタ
  * @param[in] stream   : 使用する stream_config の番号
  * @param[in] my_i2c_v : 対象とする I2C_Config 構造体へのポインタ
- * @param[in] cmd_byte : コマンド
+ * @param[in] register_address : 読み込むレジスタのアドレス
  * @param[out] data_v  : データ格納先へのポインタ
  * @retval DS_ERR_CODE
  */
-DS_ERR_CODE I2C_read_byte(DriverSuper* p_super, uint8_t stream, void* my_i2c_v, uint8_t cmd_byte, uint8_t* data_v);
+DS_ERR_CODE I2C_read_byte(DriverSuper* p_super, uint8_t stream, void* my_i2c_v,
+                          uint8_t register_address, uint8_t* data_v);
 
 /**
- * @brief I2C_Config 構造体にて指定されたchから2バイトデータを読み込みます
+ * @brief I2C_Config 構造体にて指定されたデバイスのレジスタから 2 バイトデータを読み込みます
  * @param[in] p_super  : DriverSuper 構造体へのポインタ
  * @param[in] stream   : 使用する stream_config の番号
  * @param[in] my_i2c_v : 対象とする I2C_Config 構造体へのポインタ
- * @param[in] cmd_byte : コマンド
+ * @param[in] register_address : 読み込むレジスタのアドレス
  * @param[out] data_v  : データ格納先へのポインタ
  * @retval DS_ERR_CODE
  */
-DS_ERR_CODE I2C_read_2bytes(DriverSuper* p_super, uint8_t stream, void* my_i2c_v, uint8_t cmd_byte, uint16_t* data_v);
+DS_ERR_CODE I2C_read_2bytes(DriverSuper* p_super, uint8_t stream, void* my_i2c_v,
+                            uint8_t register_address, uint16_t* data_v);
 
 #endif

--- a/IfWrapper/Common/i2c_common.h
+++ b/IfWrapper/Common/i2c_common.h
@@ -14,48 +14,48 @@
  * @brief I2C_Config 構造体にて指定されたデバイスのレジスタへ 1 バイトデータを書き込みます
  * @param[in] p_super  : DriverSuper 構造体へのポインタ
  * @param[in] stream   : 使用する stream_config の番号
- * @param[in] my_i2c_v : 対象とする I2C_Config 構造体へのポインタ
+ * @param[in] p_i2c_config : 対象とする I2C_Config 構造体へのポインタ
  * @param[in] register_address : 書き込むレジスタのアドレス
  * @param[in] data     : 書き込むデータ
- * @retval DS_ERR_CODE
+ * @retval DS_ERR_CODE (DS_send_general_cmd の返り値)
  */
-DS_ERR_CODE I2C_write_byte(DriverSuper* p_super, uint8_t stream, void* my_i2c_v,
+DS_ERR_CODE I2C_write_byte(DriverSuper* p_super, uint8_t stream, I2C_Config* p_i2c_config,
                            uint8_t register_address, uint8_t data);
 
 /**
  * @brief I2C_Config 構造体にて指定されたデバイスのレジスタへ 2 バイトデータを書き込みます
  * @param[in] p_super  : DriverSuper 構造体へのポインタ
  * @param[in] stream   : 使用する stream_config の番号
- * @param[in] my_i2c_v : 対象とする I2C_Config 構造体へのポインタ
+ * @param[in] p_i2c_config : 対象とする I2C_Config 構造体へのポインタ
  * @param[in] register_address : 書き込むレジスタのアドレス
  * @param[in] data     : 書き込むデータ
- * @retval DS_ERR_CODE
+ * @retval DS_ERR_CODE (DS_send_general_cmd の返り値)
  */
-DS_ERR_CODE I2C_write_2bytes(DriverSuper* p_super, uint8_t stream, void* my_i2c_v,
+DS_ERR_CODE I2C_write_2bytes(DriverSuper* p_super, uint8_t stream, I2C_Config* p_i2c_config,
                              uint8_t register_address, uint16_t data);
 
 /**
  * @brief I2C_Config 構造体にて指定されたデバイスのレジスタから 1 バイトデータを読み込みます
  * @param[in] p_super  : DriverSuper 構造体へのポインタ
  * @param[in] stream   : 使用する stream_config の番号
- * @param[in] my_i2c_v : 対象とする I2C_Config 構造体へのポインタ
+ * @param[in] p_i2c_config : 対象とする I2C_Config 構造体へのポインタ
  * @param[in] register_address : 読み込むレジスタのアドレス
  * @param[out] data_v  : データ格納先へのポインタ
- * @retval DS_ERR_CODE
+ * @retval DS_ERR_CODE (DS_send_general_cmd の返り値)
  */
-DS_ERR_CODE I2C_read_byte(DriverSuper* p_super, uint8_t stream, void* my_i2c_v,
+DS_ERR_CODE I2C_read_byte(DriverSuper* p_super, uint8_t stream, I2C_Config* p_i2c_config,
                           uint8_t register_address, uint8_t* data_v);
 
 /**
  * @brief I2C_Config 構造体にて指定されたデバイスのレジスタから 2 バイトデータを読み込みます
  * @param[in] p_super  : DriverSuper 構造体へのポインタ
  * @param[in] stream   : 使用する stream_config の番号
- * @param[in] my_i2c_v : 対象とする I2C_Config 構造体へのポインタ
+ * @param[in] p_i2c_config : 対象とする I2C_Config 構造体へのポインタ
  * @param[in] register_address : 読み込むレジスタのアドレス
  * @param[out] data_v  : データ格納先へのポインタ
- * @retval DS_ERR_CODE
+ * @retval DS_ERR_CODE (DS_send_general_cmd の返り値)
  */
-DS_ERR_CODE I2C_read_2bytes(DriverSuper* p_super, uint8_t stream, void* my_i2c_v,
+DS_ERR_CODE I2C_read_2bytes(DriverSuper* p_super, uint8_t stream, I2C_Config* p_i2c_config,
                             uint8_t register_address, uint16_t* data_v);
 
 #endif

--- a/IfWrapper/Common/i2c_common.h
+++ b/IfWrapper/Common/i2c_common.h
@@ -41,7 +41,7 @@ DS_ERR_CODE I2C_write_2bytes(DriverSuper* p_super, uint8_t stream, I2C_Config* p
  * @param[in] p_i2c_config : 対象とする I2C_Config 構造体へのポインタ
  * @param[in] register_address : 読み込むレジスタのアドレス
  * @param[out] data_v  : データ格納先へのポインタ
- * @retval DS_ERR_CODE (DS_send_general_cmd の返り値)
+ * @retval DS_ERR_CODE
  */
 DS_ERR_CODE I2C_read_byte(DriverSuper* p_super, uint8_t stream, I2C_Config* p_i2c_config,
                           uint8_t register_address, uint8_t* data_v);
@@ -53,7 +53,7 @@ DS_ERR_CODE I2C_read_byte(DriverSuper* p_super, uint8_t stream, I2C_Config* p_i2
  * @param[in] p_i2c_config : 対象とする I2C_Config 構造体へのポインタ
  * @param[in] register_address : 読み込むレジスタのアドレス
  * @param[out] data_v  : データ格納先へのポインタ
- * @retval DS_ERR_CODE (DS_send_general_cmd の返り値)
+ * @retval DS_ERR_CODE
  */
 DS_ERR_CODE I2C_read_2bytes(DriverSuper* p_super, uint8_t stream, I2C_Config* p_i2c_config,
                             uint8_t register_address, uint16_t* data_v);

--- a/IfWrapper/i2c.h
+++ b/IfWrapper/i2c.h
@@ -100,38 +100,38 @@ void I2C_set_rx_length(void* my_i2c_v, const uint32_t rx_length);
 
 /**
  * @brief I2C_Config 構造体にて指定されたchから1バイトデータを書き込みます
- * @param[in] my_i2c_v    : 対象とする I2C_Config 構造体へのポインタ
- * @param[in] cmd_byte    : コマンド
- * @param[in] data_v      : 受信データ格納先へのポインタ
+ * @param[in] my_i2c_v : 対象とする I2C_Config 構造体へのポインタ
+ * @param[in] cmd_byte : コマンド
+ * @param[in] data     : 書き込むデータ
  * @retval I2C_ERR_CODE
  */
-I2C_ERR_CODE I2C_write_byte(void* my_i2c_v, uint8_t cmd_byte, void* data_v);
+I2C_ERR_CODE I2C_write_byte(void* my_i2c_v, uint8_t cmd_byte, uint8_t data);
 
 /**
  * @brief I2C_Config 構造体にて指定されたchから2バイトデータを書き込みます
- * @param[in] my_i2c_v    : 対象とする I2C_Config 構造体へのポインタ
- * @param[in] cmd_byte    : コマンド
- * @param[in] data_v      : 受信データ格納先へのポインタ
+ * @param[in] my_i2c_v : 対象とする I2C_Config 構造体へのポインタ
+ * @param[in] cmd_byte : コマンド
+ * @param[in] data     : 書き込むデータ
  * @retval I2C_ERR_CODE
  */
-I2C_ERR_CODE I2C_write_2bytes(void* my_i2c_v, uint8_t cmd_byte, void* data_v);
+I2C_ERR_CODE I2C_write_2bytes(void* my_i2c_v, uint8_t cmd_byte, uint16_t data);
 
 /**
  * @brief I2C_Config 構造体にて指定されたchから1バイトデータを読み込みます
- * @param[in] my_i2c_v    : 対象とする I2C_Config 構造体へのポインタ
- * @param[in] cmd_byte    : コマンド
- * @param[out] data_v     : データ格納先へのポインタ
+ * @param[in] my_i2c_v : 対象とする I2C_Config 構造体へのポインタ
+ * @param[in] cmd_byte : コマンド
+ * @param[out] data_v  : データ格納先へのポインタ
  * @retval I2C_ERR_CODE
  */
-I2C_ERR_CODE I2C_read_byte(void* my_i2c_v, uint8_t cmd_byte, void* data_v);
+I2C_ERR_CODE I2C_read_byte(void* my_i2c_v, uint8_t cmd_byte, uint8_t* data_v);
 
 /**
  * @brief I2C_Config 構造体にて指定されたchから2バイトデータを読み込みます
- * @param[in] my_i2c_v    : 対象とする I2C_Config 構造体へのポインタ
- * @param[in] cmd_byte    : コマンド
- * @param[out] data_v     : データ格納先へのポインタ
+ * @param[in] my_i2c_v : 対象とする I2C_Config 構造体へのポインタ
+ * @param[in] cmd_byte : コマンド
+ * @param[out] data_v  : データ格納先へのポインタ
  * @retval I2C_ERR_CODE
  */
-I2C_ERR_CODE I2C_read_2bytes(void* my_i2c_v, uint8_t cmd_byte, void* data_v);
+I2C_ERR_CODE I2C_read_2bytes(void* my_i2c_v, uint8_t cmd_byte, uint16_t* data_v);
 
 #endif

--- a/IfWrapper/i2c.h
+++ b/IfWrapper/i2c.h
@@ -98,5 +98,40 @@ void I2C_set_stop_flag(void* my_i2c_v, const uint8_t stop_flag);
  */
 void I2C_set_rx_length(void* my_i2c_v, const uint32_t rx_length);
 
+/**
+ * @brief I2C_Config 構造体にて指定されたchから1バイトデータを書き込みます
+ * @param[in] my_i2c_v    : 対象とする I2C_Config 構造体へのポインタ
+ * @param[in] cmd_byte    : コマンド
+ * @param[in] data_v      : 受信データ格納先へのポインタ
+ * @retval I2C_ERR_CODE
+ */
+I2C_ERR_CODE I2C_write_byte(void* my_i2c_v, uint8_t cmd_byte, void* data_v);
+
+/**
+ * @brief I2C_Config 構造体にて指定されたchから2バイトデータを書き込みます
+ * @param[in] my_i2c_v    : 対象とする I2C_Config 構造体へのポインタ
+ * @param[in] cmd_byte    : コマンド
+ * @param[in] data_v      : 受信データ格納先へのポインタ
+ * @retval I2C_ERR_CODE
+ */
+I2C_ERR_CODE I2C_write_2bytes(void* my_i2c_v, uint8_t cmd_byte, void* data_v);
+
+/**
+ * @brief I2C_Config 構造体にて指定されたchから1バイトデータを読み込みます
+ * @param[in] my_i2c_v    : 対象とする I2C_Config 構造体へのポインタ
+ * @param[in] cmd_byte    : コマンド
+ * @param[out] data_v     : データ格納先へのポインタ
+ * @retval I2C_ERR_CODE
+ */
+I2C_ERR_CODE I2C_read_byte(void* my_i2c_v, uint8_t cmd_byte, void* data_v);
+
+/**
+ * @brief I2C_Config 構造体にて指定されたchから2バイトデータを読み込みます
+ * @param[in] my_i2c_v    : 対象とする I2C_Config 構造体へのポインタ
+ * @param[in] cmd_byte    : コマンド
+ * @param[out] data_v     : データ格納先へのポインタ
+ * @retval I2C_ERR_CODE
+ */
+I2C_ERR_CODE I2C_read_2bytes(void* my_i2c_v, uint8_t cmd_byte, void* data_v);
 
 #endif

--- a/IfWrapper/i2c.h
+++ b/IfWrapper/i2c.h
@@ -98,40 +98,4 @@ void I2C_set_stop_flag(void* my_i2c_v, const uint8_t stop_flag);
  */
 void I2C_set_rx_length(void* my_i2c_v, const uint32_t rx_length);
 
-/**
- * @brief I2C_Config 構造体にて指定されたchから1バイトデータを書き込みます
- * @param[in] my_i2c_v : 対象とする I2C_Config 構造体へのポインタ
- * @param[in] cmd_byte : コマンド
- * @param[in] data     : 書き込むデータ
- * @retval I2C_ERR_CODE
- */
-I2C_ERR_CODE I2C_write_byte(void* my_i2c_v, uint8_t cmd_byte, uint8_t data);
-
-/**
- * @brief I2C_Config 構造体にて指定されたchから2バイトデータを書き込みます
- * @param[in] my_i2c_v : 対象とする I2C_Config 構造体へのポインタ
- * @param[in] cmd_byte : コマンド
- * @param[in] data     : 書き込むデータ
- * @retval I2C_ERR_CODE
- */
-I2C_ERR_CODE I2C_write_2bytes(void* my_i2c_v, uint8_t cmd_byte, uint16_t data);
-
-/**
- * @brief I2C_Config 構造体にて指定されたchから1バイトデータを読み込みます
- * @param[in] my_i2c_v : 対象とする I2C_Config 構造体へのポインタ
- * @param[in] cmd_byte : コマンド
- * @param[out] data_v  : データ格納先へのポインタ
- * @retval I2C_ERR_CODE
- */
-I2C_ERR_CODE I2C_read_byte(void* my_i2c_v, uint8_t cmd_byte, uint8_t* data_v);
-
-/**
- * @brief I2C_Config 構造体にて指定されたchから2バイトデータを読み込みます
- * @param[in] my_i2c_v : 対象とする I2C_Config 構造体へのポインタ
- * @param[in] cmd_byte : コマンド
- * @param[out] data_v  : データ格納先へのポインタ
- * @retval I2C_ERR_CODE
- */
-I2C_ERR_CODE I2C_read_2bytes(void* my_i2c_v, uint8_t cmd_byte, uint16_t* data_v);
-
 #endif


### PR DESCRIPTION
## Issue

## 詳細
IfWrapper/Common配下にI2Cでデバイスのコマンドを指定してレジスタをread/writeする関数を追加する
レジスタのサイズは1バイトと2バイトに対応

## 検証結果
I2Cでレジスタをread/writeしているc2a_userの処理を本PRで追加した関数に置き換えて
置き換え前と同じ動作をすることを確認

## 影響範囲
－

## 補足
－

## 注意
－
