### PR TITLE
Pre Release (v3.8.0-beta.6): v3.8.0-beta.5 で追加された不適切なバリデーションの除去

### DIFF
--- a/Drivers/Super/driver_super.c
+++ b/Drivers/Super/driver_super.c
@@ -1289,7 +1289,9 @@ static DS_ERR_CODE DS_validate_stream_config_(const DriverSuper* p_super, DS_Str
 
   if (p->settings.rx_buffer_ == NULL) return DS_ERR_CODE_ERR;
   if (p->settings.rx_buffer_->buffer == NULL) return DS_ERR_CODE_ERR;
-  if (p->settings.rx_buffer_->capacity < p_super->config.settings.rx_buffer_size_in_if_rx_) return DS_ERR_CODE_ERR;
+  // ↓ rx_buffer_size_in_if_rx_ が初期値の場合，大抵の場合ここで ERR となってしまう．
+  // rx_buffer_size_in_if_rx_ は通信中のビット反転で len の情報がおかしくなったときなど用なので， capacity との比較は一旦なしに
+  // if (p->settings.rx_buffer_->capacity < p_super->config.settings.rx_buffer_size_in_if_rx_) return DS_ERR_CODE_ERR;
   if (p->settings.rx_buffer_->capacity < p->settings.rx_frame_size_) return DS_ERR_CODE_ERR;
   if (p->settings.rx_buffer_->capacity < p->settings.rx_header_size_ + p->settings.rx_footer_size_) return DS_ERR_CODE_ERR;
 


### PR DESCRIPTION
## 概要
Pre Release (v3.8.0-beta.6): v3.8.0-beta.5 で追加された不適切なバリデーションの除去

## Issue
- https://github.com/ut-issl/c2a-core/pull/508

## 詳細
`rx_buffer_size_in_if_rx_` が初期値だとDSの初期化に失敗してしまう