### PR TITLE
S2E Build CI で使われる S2E Core のバージョンを上げる

### DIFF
--- a/.github/workflows/build_with_s2e.yml
+++ b/.github/workflows/build_with_s2e.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 env:
-  S2E_CORE_VERSION: v5.0.0
+  S2E_CORE_VERSION: v6.0.0
 
 jobs:
   build_s2e_win:


### PR DESCRIPTION
## 概要
S2E Build CI で使われる S2E Core のバージョンを上げる

## Issue
- 関連する issue

## 詳細
- https://github.com/ut-issl/c2a-core/pull/533 で CI がこけたので，なおす．
- https://github.com/ut-issl/s2e-user-for-c2a-core/pull/27 によって，使われる S2E core が v6.0.0 に

## 検証結果
CI が通ればOK