### PR TITLE
Pre Release (v3.9.0-beta.2): Split C89 compile option to BUILD_C2A_AS_C99

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ option(C2A_USE_SIMPLE_LIBC          "use C2A-core hosted simple libc implementat
 option(C2A_USE_C99_STDINT           "use C99 standard stdint.h" ON)
 
 option(BUILD_C2A_AS_SILS_FW         "build C2A as SILS firmware" ON)
+option(BUILD_C2A_AS_C89             "build C2A as C89" ON)
 option(BUILD_C2A_AS_CXX             "build C2A as C++" OFF)
 option(BUILD_C2A_AS_UTF8            "build C2A as UTF-8" ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ option(C2A_USE_SIMPLE_LIBC          "use C2A-core hosted simple libc implementat
 option(C2A_USE_C99_STDINT           "use C99 standard stdint.h" ON)
 
 option(BUILD_C2A_AS_SILS_FW         "build C2A as SILS firmware" ON)
-option(BUILD_C2A_AS_C89             "build C2A as C89" ON)
+option(BUILD_C2A_AS_C99             "build C2A as C99" OFF)
 option(BUILD_C2A_AS_CXX             "build C2A as C++" OFF)
 option(BUILD_C2A_AS_UTF8            "build C2A as UTF-8" ON)
 

--- a/c2a_core_main.h
+++ b/c2a_core_main.h
@@ -10,6 +10,6 @@ void C2A_core_main(void);
 #define C2A_CORE_VER_MAJOR (3)
 #define C2A_CORE_VER_MINOR (9)
 #define C2A_CORE_VER_PATCH (0)
-#define C2A_CORE_VER_PRE   ("beta.1")
+#define C2A_CORE_VER_PRE   ("beta.2")
 
 #endif

--- a/common.cmake
+++ b/common.cmake
@@ -2,16 +2,18 @@ if(BUILD_C2A_AS_CXX)
   # memo: set_source_files_properties() must be set before add_library/add_executable on Visual Studio CMake
   set_source_files_properties(${C2A_SRCS} PROPERTIES LANGUAGE CXX)  # C++
 else()
-  if (CMAKE_C_COMPILER_ID STREQUAL "Clang")
-    # TODO: remove this!
-    # -Wno-commentが`std=c90`の後に来る必要があるのでC89のうちはこうするしかない
-    target_compile_options(${PROJECT_NAME} PUBLIC "-std=c90")
-  else()
-    set_target_properties(${PROJECT_NAME} PROPERTIES C_STANDARD 90) # C89
-    # TODO: set always!
-    # GNU拡張を禁止すると1行コメントがエラーになる
-    if(NOT CMAKE_C_COMPILER_ID STREQUAL "GNU")
-      set_target_properties(${PROJECT_NAME} PROPERTIES C_EXTENSIONS FALSE) # no extensions(GNU)
+  if(BUILD_C2A_AS_C89)
+    if (CMAKE_C_COMPILER_ID STREQUAL "Clang")
+      # TODO: remove this!
+      # -Wno-commentが`std=c90`の後に来る必要があるのでC89のうちはこうするしかない
+      target_compile_options(${PROJECT_NAME} PUBLIC "-std=c90")
+    else()
+      set_target_properties(${PROJECT_NAME} PROPERTIES C_STANDARD 90) # C89
+      # TODO: set always!
+      # GNU拡張を禁止すると1行コメントがエラーになる
+      if(NOT CMAKE_C_COMPILER_ID STREQUAL "GNU")
+        set_target_properties(${PROJECT_NAME} PROPERTIES C_EXTENSIONS FALSE) # no extensions(GNU)
+      endif()
     endif()
   endif()
 endif()

--- a/common.cmake
+++ b/common.cmake
@@ -15,6 +15,8 @@ else()
         set_target_properties(${PROJECT_NAME} PROPERTIES C_EXTENSIONS FALSE) # no extensions(GNU)
       endif()
     endif()
+  else()
+    set_target_properties(${PROJECT_NAME} PROPERTIES C_STANDARD 99) # C99
   endif()
 endif()
 

--- a/common.cmake
+++ b/common.cmake
@@ -2,7 +2,9 @@ if(BUILD_C2A_AS_CXX)
   # memo: set_source_files_properties() must be set before add_library/add_executable on Visual Studio CMake
   set_source_files_properties(${C2A_SRCS} PROPERTIES LANGUAGE CXX)  # C++
 else()
-  if(BUILD_C2A_AS_C89)
+  if(BUILD_C2A_AS_C99)
+    set_target_properties(${PROJECT_NAME} PROPERTIES C_STANDARD 99) # C99
+  else()
     if (CMAKE_C_COMPILER_ID STREQUAL "Clang")
       # TODO: remove this!
       # -Wno-commentが`std=c90`の後に来る必要があるのでC89のうちはこうするしかない
@@ -15,8 +17,6 @@ else()
         set_target_properties(${PROJECT_NAME} PROPERTIES C_EXTENSIONS FALSE) # no extensions(GNU)
       endif()
     endif()
-  else()
-    set_target_properties(${PROJECT_NAME} PROPERTIES C_STANDARD 99) # C99
   endif()
 endif()
 


### PR DESCRIPTION
## 概要
Pre Release (v3.9.0-beta.2): Split C89 compile option to BUILD_C2A_AS_C99

C99 のためのコンパイルオプションの指定を `BUILD_C2A_AS_C99` に分割する

## Issue/PR
- #102 
- Resolve #526

## 詳細
- C99 のためのコンパイルオプションを隔離し，`BUILD_C2A_AS_C99` という CMake オプションに分割
- `BUILD_C2A_AS_C99` は c2a-core では default OFF とする（C89 な C2A user が存在するため）
- `BUILD_C2A_AS_C99 = ON` のとき，C99 としてビルドする
  - C89 である必要の無い C2A user では必ずこれを設定するようにし，C99 に寄せていく


## 影響範囲
C99 でビルドしており，かつ，#526 のような雑な `common.cmake` を書いていた C2A user のみ `BUILD_C2A_AS_C99=ON` にする対応が必要（ただし，これをしていた場合 clang で意図した挙動になっていないため，このパッチを取り込む必要がある）

## 補足
- [ ] Pre Release を打つ
- [x]  マージする前にバージョンを上げる


