### PR TITLE
テレメ生成時のAPID判定のバグ修正

### DIFF
--- a/Examples/2nd_obc_user/src/src_user/Settings/TlmCmd/Ccsds/apid_define.c
+++ b/Examples/2nd_obc_user/src/src_user/Settings/TlmCmd/Ccsds/apid_define.c
@@ -31,11 +31,12 @@ int APID_is_other_obc_tlm_apid(APID apid)
 {
   switch (apid)
   {
-  case CTP_APID_FROM_ME:
-    return 0;
+  case APID_MOBC_TLM:   // FALLTHROUGH
+  case APID_TOBC_TLM:
+    return 1;
 
   default:
-    return 1;
+    return 0;
   }
 }
 

--- a/Examples/2nd_obc_user/src/src_user/Settings/TlmCmd/Ccsds/apid_define.c
+++ b/Examples/2nd_obc_user/src/src_user/Settings/TlmCmd/Ccsds/apid_define.c
@@ -31,7 +31,8 @@ int APID_is_other_obc_tlm_apid(APID apid)
 {
   switch (apid)
   {
-  case APID_MOBC_TLM:   // FALLTHROUGH
+  // FIXME: 2nd obc の場合は変更しなければいけないが， https://github.com/ut-issl/c2a-core/issues/489 で消えるので一旦このまま
+  case APID_AOBC_TLM:   // FALLTHROUGH
   case APID_TOBC_TLM:
     return 1;
 

--- a/Examples/minimum_user/src/src_user/Settings/TlmCmd/Ccsds/apid_define.c
+++ b/Examples/minimum_user/src/src_user/Settings/TlmCmd/Ccsds/apid_define.c
@@ -31,6 +31,7 @@ int APID_is_other_obc_tlm_apid(APID apid)
 {
   switch (apid)
   {
+  // FIXME: 2nd obc の場合は変更しなければいけないが， https://github.com/ut-issl/c2a-core/issues/489 で消えるので一旦このまま
   case APID_AOBC_TLM:   // FALLTHROUGH
   case APID_TOBC_TLM:
     return 1;

--- a/Examples/minimum_user/src/src_user/Settings/TlmCmd/Ccsds/apid_define.c
+++ b/Examples/minimum_user/src/src_user/Settings/TlmCmd/Ccsds/apid_define.c
@@ -31,11 +31,12 @@ int APID_is_other_obc_tlm_apid(APID apid)
 {
   switch (apid)
   {
-  case CTP_APID_FROM_ME:
-    return 0;
+  case APID_AOBC_TLM:   // FALLTHROUGH
+  case APID_TOBC_TLM:
+    return 1;
 
   default:
-    return 1;
+    return 0;
   }
 }
 


### PR DESCRIPTION
## 概要
テレメ生成時のAPID判定のバグ修正

## Issue
- 2nd obc からのテレメかどうかの判定がバグっていた

## 詳細
なぜかテレメが降りてこなくなってた

## 検証結果
- テレメが降りてくるようになった
- pytestをすべてpass

## その他
- https://github.com/ut-issl/c2a-core/pull/492 を先にマージする