### PR TITLE
Pre Release (v3.8.0-beta.5): DS に受信フレームの最大値の設定を追加

### DIFF
--- a/Drivers/Protocol/common_tlm_cmd_packet_for_driver_super.c
+++ b/Drivers/Protocol/common_tlm_cmd_packet_for_driver_super.c
@@ -59,7 +59,10 @@ DS_ERR_CODE CTCP_init_dssc(DS_StreamConfig* p_stream_config,
                            int16_t tx_frame_buffer_size,
                            DS_ERR_CODE (*data_analyzer)(DS_StreamConfig* p_stream_config, void* p_driver))
 {
-  if (tx_frame_buffer_size < EB90_FRAME_HEADER_SIZE + CTCP_MAX_LEN + EB90_FRAME_FOOTER_SIZE)
+  // MOBC か 2nd OBC かによって，送信側 (tx 側) が CTP になるか CCP になるかは不明なため，ひとまず CTCP に
+  // メモリが苦しい OBC もあるので，考えてもいいかも
+  const uint16_t max_frame_size = EB90_FRAME_HEADER_SIZE + CTCP_MAX_LEN + EB90_FRAME_FOOTER_SIZE;
+  if (tx_frame_buffer_size < max_frame_size)
   {
     return DS_ERR_CODE_ERR;
   }
@@ -73,6 +76,7 @@ DS_ERR_CODE CTCP_init_dssc(DS_StreamConfig* p_stream_config,
   DSSC_set_rx_header(p_stream_config, EB90_FRAME_kStx, EB90_FRAME_STX_SIZE);
   DSSC_set_rx_footer(p_stream_config, EB90_FRAME_kEtx, EB90_FRAME_ETX_SIZE);
   DSSC_set_rx_frame_size(p_stream_config, -1);          // 可変
+  DSSC_set_max_rx_frame_size(p_stream_config, max_frame_size);
   DSSC_set_rx_framelength_pos(p_stream_config, EB90_FRAME_STX_SIZE);
   DSSC_set_rx_framelength_type_size(p_stream_config, 2);
   DSSC_set_rx_framelength_offset(p_stream_config,

--- a/Drivers/Super/driver_super.c
+++ b/Drivers/Super/driver_super.c
@@ -950,7 +950,7 @@ static void DS_analyze_rx_buffer_variable_pickup_with_footer_(DS_StreamConfig* p
 
     if (p_footer_last == NULL)
     {
-      // まだフッタまで候補まで受信していない → 受信データはすべて今回のフレームとして確定
+      // まだフッタ候補まで受信していない → 受信データはすべて今回のフレームとして確定
       processed_data_len = unprocessed_data_len;
     }
     else

--- a/Drivers/Super/driver_super.h
+++ b/Drivers/Super/driver_super.h
@@ -327,9 +327,14 @@ struct DS_StreamConfig
                                                                    ヘッダがない場合は0に設定
                                                                    初期値: 0 */
     int16_t  rx_frame_size_;                                  /*!< 受信データ（テレメトリ）フレームサイズ
-                                                                   受信データがない場合は0に設定
+                                                                   受信データがない場合は 0 に設定
                                                                    受信データが可変の場合は負数に設定
                                                                    初期値: 0 */
+    uint16_t max_rx_frame_size_;                              /*!< 受信データ（テレメトリ）の想定される最大フレームサイズ
+                                                                   これよりも長いフレームが来た（来そうな）場合は，そのフレーム（候補）は破棄される
+                                                                   これにより，ヘッダ内部のフレーム長が巨大な値に化けていた場合などに永遠に受信してしまうことを防ぐことができる
+                                                                   rx_frame_size_ が固定長の場合は無視される
+                                                                   初期値: 0xffff */
     int16_t  rx_framelength_pos_;                             /*!< 受信データ内のフレームサイズデータの存在する場所（先頭から数えて何 byte 目に位置するか．0 起算）
                                                                    受信データが可変長の場合のみ使用される．
                                                                    フレームサイズデータがない場合には負に設定する．
@@ -589,6 +594,9 @@ uint16_t DSSC_get_rx_footer_size(const DS_StreamConfig* p_stream_config);
 int16_t DSSC_get_rx_frame_size(const DS_StreamConfig* p_stream_config);
 void DSSC_set_rx_frame_size(DS_StreamConfig* p_stream_config,
                             const int16_t rx_frame_size);
+uint16_t DSSC_get_max_rx_frame_size(const DS_StreamConfig* p_stream_config);
+void DSSC_set_max_rx_frame_size(DS_StreamConfig* p_stream_config,
+                            const uint16_t max_rx_frame_size);
 
 void DSSC_set_rx_framelength_pos(DS_StreamConfig* p_stream_config,
                                  const int16_t rx_framelength_pos);

--- a/c2a_core_main.h
+++ b/c2a_core_main.h
@@ -10,6 +10,6 @@ void C2A_core_main(void);
 #define C2A_CORE_VER_MAJOR (3)
 #define C2A_CORE_VER_MINOR (8)
 #define C2A_CORE_VER_PATCH (0)
-#define C2A_CORE_VER_PRE   ("beta.4")
+#define C2A_CORE_VER_PRE   ("beta.5")
 
 #endif


### PR DESCRIPTION
## 概要
Pre Release (v3.8.0-beta.5): DS に受信フレームの最大値の設定を追加

## Issue
- https://github.com/ut-issl/c2a-core/issues/496
- https://github.com/ut-issl/c2a-core/issues/468

## 詳細
issue と driver_super.h で diff にでるコメントを参照

## 検証結果
CIとすべてのテストが通った

## 補足
- https://github.com/ut-issl/c2a-core/pull/507 を先にマージする
- これで Driver Super, DS の大きな改修が一段落するので，Pre Release を打つ
- [x] したがって，マージする前にバージョンを上げる
