### PR TITLE
CDISの実行エラーのEL登録のlocal id を cmd id にした

### DIFF
--- a/Examples/minimum_user/src/src_user/Test/test/src_core/TlmCmd/test_command_dispatcher.py
+++ b/Examples/minimum_user/src/src_user/Test/test/src_core/TlmCmd/test_command_dispatcher.py
@@ -21,7 +21,7 @@ ope = wings_utils.get_wings_operation()
 @pytest.mark.real
 def test_cdis_exec_err():
     # ===== 以下の 2 コマンドでチェックする =====
-    # それぞれについて RT/TL で実行する
+    # それぞれを RT/TL で実行する
     # 送信するコマンドと想定されるエラーは以下
     #
     # Cmd_TMGR_UPDATE_UNIXTIME
@@ -86,8 +86,8 @@ def check_cdis_exec_err(cmd_id, params, exec_sts_expected, err_code_expected):
     assert tlm_EL["EL.TLOGS.LOW.EVENTS3.NOTE"] == err_code_expected
     assert tlm_EL["EL.TLOGS.LOW.EVENTS2.GROUP"] == c2a_enum.EL_CORE_GROUP_CDIS_EXEC_ERR_STS
     assert tlm_EL["EL.TLOGS.LOW.EVENTS2.LOCAL"] == cmd_id
-    idx_gs, r = divmod(tlm_EL["EL.TLOGS.LOW.EVENTS2.NOTE"], 2 ** 24)  # 上位 8bit
-    exec_sts, err_code = divmod(r, 2 ** 16)  # 次の 8bit と下位 16bit
+    idx_gs, r = divmod(tlm_EL["EL.TLOGS.LOW.EVENTS2.NOTE"], 2**24)  # 上位 8bit
+    exec_sts, err_code = divmod(r, 2**16)  # 次の 8bit と下位 16bit
     assert exec_sts == exec_sts_expected
     assert err_code == err_code_expected
 
@@ -97,8 +97,8 @@ def check_cdis_exec_err(cmd_id, params, exec_sts_expected, err_code_expected):
     assert tlm_EL["EL.TLOGS.LOW.EVENTS1.NOTE"] == err_code_expected
     assert tlm_EL["EL.TLOGS.LOW.EVENTS0.GROUP"] == c2a_enum.EL_CORE_GROUP_CDIS_EXEC_ERR_STS
     assert tlm_EL["EL.TLOGS.LOW.EVENTS0.LOCAL"] == cmd_id
-    idx_tl, r = divmod(tlm_EL["EL.TLOGS.LOW.EVENTS0.NOTE"], 2 ** 24)  # 上位 8bit
-    exec_sts, err_code = divmod(r, 2 ** 16)  # 次の 8bit と下位 16bit
+    idx_tl, r = divmod(tlm_EL["EL.TLOGS.LOW.EVENTS0.NOTE"], 2**24)  # 上位 8bit
+    exec_sts, err_code = divmod(r, 2**16)  # 次の 8bit と下位 16bit
     assert exec_sts == exec_sts_expected
     assert err_code == err_code_expected
 

--- a/Examples/minimum_user/src/src_user/Test/test/src_core/TlmCmd/test_command_dispatcher.py
+++ b/Examples/minimum_user/src/src_user/Test/test/src_core/TlmCmd/test_command_dispatcher.py
@@ -16,73 +16,96 @@ import wings_utils
 c2a_enum = c2a_enum_utils.get_c2a_enum()
 ope = wings_utils.get_wings_operation()
 
-# C2Aでのdefine値
-AM_TLM_PAGE_MAX = 4
-
 
 @pytest.mark.sils
 @pytest.mark.real
 def test_cdis_exec_err():
-    # === 以下の4つを無効パラメタでコマンド登録する
-    # RT Cmd_CODE_TMGR_UPDATE_UNIXTIME
-    # RT Cmd_CODE_AM_SET_PAGE_FOR_TLM
-    # TL Cmd_CODE_TMGR_UPDATE_UNIXTIME
-    # TL Cmd_CODE_AM_SET_PAGE_FOR_TLM
+    # ===== 以下の 2 コマンドでチェックする =====
+    # それぞれについて RT/TL で実行する
+    # 送信するコマンドと想定されるエラーは以下
+    #
+    # Cmd_TMGR_UPDATE_UNIXTIME
+    #   - 無効なパラメタで送信
+    #   - exec_sts: CCP_EXEC_ILLEGAL_PARAMETER = 2
+    #   - err_code: 0
+    # Cmd_TLCD_DEPLOY_BLOCK
+    #   - 無効な block を展開
+    #   - exec_sts: CCP_EXEC_ILLEGAL_CONTEXT = 3
+    #   - err_code: PL_BC_INACTIVE_BLOCK = 8
 
-    check_cdis_exec_err(c2a_enum.Cmd_CODE_TMGR_UPDATE_UNIXTIME, (-10, 0, 0))
-    check_cdis_exec_err(c2a_enum.Cmd_CODE_AM_SET_PAGE_FOR_TLM, (AM_TLM_PAGE_MAX + 100,))
+    idx_gs_0, idx_tl_0 = check_cdis_exec_err(
+        c2a_enum.Cmd_CODE_TMGR_UPDATE_UNIXTIME, (-10, 0, 0), c2a_enum.CCP_EXEC_ILLEGAL_PARAMETER, 0
+    )
+    idx_gs_1, idx_tl_1 = check_cdis_exec_err(
+        c2a_enum.Cmd_CODE_TLCD_DEPLOY_BLOCK,
+        (0, c2a_enum.BC_ID_MAX),  # BC_ID_MAX は inactive でしょう, という前提
+        c2a_enum.CCP_EXEC_ILLEGAL_CONTEXT,
+        c2a_enum.PL_BC_INACTIVE_BLOCK,
+    )
 
-    # === 最後にもう一度初期化
+    # 同じ CDIS の場合は同じ idx になることを確認
+    assert idx_gs_0 == idx_gs_1
+    assert idx_tl_0 == idx_tl_1
+
+    # 最後に EL 初期化
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
         ope, c2a_enum.Cmd_CODE_EL_INIT, (), c2a_enum.Tlm_CODE_HK
     )
 
 
-def check_cdis_exec_err(cmd_id, params):
-    # === ELの初期化
+def check_cdis_exec_err(cmd_id, params, exec_sts_expected, err_code_expected):
+    # === ELの初期化 ===
     assert "SUC" == wings.util.send_rt_cmd_and_confirm(
         ope, c2a_enum.Cmd_CODE_EL_INIT, (), c2a_enum.Tlm_CODE_HK
     )
-    tlm_EL = wings.util.generate_and_receive_tlm(
-        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_EL
-    )
-    ti_now = tlm_EL["EL.SH.TI"]
 
-    # === 引数が不正な コマンドチェック
-    assert "PRM" == wings.util.send_rt_cmd_and_confirm(ope, cmd_id, params, c2a_enum.Tlm_CODE_HK)
-    wings.util.send_tl_cmd(ope, ti_now + 30, cmd_id, params)
-    time.sleep(3)
-
-    # === ELのチェック
-    tlm_EL = wings.util.generate_and_receive_tlm(
-        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_EL
+    # === TLCD の EL を無効化 ===
+    # EL 初期化で戻ってしまうのでこの位置におく
+    assert "SUC" == wings.util.send_rt_cmd_and_confirm(
+        ope,
+        c2a_enum.Cmd_CODE_EL_DISABLE_LOGGING,
+        (c2a_enum.EL_CORE_GROUP_TLCD_DEPLOY_BLOCK,),
+        c2a_enum.Tlm_CODE_HK,
     )
 
-    # === ELのチェック
+    # === RT と TL でコマンド送信 ===
+    tlm_HK = ope.get_latest_tlm(c2a_enum.Tlm_CODE_HK)[0]
+    ti_now = tlm_HK["HK.SH.TI"]
+    assert "SUC" != wings.util.send_rt_cmd_and_confirm(ope, cmd_id, params, c2a_enum.Tlm_CODE_HK)
+    wings.util.send_tl_cmd(ope, ti_now + 50, cmd_id, params)
+    time.sleep(5)
+
+    # === ELのチェック ===
     tlm_EL = wings.util.generate_and_receive_tlm(
         ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_EL
     )
 
     # GS_cmd_dispatcher
     assert tlm_EL["EL.TLOGS.LOW.EVENTS3.GROUP"] == c2a_enum.EL_CORE_GROUP_CDIS_EXEC_ERR_CODE
-    assert tlm_EL["EL.TLOGS.LOW.EVENTS3.NOTE"] == 0
+    assert tlm_EL["EL.TLOGS.LOW.EVENTS3.LOCAL"] == cmd_id
+    assert tlm_EL["EL.TLOGS.LOW.EVENTS3.NOTE"] == err_code_expected
     assert tlm_EL["EL.TLOGS.LOW.EVENTS2.GROUP"] == c2a_enum.EL_CORE_GROUP_CDIS_EXEC_ERR_STS
-    assert (
-        tlm_EL["EL.TLOGS.LOW.EVENTS2.NOTE"] == (cmd_id << 16) | c2a_enum.CCP_EXEC_ILLEGAL_PARAMETER
-    )
-    assert tlm_EL["EL.TLOGS.LOW.EVENTS3.LOCAL"] == tlm_EL["EL.TLOGS.LOW.EVENTS2.LOCAL"]
+    assert tlm_EL["EL.TLOGS.LOW.EVENTS2.LOCAL"] == cmd_id
+    idx_gs, r = divmod(tlm_EL["EL.TLOGS.LOW.EVENTS2.NOTE"], 2 ** 24)  # 上位 8bit
+    exec_sts, err_code = divmod(r, 2 ** 16)  # 次の 8bit と下位 16bit
+    assert exec_sts == exec_sts_expected
+    assert err_code == err_code_expected
 
     # TL_cmd_dispatcher
     assert tlm_EL["EL.TLOGS.LOW.EVENTS1.GROUP"] == c2a_enum.EL_CORE_GROUP_CDIS_EXEC_ERR_CODE
-    assert tlm_EL["EL.TLOGS.LOW.EVENTS1.NOTE"] == 0
+    assert tlm_EL["EL.TLOGS.LOW.EVENTS1.LOCAL"] == cmd_id
+    assert tlm_EL["EL.TLOGS.LOW.EVENTS1.NOTE"] == err_code_expected
     assert tlm_EL["EL.TLOGS.LOW.EVENTS0.GROUP"] == c2a_enum.EL_CORE_GROUP_CDIS_EXEC_ERR_STS
-    assert (
-        tlm_EL["EL.TLOGS.LOW.EVENTS0.NOTE"] == (cmd_id << 16) | c2a_enum.CCP_EXEC_ILLEGAL_PARAMETER
-    )
-    assert tlm_EL["EL.TLOGS.LOW.EVENTS1.LOCAL"] == tlm_EL["EL.TLOGS.LOW.EVENTS0.LOCAL"]
+    assert tlm_EL["EL.TLOGS.LOW.EVENTS0.LOCAL"] == cmd_id
+    idx_tl, r = divmod(tlm_EL["EL.TLOGS.LOW.EVENTS0.NOTE"], 2 ** 24)  # 上位 8bit
+    exec_sts, err_code = divmod(r, 2 ** 16)  # 次の 8bit と下位 16bit
+    assert exec_sts == exec_sts_expected
+    assert err_code == err_code_expected
 
-    # GSとTLをlocalで区別できているか
-    assert tlm_EL["EL.TLOGS.LOW.EVENTS1.LOCAL"] != tlm_EL["EL.TLOGS.LOW.EVENTS3.LOCAL"]
+    # GS と TL0 を note で区別できているか
+    assert idx_gs != idx_tl
+
+    return [idx_gs, idx_tl]
 
 
 if __name__ == "__main__":

--- a/TlmCmd/command_dispatcher.h
+++ b/TlmCmd/command_dispatcher.h
@@ -28,6 +28,7 @@ typedef struct
  */
 typedef struct
 {
+  uint8_t idx;              //!< CDIS のインデックス. EL で用いる
   CDIS_ExecInfo prev;       //!< 前回のコマンド実行情報
   CDIS_ExecInfo prev_err;   //!< 最後にエラーが出たコマンド実行情報
   uint32_t error_counter;   //!< エラーカウンタ


### PR DESCRIPTION
## 概要
CDISの実行エラーのEL登録のlocal id を cmd id にした

## Issue
- https://github.com/ut-issl/c2a-core/issues/480

## 詳細
issueの通り。cmd id ごとに EL 登録を無効化したいというのが最大のモチベ。

## 検証結果
手元で修正したpytestを通した

