### PR TITLE
BC展開時刻被りはコマンド実行エラーにしないようにした

### DIFF
--- a/Applications/timeline_command_dispatcher.c
+++ b/Applications/timeline_command_dispatcher.c
@@ -275,7 +275,7 @@ CCP_CmdRet Cmd_TLCD_DEPLOY_BLOCK(const CommonCmdPacket* packet)
     EL_record_event((EL_GROUP)EL_CORE_GROUP_TLCD_DEPLOY_BLOCK,
                     (uint32_t)ack,
                     EL_ERROR_LEVEL_LOW,
-                    (uint32_t)block_no);
+                    (uint32_t)( ((0x000000ff & id) << 24) | (0x00ffffff & block_no) ));
     if (ack == PL_BC_TIME_ADJUSTED)
     {
       return CCP_make_cmd_ret(CCP_EXEC_SUCCESS, (uint32_t)ack);

--- a/Applications/timeline_command_dispatcher.c
+++ b/Applications/timeline_command_dispatcher.c
@@ -275,8 +275,15 @@ CCP_CmdRet Cmd_TLCD_DEPLOY_BLOCK(const CommonCmdPacket* packet)
     EL_record_event((EL_GROUP)EL_CORE_GROUP_TLCD_DEPLOY_BLOCK,
                     (uint32_t)ack,
                     EL_ERROR_LEVEL_LOW,
-                    (uint32_t)( ((0x000000ff & id) << 24) | (0x00ffffff & block_no) ));
-    return CCP_make_cmd_ret(CCP_EXEC_ILLEGAL_CONTEXT, (uint32_t)ack);
+                    (uint32_t)block_no);
+    if (ack == PL_BC_TIME_ADJUSTED)
+    {
+      return CCP_make_cmd_ret(CCP_EXEC_SUCCESS, (uint32_t)ack);
+    }
+    else
+    {
+      return CCP_make_cmd_ret(CCP_EXEC_ILLEGAL_CONTEXT, (uint32_t)ack);
+    }
   }
 
   return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);

--- a/Applications/timeline_command_dispatcher.c
+++ b/Applications/timeline_command_dispatcher.c
@@ -286,7 +286,7 @@ CCP_CmdRet Cmd_TLCD_DEPLOY_BLOCK(const CommonCmdPacket* packet)
     }
   }
 
-  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);
+  return CCP_make_cmd_ret(CCP_EXEC_SUCCESS, (uint32_t)ack);
 }
 
 CCP_CmdRet Cmd_TLCD_CLEAR_ERR_LOG(const CommonCmdPacket* packet)


### PR DESCRIPTION
## 概要
BC展開時刻被りはコマンド実行エラーにしないようにした

## Issue
- https://github.com/ut-issl/c2a-core/issues/483

## 詳細
詳しくは issue

## 検証結果
pytest を手元で回して全て通った

