### PR TITLE
Update black to 23.1.0 from 22.12.0

### DIFF
--- a/.github/workflows/python_check_format.yml
+++ b/.github/workflows/python_check_format.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: install black formatter
-        run: pip install black==22.12.0
+        run: pip install black==23.1.0
 
       # - name: check python format with black
       #   uses: psf/black@stable

--- a/Examples/2nd_obc_user/src/src_user/Test/test/conftest.py
+++ b/Examples/2nd_obc_user/src/src_user/Test/test/conftest.py
@@ -23,7 +23,6 @@ def increase_hk_frequency():
 
 
 def _increase_hk_frequency():
-
     ope.send_rt_cmd(
         mobc_c2a_enum.Cmd_CODE_TLCD_CLEAR_ALL_TIMELINE,
         (2,),

--- a/Examples/minimum_user/src/src_user/Test/test/conftest.py
+++ b/Examples/minimum_user/src/src_user/Test/test/conftest.py
@@ -22,7 +22,6 @@ def increase_hk_frequency():
 
 
 def _increase_hk_frequency():
-
     ope.send_rt_cmd(
         c2a_enum.Cmd_CODE_TLCD_CLEAR_ALL_TIMELINE,
         (2,),

--- a/Examples/minimum_user/src/src_user/Test/test/src_core/Applications/test_timeline_command_dispatcher.py
+++ b/Examples/minimum_user/src/src_user/Test/test/src_core/Applications/test_timeline_command_dispatcher.py
@@ -161,7 +161,6 @@ def test_tlcd_set_id_and_page_for_tlm():
 @pytest.mark.sils
 @pytest.mark.real
 def test_tlcd_send_and_clear_tl():
-
     clear_tl_gs_and_tl_mis()
 
     tlm_TL = wings.util.generate_and_receive_tlm(

--- a/Examples/minimum_user/src/src_user/Test/test/src_core/System/TimeManager/test_time_manager.py
+++ b/Examples/minimum_user/src/src_user/Test/test/src_core/System/TimeManager/test_time_manager.py
@@ -28,7 +28,6 @@ TMGR_DEFAULT_UNIXTIME_EPOCH_FOR_UTL = 1577836800.0
 @pytest.mark.sils
 @pytest.mark.real
 def test_tmgr_set_time():
-
     assert "PRM" == wings.util.send_rt_cmd_and_confirm(
         ope, c2a_enum.Cmd_CODE_TMGR_SET_TIME, (0xFFFFFFFF,), c2a_enum.Tlm_CODE_HK
     )
@@ -52,7 +51,6 @@ def test_tmgr_set_time():
 @pytest.mark.sils
 @pytest.mark.real
 def test_tmgr_set_unixtime():
-
     # unixtime_at_ti0 を current_unixtime とランダムな TI で更新
     current_unixtime = time.time()
     ti = random.randrange(1000)
@@ -87,7 +85,6 @@ def test_tmgr_set_unixtime():
 @pytest.mark.sils
 @pytest.mark.real
 def test_tmgr_set_utl_unixtime_epoch():
-
     # 負の値ではコマンドが通らないことを確認
     assert "PRM" == wings.util.send_rt_cmd_and_confirm(
         ope, c2a_enum.Cmd_CODE_TMGR_SET_UTL_UNIXTIME_EPOCH, (-10.0,), c2a_enum.Tlm_CODE_HK
@@ -108,7 +105,6 @@ def test_tmgr_set_utl_unixtime_epoch():
 @pytest.mark.sils
 @pytest.mark.real
 def test_tmgr_set_and_reset_cycle_correction():
-
     # 負の値ではコマンドが通らないことを確認
     assert "PRM" == wings.util.send_rt_cmd_and_confirm(
         ope, c2a_enum.Cmd_CODE_TMGR_SET_CYCLE_CORRECTION, (-0.5,), c2a_enum.Tlm_CODE_HK

--- a/Examples/minimum_user/src/src_user/Test/test/src_core/TlmCmd/test_block_command_loader.py
+++ b/Examples/minimum_user/src/src_user/Test/test/src_core/TlmCmd/test_block_command_loader.py
@@ -34,7 +34,6 @@ PARAMS_LIST = [
 @pytest.mark.sils
 @pytest.mark.real
 def test_bcl_prepare_param():
-
     # BC_TEST_BCL を BLテレメに降ろしてくる
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
         ope,


### PR DESCRIPTION
## 概要
Update black to 23.1.0 from 22.12.0.

## Issue
- https://github.com/ut-issl/c2a-core/issues/491

