### PR TITLE
Fix USE_SIMPLE_LIBC option definition to top

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ option(USE_ALL_C2A_CORE_TEST_APPS   "use C2A-core all Test Applications" ON)
 option(USE_ALL_C2A_CORE_LIB         "use C2A-core all Library" ON)
 option(USE_32BIT_COMPILER           "use 32bit compiler" OFF)
 
+option(C2A_USE_SIMPLE_LIBC          "use C2A-core hosted simple libc implementation" OFF)
+
 option(BUILD_C2A_AS_SILS_FW         "build C2A as SILS firmware" ON)
 option(BUILD_C2A_AS_CXX             "build C2A as C++" OFF)
 option(BUILD_C2A_AS_UTF8            "build C2A as UTF-8" ON)

--- a/Library/CMakeLists.txt
+++ b/Library/CMakeLists.txt
@@ -2,8 +2,6 @@ cmake_minimum_required(VERSION 3.13)
 
 project(C2A_CORE_LIB)
 
-option(C2A_USE_SIMPLE_LIBC "use C2A-core hosted simple libc implementation" OFF)
-
 if(C2A_USE_SIMPLE_LIBC)
   message("use simple libc!!!")
   set(C2A_LIBC_SRC


### PR DESCRIPTION
## 概要
CMake のオプション定義が深い階層にあると適切に動作しない場合があるので，top の `CMakeLists.txt` に移す

