### PR TITLE
Fix typo "Tlemetry"

### DIFF
--- a/Docs/Core/communication.md
+++ b/Docs/Core/communication.md
@@ -76,7 +76,7 @@ https://github.com/ut-issl/c2a-core/blob/b84c3d051a1e15ab62c8f1a9744957daa4a62a3
     - `0x01`: Version 1
 - Board Time
     - テレメトリが生成されたボード (OBC など) の時刻 (TI など)
-- Tlemetry ID
+- Telemetry ID
     - テレメトリID
     - APID 内でユニークであればいい
 - Global Time


### PR DESCRIPTION
## 概要
typo "Tlemetry" を "Telemetry" に修正

## 影響範囲
ドキュメンテーションのみの変更。
