### PR TITLE
DS での rx_buffer を stream ごとに driver instance から設定可能にする

### DIFF
--- a/Drivers/Super/driver_super.c
+++ b/Drivers/Super/driver_super.c
@@ -246,7 +246,7 @@ DS_ERR_CODE DS_init(DriverSuper* p_super,
   DS_StreamRecBuffer* rx_buffers[DS_STREAM_MAX];
   DS_nullify_stream_rec_buffers(rx_buffers);
   rx_buffers[0] = rx_buffer;
-  return DS_init_streams(p_super, rx_buffers, if_config, load_init_setting);
+  return DS_init_streams(p_super, if_config, rx_buffers, load_init_setting);
 }
 
 

--- a/Drivers/Super/driver_super.c
+++ b/Drivers/Super/driver_super.c
@@ -239,8 +239,8 @@ void DS_move_forward_frame_head_candidate_of_stream_rec_buffer_(DS_StreamRecBuff
 // ###### DriverSuper基本関数 ######
 
 DS_ERR_CODE DS_init(DriverSuper* p_super,
-                    DS_StreamRecBuffer* rx_buffer,
                     void* if_config,
+                    DS_StreamRecBuffer* rx_buffer,
                     DS_ERR_CODE (*load_init_setting)(DriverSuper* p_super))
 {
   DS_StreamRecBuffer* rx_buffers[DS_STREAM_MAX];
@@ -251,8 +251,8 @@ DS_ERR_CODE DS_init(DriverSuper* p_super,
 
 
 DS_ERR_CODE DS_init_streams(DriverSuper* p_super,
-                            DS_StreamRecBuffer* rx_buffers[DS_STREAM_MAX],
                             void* if_config,
+                            DS_StreamRecBuffer* rx_buffers[DS_STREAM_MAX],
                             DS_ERR_CODE (*load_init_setting)(DriverSuper* p_super))
 {
   uint8_t stream;
@@ -1595,14 +1595,16 @@ DS_ERR_CODE DSSC_get_ret_from_data_analyzer(const DS_StreamConfig* p_stream_conf
 
 // ###### Driver 汎用 Util 関数 ######
 
-void DS_init_stream_rec_buffer(DS_StreamRecBuffer* stream_rec_buffer,
-                               uint8_t* buffer,
-                               const uint16_t buffer_capacity)
+DS_ERR_CODE DS_init_stream_rec_buffer(DS_StreamRecBuffer* stream_rec_buffer,
+                                      uint8_t* buffer,
+                                      const uint16_t buffer_capacity)
 {
-  if (stream_rec_buffer == NULL) return;
+  if (stream_rec_buffer == NULL) return DS_ERR_CODE_ERR;
+  if (buffer == NULL) return DS_ERR_CODE_ERR;
   stream_rec_buffer->buffer = buffer;
   stream_rec_buffer->capacity = buffer_capacity;
   DS_clear_stream_rec_buffer_(stream_rec_buffer);
+  return DS_ERR_CODE_OK;
 }
 
 
@@ -1683,6 +1685,7 @@ uint16_t DSSC_get_fixed_rx_frame_size(const DS_StreamConfig* p_stream_config)
 void DS_clear_stream_rec_buffer_(DS_StreamRecBuffer* stream_rec_buffer)
 {
   if (stream_rec_buffer == NULL) return;
+  if (stream_rec_buffer->buffer == NULL) return;
 
   memset(stream_rec_buffer->buffer,
          0x00,

--- a/Drivers/Super/driver_super.h
+++ b/Drivers/Super/driver_super.h
@@ -410,20 +410,40 @@ struct DriverSuper
 // ###### DriverSuper 基本関数 ######
 
 /**
- * @brief  継承先の機器より DriverSuper を初期化する
+ * @brief  継承先の機器より DriverSuper を初期化する（stream 0 のみの使用の場合）
  *
  *         DriverSuper 構造体を継承先 Drive 構造体のメンバとして定義（継承）し，ポインタを渡すことでポートを初期化する．
  *         そして，構造体内の初期化が必要な変数を初期化する．
  *         デフォルト値の上書きは load_init_setting で行う
- * @note   DriverSuperを使用する時は起動時に必ず実施すること
+ * @note   DriverSuper を使用する時は起動時に必ず実施すること
  * @param  p_super:           初期化する DriverSuper 構造体へのポインタ
+ * @param  rx_buffer:         初期化する DriverSuper の stream 0 で用いられるフレーム受信バッファ
  * @param  if_config:         初期化する Driverで用いられている IF の config 構造体
  * @param  load_init_setting: DriverSuper の初期設定ロード関数ポインタ
  * @return DS_ERR_CODE
  */
 DS_ERR_CODE DS_init(DriverSuper* p_super,
+                    DS_StreamRecBuffer* rx_buffer,
                     void* if_config,
                     DS_ERR_CODE (*load_init_setting)(DriverSuper* p_super));
+
+/**
+ * @brief  継承先の機器より DriverSuper を初期化する（複数の stream を使用する場合）
+ *
+ *         DriverSuper 構造体を継承先 Drive 構造体のメンバとして定義（継承）し，ポインタを渡すことでポートを初期化する．
+ *         そして，構造体内の初期化が必要な変数を初期化する．
+ *         デフォルト値の上書きは load_init_setting で行う
+ * @note   DriverSuper を使用する時は起動時に必ず実施すること
+ * @param  p_super:           初期化する DriverSuper 構造体へのポインタ
+ * @param  rx_buffers:        初期化する DriverSuper で用いられるフレーム受信バッファ．使用しない stream は NULL を設定しておく
+ * @param  if_config:         初期化する Driverで用いられている IF の config 構造体
+ * @param  load_init_setting: DriverSuper の初期設定ロード関数ポインタ
+ * @return DS_ERR_CODE
+ */
+DS_ERR_CODE DS_init_streams(DriverSuper* p_super,
+                            DS_StreamRecBuffer* rx_buffers[DS_STREAM_MAX],
+                            void* if_config,
+                            DS_ERR_CODE (*load_init_setting)(DriverSuper* p_super));
 
 /**
  * @brief  DriverSuper のリセット
@@ -436,7 +456,7 @@ DS_ERR_CODE DS_reset(DriverSuper* p_super);
 /**
  * @brief  DriverSuper の設定に不整合が生じていないかチェックする
  *
- *         Driverの 設定を変えた場合は毎回呼び出すことを推奨する
+ *         Driver の設定を変えた場合は毎回呼び出すことを推奨する
  * @note   DS_init 内で呼ばれている．
  * @note   内部の管理フラグを変更しているので， p_super に厳密な const 性はない
  * @param  p_super: DriverSuper 構造体へのポインタ
@@ -448,7 +468,7 @@ DS_ERR_CODE DS_validate_config(DriverSuper* p_super);
  * @brief  受信バッファをクリアする
  *
  *         例えば，ヘッダなしテレメの場合，途中でゴミデータが入ると以後すべてのフレームがずれてしまう．
- *         そのようなとき（ CRC エラーがでるとか，受信データが明らかにおかしい場合）に，buffer を一度クリアし，
+ *         そのようなとき（CRC エラーがでるとか，受信データが明らかにおかしい場合）に，buffer を一度クリアし，
  *         次に届くデータからフレーム解析を先頭から行うようにするために用いる．
  * @param  p_super: DriverSuper 構造体へのポインタ
  * @return DS_ERR_CODE
@@ -610,6 +630,14 @@ DS_ERR_CODE DSSC_get_ret_from_data_analyzer(const DS_StreamConfig* p_stream_conf
 void DS_init_stream_rec_buffer(DS_StreamRecBuffer* stream_rec_buffer,
                                uint8_t* buffer,
                                const uint16_t buffer_capacity);
+
+/**
+ * @brief DS_StreamRecBuffer の要素数 DS_STREAM_MAX の配列を NULL で初期化する
+ * @note  DS_init_streams の引数を作るのに使う
+ * @param[out] rx_buffers: 初期化する DS_StreamRecBuffer の配列
+ * @return void
+ */
+void DS_nullify_stream_rec_buffers(DS_StreamRecBuffer* rx_buffers[DS_STREAM_MAX]);
 
 /**
  * @brief  DS_DRIVER_ERR_CODE から CCP_CmdRet への変換関数

--- a/Drivers/Super/driver_super.h
+++ b/Drivers/Super/driver_super.h
@@ -417,14 +417,14 @@ struct DriverSuper
  *         デフォルト値の上書きは load_init_setting で行う
  * @note   DriverSuper を使用する時は起動時に必ず実施すること
  * @param  p_super:           初期化する DriverSuper 構造体へのポインタ
- * @param  rx_buffer:         初期化する DriverSuper の stream 0 で用いられるフレーム受信バッファ
  * @param  if_config:         初期化する Driverで用いられている IF の config 構造体
+ * @param  rx_buffer:         初期化する DriverSuper の stream 0 で用いられるフレーム受信バッファ
  * @param  load_init_setting: DriverSuper の初期設定ロード関数ポインタ
  * @return DS_ERR_CODE
  */
 DS_ERR_CODE DS_init(DriverSuper* p_super,
-                    DS_StreamRecBuffer* rx_buffer,
                     void* if_config,
+                    DS_StreamRecBuffer* rx_buffer,
                     DS_ERR_CODE (*load_init_setting)(DriverSuper* p_super));
 
 /**
@@ -435,14 +435,14 @@ DS_ERR_CODE DS_init(DriverSuper* p_super,
  *         デフォルト値の上書きは load_init_setting で行う
  * @note   DriverSuper を使用する時は起動時に必ず実施すること
  * @param  p_super:           初期化する DriverSuper 構造体へのポインタ
- * @param  rx_buffers:        初期化する DriverSuper で用いられるフレーム受信バッファ．使用しない stream は NULL を設定しておく
  * @param  if_config:         初期化する Driverで用いられている IF の config 構造体
+ * @param  rx_buffers:        初期化する DriverSuper で用いられるフレーム受信バッファ．使用しない stream は NULL を設定しておく
  * @param  load_init_setting: DriverSuper の初期設定ロード関数ポインタ
  * @return DS_ERR_CODE
  */
 DS_ERR_CODE DS_init_streams(DriverSuper* p_super,
-                            DS_StreamRecBuffer* rx_buffers[DS_STREAM_MAX],
                             void* if_config,
+                            DS_StreamRecBuffer* rx_buffers[DS_STREAM_MAX],
                             DS_ERR_CODE (*load_init_setting)(DriverSuper* p_super));
 
 /**
@@ -625,11 +625,11 @@ DS_ERR_CODE DSSC_get_ret_from_data_analyzer(const DS_StreamConfig* p_stream_conf
  * @param[out] stream_rec_buffer: 初期化する DS_StreamRecBuffer
  * @param[in]  buffer:            与えるメモリ領域
  * @param[in]  buffer_capacity:   与えるメモリサイズ
- * @return void
+ * @return DS_ERR_CODE
  */
-void DS_init_stream_rec_buffer(DS_StreamRecBuffer* stream_rec_buffer,
-                               uint8_t* buffer,
-                               const uint16_t buffer_capacity);
+DS_ERR_CODE DS_init_stream_rec_buffer(DS_StreamRecBuffer* stream_rec_buffer,
+                                      uint8_t* buffer,
+                                      const uint16_t buffer_capacity);
 
 /**
  * @brief DS_StreamRecBuffer の要素数 DS_STREAM_MAX の配列を NULL で初期化する

--- a/Drivers/Super/driver_super.h
+++ b/Drivers/Super/driver_super.h
@@ -412,7 +412,7 @@ struct DriverSuper
 /**
  * @brief  継承先の機器より DriverSuper を初期化する（stream 0 のみの使用の場合）
  *
- *         DriverSuper 構造体を継承先 Drive 構造体のメンバとして定義（継承）し，ポインタを渡すことでポートを初期化する．
+ *         DriverSuper 構造体を継承先 Driver 構造体のメンバとして定義（継承）し，ポインタを渡すことでポートを初期化する．
  *         そして，構造体内の初期化が必要な変数を初期化する．
  *         デフォルト値の上書きは load_init_setting で行う
  * @note   DriverSuper を使用する時は起動時に必ず実施すること
@@ -430,7 +430,7 @@ DS_ERR_CODE DS_init(DriverSuper* p_super,
 /**
  * @brief  継承先の機器より DriverSuper を初期化する（複数の stream を使用する場合）
  *
- *         DriverSuper 構造体を継承先 Drive 構造体のメンバとして定義（継承）し，ポインタを渡すことでポートを初期化する．
+ *         DriverSuper 構造体を継承先 Driver 構造体のメンバとして定義（継承）し，ポインタを渡すことでポートを初期化する．
  *         そして，構造体内の初期化が必要な変数を初期化する．
  *         デフォルト値の上書きは load_init_setting で行う
  * @note   DriverSuper を使用する時は起動時に必ず実施すること

--- a/Examples/2nd_obc_user/src/src_user/Drivers/Etc/mobc.c
+++ b/Examples/2nd_obc_user/src/src_user/Drivers/Etc/mobc.c
@@ -11,17 +11,12 @@
 #include <src_core/Drivers/Protocol/eb90_frame_for_driver_super.h>
 #include <src_core/Drivers/Protocol/common_tlm_cmd_packet_for_driver_super.h>
 #include <string.h>
-#include "../../Settings/DriverSuper/driver_buffer_define.h"
 
 #define MOBC_STREAM_TLM_CMD   (0)   //!< テレコマで使うストリーム
 
 static uint8_t MOBC_tx_frame_[EB90_FRAME_HEADER_SIZE +
                               CTCP_MAX_LEN +
                               EB90_FRAME_FOOTER_SIZE];
-
-// バッファ
-static uint8_t MOBC_rx_buffer_allocation_[DS_STREAM_REC_BUFFER_SIZE_DEFAULT];
-static DS_StreamRecBuffer MOBC_rx_buffer_;
 
 static DS_ERR_CODE MOBC_load_driver_super_init_settings_(DriverSuper* p_super);
 static DS_ERR_CODE MOBC_analyze_rec_data_(DS_StreamConfig* p_stream_config,
@@ -42,6 +37,7 @@ DS_INIT_ERR_CODE MOBC_init(MOBC_Driver* mobc_driver, uint8_t ch, DS_StreamRecBuf
 
   ret = DS_init(&(mobc_driver->driver.super),
                 &(mobc_driver->driver.uart_config),
+                rx_buffer,
                 MOBC_load_driver_super_init_settings_);
   if (ret != DS_ERR_CODE_OK) return DS_INIT_DS_INIT_ERR;
   return DS_INIT_OK;
@@ -58,10 +54,6 @@ static DS_ERR_CODE MOBC_load_driver_super_init_settings_(DriverSuper* p_super)
   p_stream_config = &(p_super->stream_config[MOBC_STREAM_TLM_CMD]);
 
   CTCP_init_dssc(p_stream_config, MOBC_tx_frame_, sizeof(MOBC_tx_frame_), MOBC_analyze_rec_data_);
-  DS_init_stream_rec_buffer(&MOBC_rx_buffer_,
-                            MOBC_rx_buffer_allocation_,
-                            sizeof(MOBC_rx_buffer_allocation_));
-  DSSC_set_rx_buffer(p_stream_config, &MOBC_rx_buffer_);
 
   // 定期 TLM の監視機能の有効化しない → ので設定上書きなし
 

--- a/Examples/2nd_obc_user/src/src_user/Drivers/Etc/mobc.c
+++ b/Examples/2nd_obc_user/src/src_user/Drivers/Etc/mobc.c
@@ -28,7 +28,7 @@ static DS_ERR_CODE MOBC_analyze_rec_data_(DS_StreamConfig* p_stream_config,
                                           void* p_driver);
 
 
-DS_INIT_ERR_CODE MOBC_init(MOBC_Driver* mobc_driver, uint8_t ch)
+DS_INIT_ERR_CODE MOBC_init(MOBC_Driver* mobc_driver, uint8_t ch, DS_StreamRecBuffer* rx_buffer)
 {
   DS_ERR_CODE ret;
 

--- a/Examples/2nd_obc_user/src/src_user/Drivers/Etc/mobc.h
+++ b/Examples/2nd_obc_user/src/src_user/Drivers/Etc/mobc.h
@@ -77,16 +77,17 @@ typedef struct
  * @brief  MOBC初期化
  *
  *         MOBC_Driver 構造体のポインタを渡すことでポートを初期化し， MOBC_Driver の各メンバも初期化する
- * @param  *mobc_driver : 初期化する MOBC_Driver 構造体へのポインタ
- * @param  ch           : MOBCが接続されている UART ポート番号
+ * @param  mobc_driver: 初期化する MOBC_Driver 構造体へのポインタ
+ * @param  ch:          MOBC が接続されている UART ポート番号
+ * @param  rx_buffer:   受信バッファ
  * @return DS_INIT_ERR_CODE
  */
-DS_INIT_ERR_CODE MOBC_init(MOBC_Driver* mobc_driver, uint8_t ch);
+DS_INIT_ERR_CODE MOBC_init(MOBC_Driver* mobc_driver, uint8_t ch, DS_StreamRecBuffer* rx_buffer);
 
 
 /**
  * @brief  MOBC からのデータ（ MOBC → AOBC のコマンド）受信
- * @param  *mobc_driver : MOBC_Driver 構造体へのポインタ
+ * @param  mobc_driver: MOBC_Driver 構造体へのポインタ
  * @return DS_REC_ERR_CODE
  */
 DS_REC_ERR_CODE MOBC_rec(MOBC_Driver* mobc_driver);
@@ -94,8 +95,8 @@ DS_REC_ERR_CODE MOBC_rec(MOBC_Driver* mobc_driver);
 
 /**
  * @brief  MOBC へのデータ（MOBC → AOBCのテレメ）送信
- * @param  *mobc_driver : MOBC_Drive r構造体へのポインタ
- * @param  *packet : 送信する CTP packet
+ * @param  mobc_driver: MOBC_Drive r構造体へのポインタ
+ * @param  packet: 送信する CTP packet
  * @return DS_CMD_ERR_CODE
  */
 DS_CMD_ERR_CODE MOBC_send(MOBC_Driver* mobc_driver, const CommonTlmPacket* packet);

--- a/Examples/2nd_obc_user/src/src_user/Drivers/Etc/mobc.h
+++ b/Examples/2nd_obc_user/src/src_user/Drivers/Etc/mobc.h
@@ -95,7 +95,7 @@ DS_REC_ERR_CODE MOBC_rec(MOBC_Driver* mobc_driver);
 
 /**
  * @brief  MOBC へのデータ（MOBC → AOBCのテレメ）送信
- * @param  mobc_driver: MOBC_Drive r構造体へのポインタ
+ * @param  mobc_driver: MOBC_Driver 構造体へのポインタ
  * @param  packet: 送信する CTP packet
  * @return DS_CMD_ERR_CODE
  */

--- a/Examples/2nd_obc_user/src/src_user/Settings/DriverSuper/driver_buffer_define.h
+++ b/Examples/2nd_obc_user/src/src_user/Settings/DriverSuper/driver_buffer_define.h
@@ -5,6 +5,10 @@
 #ifndef DRIVER_BUFFER_DEFINE_H_
 #define DRIVER_BUFFER_DEFINE_H_
 
-#define DS_STREAM_REC_BUFFER_SIZE_DEFAULT   (1024 * 2)    //!< DS_StreamRecBuffer のバッファサイズのデフォルト値
+#include "./driver_super_params.h"
+
+#define DS_STREAM_REC_BUFFER_SIZE_DEFAULT   (DS_IF_RX_BUFFER_SIZE * 2)    /*!< DS_StreamRecBuffer のバッファサイズのデフォルト値
+                                                                               UART などの非同期通信はメモリに余力があれば DS_IF_RX_BUFFER_SIZE * 2 を推奨
+                                                                               詳細は dirver_super.c の @note を参照 */
 
 #endif

--- a/Examples/minimum_user/src/src_user/Applications/DriverInstances/di_gs.c
+++ b/Examples/minimum_user/src/src_user/Applications/DriverInstances/di_gs.c
@@ -45,8 +45,8 @@ static RESULT DI_GS_init_(void)
   int stream;
   DS_INIT_ERR_CODE ret;
   DS_StreamRecBuffer* ccsds_rx_buffers[DS_STREAM_MAX];
-  DS_nullify_stream_rec_buffers(ccsds_rx_buffers);
   DS_StreamRecBuffer* uart_rx_buffers[DS_STREAM_MAX];
+  DS_nullify_stream_rec_buffers(ccsds_rx_buffers);
   DS_nullify_stream_rec_buffers(uart_rx_buffers);
 
   // GS_RX_HEADER_NUM > DS_STREAM_MAX のアサーションは gs.c でやっているのでここではしない

--- a/Examples/minimum_user/src/src_user/Applications/DriverInstances/di_gs.c
+++ b/Examples/minimum_user/src/src_user/Applications/DriverInstances/di_gs.c
@@ -3,22 +3,13 @@
  * @file
  * @brief GS Driver のインスタンス化
  */
-
 #include "di_gs.h"
-
 #include <src_core/TlmCmd/packet_handler.h>
 #include <src_core/TlmCmd/common_cmd_packet_util.h>
 #include <src_core/Library/print.h>
 #include "../../Drivers/Com/gs_validate.h"
 #include "../../Settings/port_config.h"
-
-static GS_Driver gs_driver_;
-const GS_Driver* const gs_driver = &gs_driver_;
-
-static DI_GS_TlmPacketHandler DI_GS_ms_tlm_packet_handler_; // mission
-const DI_GS_TlmPacketHandler* const DI_GS_ms_tlm_packet_handler = &DI_GS_ms_tlm_packet_handler_;
-static DI_GS_TlmPacketHandler DI_GS_rp_tlm_packet_handler_; // replay tlm
-const DI_GS_TlmPacketHandler* const DI_GS_rp_tlm_packet_handler = &DI_GS_rp_tlm_packet_handler_;
+#include "../../Settings/DriverSuper/driver_buffer_define.h"
 
 // 以下 init と update の定義
 static void DI_GS_cmd_packet_handler_init_(void);
@@ -30,6 +21,21 @@ static void DI_GS_rpt_packet_handler_init_(void);
 static void DI_GS_rpt_packet_handler_(void);
 
 static void DI_GS_set_t2m_flush_interval_(cycle_t flush_interval, DI_GS_TlmPacketHandler* gs_tlm_packet_handler);
+
+static GS_Driver gs_driver_;
+const GS_Driver* const gs_driver = &gs_driver_;
+
+static DI_GS_TlmPacketHandler DI_GS_ms_tlm_packet_handler_; // mission
+const DI_GS_TlmPacketHandler* const DI_GS_ms_tlm_packet_handler = &DI_GS_ms_tlm_packet_handler_;
+static DI_GS_TlmPacketHandler DI_GS_rp_tlm_packet_handler_; // replay tlm
+const DI_GS_TlmPacketHandler* const DI_GS_rp_tlm_packet_handler = &DI_GS_rp_tlm_packet_handler_;
+
+// バッファ
+static DS_StreamRecBuffer DI_GS_ccsds_rx_buffer_[GS_RX_HEADER_NUM];
+static uint8_t DI_GS_ccsds_rx_buffer_allocation_[GS_RX_HEADER_NUM][DS_STREAM_REC_BUFFER_SIZE_DEFAULT];
+static DS_StreamRecBuffer DI_GS_uart_rx_buffer_[GS_RX_HEADER_NUM];
+static uint8_t DI_GS_uart_rx_buffer_allocation_[GS_RX_HEADER_NUM][DS_STREAM_REC_BUFFER_SIZE_DEFAULT];
+
 
 AppInfo DI_GS_cmd_packet_handler(void)
 {
@@ -48,9 +54,36 @@ AppInfo DI_GS_rpt_packet_handler(void)
 
 static void DI_GS_cmd_packet_handler_init_(void)
 {
-  int ret = GS_init(&gs_driver_, PORT_CH_RS422_MOBC_EXT);
+  int stream;
+  DS_INIT_ERR_CODE ret;
+  DS_StreamRecBuffer* ccsds_rx_buffers[DS_STREAM_MAX];
+  DS_nullify_stream_rec_buffers(ccsds_rx_buffers);
+  DS_StreamRecBuffer* uart_rx_buffers[DS_STREAM_MAX];
+  DS_nullify_stream_rec_buffers(uart_rx_buffers);
 
-  if (ret != 0)
+  // GS_RX_HEADER_NUM > DS_STREAM_MAX のアサーションは gs.c でやっているのでここではしない
+  for (stream = 0; stream < GS_RX_HEADER_NUM; ++stream)
+  {
+    DS_ERR_CODE ret1;
+    DS_ERR_CODE ret2;
+    ret1 = DS_init_stream_rec_buffer(&DI_GS_ccsds_rx_buffer_[stream],
+                                     DI_GS_ccsds_rx_buffer_allocation_[stream],
+                                     sizeof(DI_GS_ccsds_rx_buffer_allocation_[stream]));
+    ret2 = DS_init_stream_rec_buffer(&DI_GS_uart_rx_buffer_[stream],
+                                     DI_GS_uart_rx_buffer_allocation_[stream],
+                                     sizeof(DI_GS_uart_rx_buffer_allocation_[stream]));
+    if (ret1 != DS_ERR_CODE_OK || ret2 != DS_ERR_CODE_OK)
+    {
+      Printf("GS buffer init Failed ! %d, %d \n", ret1, ret2);
+      return;
+    }
+    ccsds_rx_buffers[stream] = &DI_GS_ccsds_rx_buffer_[stream];
+    uart_rx_buffers[stream]  = &DI_GS_uart_rx_buffer_[stream];
+  }
+
+  ret = GS_init(&gs_driver_, PORT_CH_RS422_MOBC_EXT, ccsds_rx_buffers, uart_rx_buffers);
+
+  if (ret != DS_INIT_OK)
   {
     Printf("!! GS Init Error %d !!\n", ret);
   }

--- a/Examples/minimum_user/src/src_user/Applications/DriverInstances/di_uart_test.h
+++ b/Examples/minimum_user/src/src_user/Applications/DriverInstances/di_uart_test.h
@@ -9,7 +9,7 @@
 #include <src_core/System/ApplicationManager/app_info.h>
 #include <src_core/TlmCmd/common_cmd_packet.h>
 
-extern const UART_TEST_Driver* uart_test_instance;
+extern const UART_TEST_Driver* const uart_test_instance;
 
 // アプリケーション
 AppInfo UART_TEST_update(void);

--- a/Examples/minimum_user/src/src_user/Drivers/Aocs/aobc.c
+++ b/Examples/minimum_user/src/src_user/Drivers/Aocs/aobc.c
@@ -28,7 +28,7 @@ static DS_ERR_CODE AOBC_load_driver_super_init_settings_(DriverSuper* p_super);
 static DS_ERR_CODE AOBC_analyze_rec_data_(DS_StreamConfig* p_stream_config,
                                           void* p_driver);
 
-DS_INIT_ERR_CODE AOBC_init(AOBC_Driver* aobc_driver, uint8_t ch)
+DS_INIT_ERR_CODE AOBC_init(AOBC_Driver* aobc_driver, uint8_t ch, DS_StreamRecBuffer* rx_buffer)
 {
   DS_ERR_CODE ret;
 

--- a/Examples/minimum_user/src/src_user/Drivers/Aocs/aobc.c
+++ b/Examples/minimum_user/src/src_user/Drivers/Aocs/aobc.c
@@ -12,17 +12,12 @@
 #include <src_core/Drivers/Protocol/eb90_frame_for_driver_super.h>
 #include <src_core/Drivers/Protocol/common_tlm_cmd_packet_for_driver_super.h>
 #include <string.h>
-#include "../../Settings/DriverSuper/driver_buffer_define.h"
 
 #define AOBC_STREAM_TLM_CMD   (0)   //!< テレコマで使うストリーム
 
 static uint8_t AOBC_tx_frame_[EB90_FRAME_HEADER_SIZE +
                               CTCP_MAX_LEN +
                               EB90_FRAME_FOOTER_SIZE];
-
-// バッファ
-static uint8_t AOBC_rx_buffer_allocation_[DS_STREAM_REC_BUFFER_SIZE_DEFAULT];
-static DS_StreamRecBuffer AOBC_rx_buffer_;
 
 static DS_ERR_CODE AOBC_load_driver_super_init_settings_(DriverSuper* p_super);
 static DS_ERR_CODE AOBC_analyze_rec_data_(DS_StreamConfig* p_stream_config,
@@ -43,6 +38,7 @@ DS_INIT_ERR_CODE AOBC_init(AOBC_Driver* aobc_driver, uint8_t ch, DS_StreamRecBuf
 
   ret = DS_init(&(aobc_driver->driver.super),
                 &(aobc_driver->driver.uart_config),
+                rx_buffer,
                 AOBC_load_driver_super_init_settings_);
   if (ret != DS_ERR_CODE_OK) return DS_INIT_DS_INIT_ERR;
   return DS_INIT_OK;
@@ -59,10 +55,6 @@ static DS_ERR_CODE AOBC_load_driver_super_init_settings_(DriverSuper* p_super)
   p_stream_config = &(p_super->stream_config[AOBC_STREAM_TLM_CMD]);
 
   CTCP_init_dssc(p_stream_config, AOBC_tx_frame_, sizeof(AOBC_tx_frame_), AOBC_analyze_rec_data_);
-  DS_init_stream_rec_buffer(&AOBC_rx_buffer_,
-                            AOBC_rx_buffer_allocation_,
-                            sizeof(AOBC_rx_buffer_allocation_));
-  DSSC_set_rx_buffer(p_stream_config, &AOBC_rx_buffer_);
 
   // 定期 TLM の監視機能の有効化しない → ので設定上書きなし
 

--- a/Examples/minimum_user/src/src_user/Drivers/Aocs/aobc.h
+++ b/Examples/minimum_user/src/src_user/Drivers/Aocs/aobc.h
@@ -78,10 +78,11 @@ struct AOBC_Driver
  *
  *         AOBC_Driver 構造体のポインタを渡すことでポートを初期化し， AOBC_Driver の各メンバも初期化する
  * @param  aobc_driver: 初期化する AOBC_Driver 構造体へのポインタ
- * @param  ch         : AOBC が接続されている UART ポート番号
+ * @param  ch:          AOBC が接続されている UART ポート番号
+ * @param  rx_buffer:   受信バッファ
  * @return DS_INIT_ERR_CODE
  */
-DS_INIT_ERR_CODE AOBC_init(AOBC_Driver* aobc_driver, uint8_t ch);
+DS_INIT_ERR_CODE AOBC_init(AOBC_Driver* aobc_driver, uint8_t ch, DS_StreamRecBuffer* rx_buffer);
 
 /**
  * @brief  AOBC のデータ（テレメ）受信
@@ -93,7 +94,7 @@ DS_REC_ERR_CODE AOBC_rec(AOBC_Driver* aobc_driver);
 /**
  * @brief  AOBC へのコマンド送信
  * @param  aobc_driver: AOBC_Driver 構造体へのポインタ
- * @param  packet     : 送信する packet
+ * @param  packet:      送信する packet
  * @return DS_CMD_ERR_CODE
  * @note   これを受信した AOBC C2A は， packet をそのまま PH_analyze_cmd_packet に流せばよい．
  */

--- a/Examples/minimum_user/src/src_user/Drivers/Com/gs.c
+++ b/Examples/minimum_user/src/src_user/Drivers/Com/gs.c
@@ -61,7 +61,7 @@ static void GS_load_default_driver_super_init_settings_(DriverSuper* p_super);
  */
 static DS_ERR_CODE GS_analyze_rec_data_(DS_StreamConfig* p_stream_config, void* p_driver);
 
-DS_INIT_ERR_CODE GS_init(GS_Driver* gs_driver, uint8_t uart_ch)
+DS_INIT_ERR_CODE GS_init(GS_Driver* gs_driver, uint8_t uart_ch, DS_StreamRecBuffer* rx_buffers[DS_STREAM_MAX])
 {
   DS_ERR_CODE ret_uart, ret_ccsds;
   int i;

--- a/Examples/minimum_user/src/src_user/Drivers/Com/gs.c
+++ b/Examples/minimum_user/src/src_user/Drivers/Com/gs.c
@@ -13,13 +13,11 @@
 #include <src_core/TlmCmd/packet_handler.h>
 #include <src_core/TlmCmd/Ccsds/space_packet_typedef.h>
 #include "../../Library/stdint.h"
-#include "../../Settings/DriverSuper/driver_buffer_define.h"
+
 
 #define GS_RX_HEADER_SIZE (2)
 #define GS_RX_FRAMELENGTH_TYPE_SIZE (2)
 #define GS_TX_STREAM (0) // どれでも良いがとりあえず 0 で
-
-#define GS_RX_HEADER_NUM (3)
 
 #if GS_RX_HEADER_NUM > DS_STREAM_MAX
 #error GS RX HEADER NUM TOO MANY
@@ -28,10 +26,6 @@
 // それぞれ AD, BD, BC
 static uint8_t GS_rx_header_[GS_RX_HEADER_NUM][GS_RX_HEADER_SIZE];
 static uint8_t GS_tx_frame_[VCDU_LEN];
-
-// バッファ
-static uint8_t GS_rx_buffer_allocation_[GS_RX_HEADER_NUM][DS_STREAM_REC_BUFFER_SIZE_DEFAULT];
-static DS_StreamRecBuffer GS_rx_buffer_[GS_RX_HEADER_NUM];
 
 /**
  * @brief CCSDS 側 Driver の DS 上での初期化設定
@@ -61,10 +55,14 @@ static void GS_load_default_driver_super_init_settings_(DriverSuper* p_super);
  */
 static DS_ERR_CODE GS_analyze_rec_data_(DS_StreamConfig* p_stream_config, void* p_driver);
 
-DS_INIT_ERR_CODE GS_init(GS_Driver* gs_driver, uint8_t uart_ch, DS_StreamRecBuffer* rx_buffers[DS_STREAM_MAX])
+DS_INIT_ERR_CODE GS_init(GS_Driver* gs_driver,
+                         uint8_t uart_ch,
+                         DS_StreamRecBuffer* ccsds_rx_buffers[DS_STREAM_MAX],
+                         DS_StreamRecBuffer* uart_rx_buffers[DS_STREAM_MAX])
 {
   DS_ERR_CODE ret_uart, ret_ccsds;
   int i;
+  int stream;
 
   memset(gs_driver, 0x00, sizeof(GS_Driver));
 
@@ -83,14 +81,20 @@ DS_INIT_ERR_CODE GS_init(GS_Driver* gs_driver, uint8_t uart_ch, DS_StreamRecBuff
   GS_rx_header_[0][0] |= (uint8_t)((TCTF_TYPE_AD & 0x0f) << 4);
   GS_rx_header_[1][0] |= (uint8_t)((TCTF_TYPE_BD & 0x0f) << 4);
   GS_rx_header_[2][0] |= (uint8_t)((TCTF_TYPE_BC & 0x0f) << 4);
-  for (i = 0; i < GS_RX_HEADER_NUM; ++i)
+  for (stream = 0; stream < GS_RX_HEADER_NUM; ++stream)
   {
-    GS_rx_header_[i][0] |= (uint8_t)((TCTF_SCID_SAMPLE_SATELLITE & 0x3ff) >> 8);
-    GS_rx_header_[i][1] |= (uint8_t)(TCTF_SCID_SAMPLE_SATELLITE & 0xff);
+    GS_rx_header_[stream][0] |= (uint8_t)((TCTF_SCID_SAMPLE_SATELLITE & 0x3ff) >> 8);
+    GS_rx_header_[stream][1] |= (uint8_t)(TCTF_SCID_SAMPLE_SATELLITE & 0xff);
   }
 
-  ret_ccsds = DS_init(&gs_driver->driver_ccsds.super, &gs_driver->driver_ccsds.ccsds_config, GS_load_ccsds_driver_super_init_settings_);
-  ret_uart  = DS_init(&gs_driver->driver_uart.super, &gs_driver->driver_uart.uart_config, GS_load_uart_driver_super_init_settings_);
+  ret_ccsds = DS_init_streams(&gs_driver->driver_ccsds.super,
+                              &gs_driver->driver_ccsds.ccsds_config,
+                              ccsds_rx_buffers,
+                              GS_load_ccsds_driver_super_init_settings_);
+  ret_uart  = DS_init_streams(&gs_driver->driver_uart.super,
+                              &gs_driver->driver_uart.uart_config,
+                              uart_rx_buffers,
+                              GS_load_uart_driver_super_init_settings_);
   if (ret_ccsds != DS_ERR_CODE_OK || ret_uart != DS_ERR_CODE_OK) return DS_INIT_DS_INIT_ERR;
   gs_driver->latest_info = &gs_driver->info[GS_PORT_TYPE_CCSDS];
   gs_driver->tlm_tx_port_type = GS_PORT_TYPE_CCSDS;
@@ -155,11 +159,6 @@ static void GS_load_default_driver_super_init_settings_(DriverSuper* p_super)
     DSSC_set_rx_framelength_type_size(p_stream_config, GS_RX_FRAMELENGTH_TYPE_SIZE);
     DSSC_set_rx_framelength_offset(p_stream_config, 1); // TCTF の framelength は 0 起算
     DSSC_set_data_analyzer(p_stream_config, GS_analyze_rec_data_);
-
-    DS_init_stream_rec_buffer(&GS_rx_buffer_[stream],
-                              GS_rx_buffer_allocation_[stream],
-                              sizeof(GS_rx_buffer_allocation_[stream]));
-    DSSC_set_rx_buffer(p_stream_config, &GS_rx_buffer_[stream]);
   }
 }
 

--- a/Examples/minimum_user/src/src_user/Drivers/Com/gs.h
+++ b/Examples/minimum_user/src/src_user/Drivers/Com/gs.h
@@ -13,6 +13,8 @@
 #include "../../TlmCmd/Ccsds/vcdu.h"
 #include "gs_validate.h"
 
+#define GS_RX_HEADER_NUM (3)
+
 /**
  * @enum  GS_PORT_TYPE
  * @brief GS の通信ポートは CCSDS と UART の 2 つある
@@ -85,12 +87,16 @@ typedef struct
 
 /**
  * @brief Driver の初期化
- * @param[in] gs_driver:  ドライバー
- * @param[in] uart_ch:    有線通信時の CH
- * @param[in] rx_buffers: 受信バッファ
+ * @param[in] gs_driver:        ドライバー
+ * @param[in] uart_ch:          有線通信時の CH
+ * @param[in] ccsds_rx_buffers: CCSDS 用受信バッファ
+ * @param[in] uart_rx_buffers:  UART 用受信バッファ
  * @return DS_INIT_ERR_CODE
  */
-DS_INIT_ERR_CODE GS_init(GS_Driver* gs_driver, uint8_t uart_ch, DS_StreamRecBuffer* rx_buffers[DS_STREAM_MAX]);
+DS_INIT_ERR_CODE GS_init(GS_Driver* gs_driver,
+                         uint8_t uart_ch,
+                         DS_StreamRecBuffer* ccsds_rx_buffers[DS_STREAM_MAX],
+                         DS_StreamRecBuffer* uart_rx_buffers[DS_STREAM_MAX]);
 
 /**
  * @brief 地上から CMD を受信する. 形式は TC Transer Frame

--- a/Examples/minimum_user/src/src_user/Drivers/Com/gs.h
+++ b/Examples/minimum_user/src/src_user/Drivers/Com/gs.h
@@ -85,10 +85,12 @@ typedef struct
 
 /**
  * @brief Driver の初期化
- * @param[in] uart_ch: 有線通信時の CH
+ * @param[in] gs_driver:  ドライバー
+ * @param[in] uart_ch:    有線通信時の CH
+ * @param[in] rx_buffers: 受信バッファ
  * @return DS_INIT_ERR_CODE
  */
-DS_INIT_ERR_CODE GS_init(GS_Driver* gs_driver, uint8_t uart_ch);
+DS_INIT_ERR_CODE GS_init(GS_Driver* gs_driver, uint8_t uart_ch, DS_StreamRecBuffer* rx_buffers[DS_STREAM_MAX]);
 
 /**
  * @brief 地上から CMD を受信する. 形式は TC Transer Frame
@@ -102,7 +104,7 @@ DS_REC_ERR_CODE GS_rec_tctf(GS_Driver* gs_driver);
  * @note  DS_send_general_cmd が使われているが, これは DS は MOBC コンポ間を想定しているため, MOBC から見るとコンポに cmd を送信している様に見える, が 今回は MOBC から地上に TLM を送信している
  * @note TLM 送信, 形式は VCDU
  * @param[in] gs_driver: ドライバー
- * @param[in] vcdu: 送信する VCDU. 場合によってはそのまま DS に渡すので， local変数ではなくstaticな変数を渡すこと
+ * @param[in] vcdu:      送信する VCDU. 場合によってはそのまま DS に渡すので， local変数ではなくstaticな変数を渡すこと
  * @return DS_CMD_ERR_CODE: 送信結果
  */
 DS_CMD_ERR_CODE GS_send_vcdu(GS_Driver* gs_driver, const VCDU* vcdu);

--- a/Examples/minimum_user/src/src_user/Drivers/Etc/uart_test.c
+++ b/Examples/minimum_user/src/src_user/Drivers/Etc/uart_test.c
@@ -36,7 +36,7 @@ static DS_ERR_CODE UART_TEST_load_driver_super_init_settings_(DriverSuper* p_sup
 static DS_ERR_CODE UART_TEST_analyze_rec_data_(DS_StreamConfig* p_stream_config, void* p_driver);
 
 
-DS_INIT_ERR_CODE UART_TEST_init(UART_TEST_Driver* uart_test_instance, unsigned char ch)
+DS_INIT_ERR_CODE UART_TEST_init(UART_TEST_Driver* uart_test_instance, uint8_t ch, DS_StreamRecBuffer* rx_buffers[DS_STREAM_MAX])
 {
   DS_ERR_CODE ret;
 

--- a/Examples/minimum_user/src/src_user/Drivers/Etc/uart_test.c
+++ b/Examples/minimum_user/src/src_user/Drivers/Etc/uart_test.c
@@ -10,13 +10,11 @@
 #include "../../Settings/sils_define.h"
 #include "string.h"   // for memcpy
 #include <stdio.h>    // SILSでのprint
-#include "../../Settings/DriverSuper/driver_buffer_define.h"
 
 // ヘッダーフッター
 #define UART_TEST_HEADER_SIZE        (8)
 #define UART_TEST_FOOTER_SIZE        (2)
 #define UART_TEST_TX_FRAME_SIZE_MAX  (16)
-
 
 static const uint8_t UART_TEST_header_[UART_TEST_HEADER_SIZE] = {0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xA6, 0xA7};
 static const uint8_t UART_TEST_footer_[UART_TEST_FOOTER_SIZE] = {0xBF, 0xBE};
@@ -25,12 +23,6 @@ static const uint8_t UART_TEST_footer_[UART_TEST_FOOTER_SIZE] = {0xBF, 0xBE};
 #define UART_TEST_STREAM_VAR   (1)   //!< 可変長
 
 static uint8_t UART_TEST_tx_frame_[UART_TEST_TX_FRAME_SIZE_MAX];
-
-// バッファ
-static uint8_t UART_TEST_rx_buffer_allocation_0_[DS_STREAM_REC_BUFFER_SIZE_DEFAULT];
-static uint8_t UART_TEST_rx_buffer_allocation_1_[DS_STREAM_REC_BUFFER_SIZE_DEFAULT];
-static DS_StreamRecBuffer UART_TEST_rx_buffer_0_;
-static DS_StreamRecBuffer UART_TEST_rx_buffer_1_;
 
 static DS_ERR_CODE UART_TEST_load_driver_super_init_settings_(DriverSuper* p_super);
 static DS_ERR_CODE UART_TEST_analyze_rec_data_(DS_StreamConfig* p_stream_config, void* p_driver);
@@ -46,7 +38,10 @@ DS_INIT_ERR_CODE UART_TEST_init(UART_TEST_Driver* uart_test_instance, uint8_t ch
   uart_test_instance->driver.uart_config.data_length = UART_DATA_LENGTH_8BIT;
   uart_test_instance->driver.uart_config.stop_bit = UART_STOP_BIT_1BIT;
 
-  ret = DS_init(&(uart_test_instance->driver.super), &(uart_test_instance->driver.uart_config), UART_TEST_load_driver_super_init_settings_);
+  ret = DS_init_streams(&(uart_test_instance->driver.super),
+                        &(uart_test_instance->driver.uart_config),
+                        rx_buffers,
+                        UART_TEST_load_driver_super_init_settings_);
   if (ret != DS_ERR_CODE_OK) return DS_INIT_DS_INIT_ERR;
   return DS_INIT_OK;
 }
@@ -73,11 +68,6 @@ static DS_ERR_CODE UART_TEST_load_driver_super_init_settings_(DriverSuper* p_sup
   DSSC_set_rx_frame_size(p_stream_config, 12);
   DSSC_set_data_analyzer(p_stream_config, UART_TEST_analyze_rec_data_);
 
-  DS_init_stream_rec_buffer(&UART_TEST_rx_buffer_0_,
-                            UART_TEST_rx_buffer_allocation_0_,
-                            sizeof(UART_TEST_rx_buffer_allocation_0_));
-  DSSC_set_rx_buffer(p_stream_config, &UART_TEST_rx_buffer_0_);
-
   // stream1の設定
   p_stream_config = &(p_super->stream_config[UART_TEST_STREAM_VAR]);
   DSSC_enable(p_stream_config);
@@ -93,11 +83,6 @@ static DS_ERR_CODE UART_TEST_load_driver_super_init_settings_(DriverSuper* p_sup
   DSSC_set_rx_framelength_type_size(p_stream_config, 2);
   DSSC_set_rx_framelength_offset(p_stream_config, UART_TEST_HEADER_SIZE + UART_TEST_FOOTER_SIZE);
   DSSC_set_data_analyzer(p_stream_config, UART_TEST_analyze_rec_data_);
-
-  DS_init_stream_rec_buffer(&UART_TEST_rx_buffer_1_,
-                            UART_TEST_rx_buffer_allocation_1_,
-                            sizeof(UART_TEST_rx_buffer_allocation_1_));
-  DSSC_set_rx_buffer(p_stream_config, &UART_TEST_rx_buffer_1_);
 
   // 定期TLMの監視機能の有効化しない → ので設定上書きなし
 

--- a/Examples/minimum_user/src/src_user/Drivers/Etc/uart_test.h
+++ b/Examples/minimum_user/src/src_user/Drivers/Etc/uart_test.h
@@ -47,7 +47,7 @@ DS_INIT_ERR_CODE UART_TEST_init(UART_TEST_Driver* uart_test_instance, uint8_t ch
 
 /**
  * @brief  UART_TESTのデータ（テレメ）受信
- * @param  *uart_test_instance: UART_TEST_Driver構造体へのポインタ
+ * @param  uart_test_instance: UART_TEST_Driver構造体へのポインタ
  * @return DS_REC_ERR_CODE
  */
 DS_REC_ERR_CODE UART_TEST_rec(UART_TEST_Driver* uart_test_instance);

--- a/Examples/minimum_user/src/src_user/Drivers/Etc/uart_test.h
+++ b/Examples/minimum_user/src/src_user/Drivers/Etc/uart_test.h
@@ -38,23 +38,24 @@ typedef struct
  * @brief  UART_TEST初期化
  *
  *         UART_TEST_Driver構造体のポインタを渡すことでポートを初期化し，UART_TEST_Driverの各メンバも初期化する
- * @param  *uart_test_instance : 初期化するUART_TEST_Driver構造体へのポインタ
- * @param  ch    : UART_TESTが接続されているUARTポート番号
+ * @param  uart_test_instance: 初期化するUART_TEST_Driver構造体へのポインタ
+ * @param  ch:                 UART_TESTが接続されているUARTポート番号
+ * @param  rx_buffers:         受信バッファ
  * @return DS_INIT_ERR_CODE
  */
-DS_INIT_ERR_CODE UART_TEST_init(UART_TEST_Driver* uart_test_instance, unsigned char ch);
+DS_INIT_ERR_CODE UART_TEST_init(UART_TEST_Driver* uart_test_instance, uint8_t ch, DS_StreamRecBuffer* rx_buffers[DS_STREAM_MAX]);
 
 /**
  * @brief  UART_TESTのデータ（テレメ）受信
- * @param  *uart_test_instance : UART_TEST_Driver構造体へのポインタ
+ * @param  *uart_test_instance: UART_TEST_Driver構造体へのポインタ
  * @return DS_REC_ERR_CODE
  */
 DS_REC_ERR_CODE UART_TEST_rec(UART_TEST_Driver* uart_test_instance);
 
 /**
  * @brief  UART_TESTへのコマンド送信
- * @param  *uart_test_instance   : UART_TEST_Driver構造体へのポインタ
- * @param  id      : Cmd id
+ * @param  uart_test_instance: UART_TEST_Driver構造体へのポインタ
+ * @param  id:                 Cmd id
  * @return DS_CMD_ERR_CODE
  */
 DS_CMD_ERR_CODE UART_TEST_send(UART_TEST_Driver* uart_test_instance, uint8_t id);

--- a/Examples/minimum_user/src/src_user/Settings/DriverSuper/driver_buffer_define.h
+++ b/Examples/minimum_user/src/src_user/Settings/DriverSuper/driver_buffer_define.h
@@ -5,6 +5,10 @@
 #ifndef DRIVER_BUFFER_DEFINE_H_
 #define DRIVER_BUFFER_DEFINE_H_
 
-#define DS_STREAM_REC_BUFFER_SIZE_DEFAULT   (1024 * 2)    //!< DS_StreamRecBuffer のバッファサイズのデフォルト値
+#include "./driver_super_params.h"
+
+#define DS_STREAM_REC_BUFFER_SIZE_DEFAULT   (DS_IF_RX_BUFFER_SIZE * 2)    /*!< DS_StreamRecBuffer のバッファサイズのデフォルト値
+                                                                               UART などの非同期通信はメモリに余力があれば DS_IF_RX_BUFFER_SIZE * 2 を推奨
+                                                                               詳細は dirver_super.c の @note を参照 */
 
 #endif


### PR DESCRIPTION
## 概要
DS での rx_buffer を stream ごとに driver instance から設定可能にする

## Issue
- https://github.com/ut-issl/c2a-core/issues/443
- https://github.com/ut-issl/c2a-core/issues/154
- https://github.com/ut-issl/c2a-core/issues/468

## 詳細
Driverが持っていた DS の rx buffer を DI で生成し，Driver に渡すようにした．
これによって，同一 Driver で複数の DI を持つコンポに対応

## 検証結果
既存のテストがすべて通る

## 影響範囲
DI，Driverの初期化がすべて変わる

## 備考
- https://github.com/ut-issl/c2a-core/pull/504 を先にマージする
