### PR TITLE
Pre Release (v3.8.0-beta.4): 認証なしの最新の WINGS への対応

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,8 +60,6 @@ dkms.conf
 # for c2a user sample
 Examples/minimum_user/src/src_core
 Examples/minimum_user/build
-Examples/minimum_user/src/src_user/Test/authorization.json
 Examples/2nd_obc_user/src/src_core
 Examples/2nd_obc_user/build
-Examples/2nd_obc_user/src/src_user/Test/authorization.json
 *.pyc

--- a/Examples/2nd_obc_user/src/src_user/Test/authorization.json.temp
+++ b/Examples/2nd_obc_user/src/src_user/Test/authorization.json.temp
@@ -1,7 +1,0 @@
-{
-    "client_id": "hoge_id",
-    "client_secret": "hoge_secret",
-    "grant_type": "hoge",
-    "username": "hoge@fuga",
-    "password": "piyopiyo"
-}

--- a/Examples/2nd_obc_user/src/src_user/Test/utils/wings_utils.py
+++ b/Examples/2nd_obc_user/src/src_user/Test/utils/wings_utils.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-import json
-import os
 import isslwings as wings
 
 

--- a/Examples/2nd_obc_user/src/src_user/Test/utils/wings_utils.py
+++ b/Examples/2nd_obc_user/src/src_user/Test/utils/wings_utils.py
@@ -6,16 +6,4 @@ import isslwings as wings
 
 
 def get_wings_operation():
-    authorization = dict(
-        client_id=os.environ.get("WINGS_CLIENT_ID"),
-        client_secret=os.environ.get("WINGS_CLIENT_SECRET"),
-        grant_type=os.environ.get("WINGS_GRANT_TYPE"),
-        username=os.environ.get("WINGS_USERNAME"),
-        password=os.environ.get("WINGS_PASSWORD"),
-    )
-
-    # 環境変数があればそちらを優先
-    if None in authorization.values():
-        with open(os.path.dirname(__file__) + "/../authorization.json") as f:
-            authorization = json.load(f)
-    return wings.Operation(authentication_info=authorization)
+    return wings.Operation()

--- a/Examples/2nd_obc_user/sync_with_minimum_user.bat
+++ b/Examples/2nd_obc_user/sync_with_minimum_user.bat
@@ -29,7 +29,6 @@ call :sync_file ".\src\src_user\TlmCmd\common_tlm_cmd_packet.c" "..\minimum_user
 call :sync_file ".\src\src_user\TlmCmd\common_tlm_packet.c" "..\minimum_user\src\src_user\TlmCmd\common_tlm_packet.c"
 
 call :sync_file ".\src\src_user\Test\utils\wings_utils.py" "..\minimum_user\src\src_user\Test\utils\wings_utils.py"
-call :sync_file ".\src\src_user\Test\authorization.json.temp" "..\minimum_user\src\src_user\Test\authorization.json.temp"
 call :sync_file ".\src\src_user\Test\pytest.ini" "..\minimum_user\src\src_user\Test\pytest.ini"
 
 

--- a/Examples/minimum_user/src/src_user/Test/README.md
+++ b/Examples/minimum_user/src/src_user/Test/README.md
@@ -48,14 +48,3 @@ or
 cd ./test/src_user/Applications/UserDefined/
 pytest -m real -v test_tlm_mem_dump.py
 ```
-
-## 認証情報について
-wings と通信するにあたりに対して認証情報を渡す必要がある. `authorization.json.temp` と同じ key を持つ正しい `authorization.json` を誰かからもらうか，又はそれぞれの key に対応する環境変数を埋めること. 対応を下表に示す.
-
-| `authorization.json` の key | 環境変数            |
-| :-------------------------- | :------------------ |
-| client_id                   | WINGS_CLIENT_ID     |
-| client_secret               | WINGS_CLIENT_SECRET |
-| grant_type                  | WINGS_GRANT_TYPE    |
-| username                    | WINGS_USERNAME      |
-| password                    | WINGS_PASSWORD      |

--- a/Examples/minimum_user/src/src_user/Test/authorization.json.temp
+++ b/Examples/minimum_user/src/src_user/Test/authorization.json.temp
@@ -1,7 +1,0 @@
-{
-    "client_id": "hoge_id",
-    "client_secret": "hoge_secret",
-    "grant_type": "hoge",
-    "username": "hoge@fuga",
-    "password": "piyopiyo"
-}

--- a/Examples/minimum_user/src/src_user/Test/utils/wings_utils.py
+++ b/Examples/minimum_user/src/src_user/Test/utils/wings_utils.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-import json
-import os
 import isslwings as wings
 
 

--- a/Examples/minimum_user/src/src_user/Test/utils/wings_utils.py
+++ b/Examples/minimum_user/src/src_user/Test/utils/wings_utils.py
@@ -6,16 +6,4 @@ import isslwings as wings
 
 
 def get_wings_operation():
-    authorization = dict(
-        client_id=os.environ.get("WINGS_CLIENT_ID"),
-        client_secret=os.environ.get("WINGS_CLIENT_SECRET"),
-        grant_type=os.environ.get("WINGS_GRANT_TYPE"),
-        username=os.environ.get("WINGS_USERNAME"),
-        password=os.environ.get("WINGS_PASSWORD"),
-    )
-
-    # 環境変数があればそちらを優先
-    if None in authorization.values():
-        with open(os.path.dirname(__file__) + "/../authorization.json") as f:
-            authorization = json.load(f)
-    return wings.Operation(authentication_info=authorization)
+    return wings.Operation()

--- a/c2a_core_main.h
+++ b/c2a_core_main.h
@@ -10,6 +10,6 @@ void C2A_core_main(void);
 #define C2A_CORE_VER_MAJOR (3)
 #define C2A_CORE_VER_MINOR (8)
 #define C2A_CORE_VER_PATCH (0)
-#define C2A_CORE_VER_PRE   ("beta.3")
+#define C2A_CORE_VER_PRE   ("beta.4")
 
 #endif


### PR DESCRIPTION
## 概要
Pre Release (v3.8.0-beta.4): 認証なしの最新の WINGS への対応

## Issue
- https://github.com/ut-issl/python-wings-interface/issues/28

## 詳細
- pytest でつかう WINGS の認証を削除

## 検証結果
- すべての test が通った

## 影響範囲
- 認証ありの古い WINGS は使えなくなる
- https://github.com/ut-issl/python-wings-interface/pull/31 とともにマージする

## 補足
- [x] リリースを打つ（バージョンを上げてからマージする）
- [x] https://github.com/ut-issl/c2a-core/pull/490 を先にマージする
