### PR TITLE
APID_is_other_obc_tlm_apid の削除

### DIFF
--- a/Examples/2nd_obc_user/src/src_user/Settings/TlmCmd/Ccsds/apid_define.c
+++ b/Examples/2nd_obc_user/src/src_user/Settings/TlmCmd/Ccsds/apid_define.c
@@ -27,18 +27,4 @@ APID APID_get_apid_from_uint16(uint16_t apid)
   }
 }
 
-int APID_is_other_obc_tlm_apid(APID apid)
-{
-  switch (apid)
-  {
-  // FIXME: 2nd obc の場合は変更しなければいけないが， https://github.com/ut-issl/c2a-core/issues/489 で消えるので一旦このまま
-  case APID_AOBC_TLM:   // FALLTHROUGH
-  case APID_TOBC_TLM:
-    return 1;
-
-  default:
-    return 0;
-  }
-}
-
 #pragma section

--- a/Examples/2nd_obc_user/src/src_user/Settings/TlmCmd/Ccsds/apid_define.h
+++ b/Examples/2nd_obc_user/src/src_user/Settings/TlmCmd/Ccsds/apid_define.h
@@ -36,13 +36,4 @@ typedef enum
  */
 APID APID_get_apid_from_uint16(uint16_t apid);
 
-/**
- * @brief  入力した APID が他の OBC で生成された TLM の APID かどうか
- * @param  apid: APID
- * @note   不正な APID は 0 を返す
- * @retval 1: 他 OBC で生成された TLM の APID
- * @retval 0: それ以外の APID
- */
-int APID_is_other_obc_tlm_apid(APID apid);
-
 #endif

--- a/Examples/minimum_user/src/src_user/Settings/TlmCmd/Ccsds/apid_define.c
+++ b/Examples/minimum_user/src/src_user/Settings/TlmCmd/Ccsds/apid_define.c
@@ -27,18 +27,4 @@ APID APID_get_apid_from_uint16(uint16_t apid)
   }
 }
 
-int APID_is_other_obc_tlm_apid(APID apid)
-{
-  switch (apid)
-  {
-  // FIXME: 2nd obc の場合は変更しなければいけないが， https://github.com/ut-issl/c2a-core/issues/489 で消えるので一旦このまま
-  case APID_AOBC_TLM:   // FALLTHROUGH
-  case APID_TOBC_TLM:
-    return 1;
-
-  default:
-    return 0;
-  }
-}
-
 #pragma section

--- a/Examples/minimum_user/src/src_user/Settings/TlmCmd/Ccsds/apid_define.h
+++ b/Examples/minimum_user/src/src_user/Settings/TlmCmd/Ccsds/apid_define.h
@@ -36,13 +36,4 @@ typedef enum
  */
 APID APID_get_apid_from_uint16(uint16_t apid);
 
-/**
- * @brief  入力した APID が他の OBC で生成された TLM の APID かどうか
- * @param  apid: APID
- * @note   不正な APID は 0 を返す
- * @retval 1: 他 OBC で生成された TLM の APID
- * @retval 0: それ以外の APID
- */
-int APID_is_other_obc_tlm_apid(APID apid);
-
 #endif

--- a/TlmCmd/telemetry_generator.c
+++ b/TlmCmd/telemetry_generator.c
@@ -55,7 +55,7 @@ CCP_CmdRet Cmd_GENERATE_TLM(const CommonCmdPacket* packet)
   if (ack != TF_TLM_FUNC_ACK_SUCCESS) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
 
   // Header
-  if (CTP_get_apid(&ctp_) != (APID)(APID_UNKNOWN & 0x7ff))    // FIXME: APID_UNKNOWN = APID_FILL_PKT + 1 だと 11 bit から溢れてる...
+  if ((APID)(CTP_get_apid(&ctp_) & 0x7ff) != (APID)(APID_UNKNOWN & 0x7ff))    // FIXME: APID_UNKNOWN = APID_FILL_PKT + 1 だと 11 bit から溢れてる...
   {
     // 2nd OBC で生成された TLM の primary header, secondary header の board time はそのまま維持
   }

--- a/TlmCmd/telemetry_generator.c
+++ b/TlmCmd/telemetry_generator.c
@@ -39,8 +39,8 @@ CCP_CmdRet Cmd_GENERATE_TLM(const CommonCmdPacket* packet)
   }
 
   // ctp の ヘッダ部分の APID をクリア
-  // この後で， APID_is_other_obc_tlm_apid で配送元 OBC を割り出せるように
-  CTP_set_apid(&ctp_, APID_UNKNOWN);
+  // この後で， 配送元 OBC が自身か 2nd obc かを割り出せるように
+  CTP_set_apid(&ctp_, (APID)(APID_UNKNOWN & 0x7ff));    // FIXME: APID_UNKNOWN = APID_FILL_PKT + 1 だと 11 bit から溢れてる...
 
   // ADU生成
   // ADU分割が発生しない場合に限定したコードになっている。
@@ -55,7 +55,7 @@ CCP_CmdRet Cmd_GENERATE_TLM(const CommonCmdPacket* packet)
   if (ack != TF_TLM_FUNC_ACK_SUCCESS) return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
 
   // Header
-  if (APID_is_other_obc_tlm_apid(CTP_get_apid(&ctp_)))
+  if (CTP_get_apid(&ctp_) != (APID)(APID_UNKNOWN & 0x7ff))    // FIXME: APID_UNKNOWN = APID_FILL_PKT + 1 だと 11 bit から溢れてる...
   {
     // 2nd OBC で生成された TLM の primary header, secondary header の board time はそのまま維持
   }


### PR DESCRIPTION
## 概要
APID_is_other_obc_tlm_apid の削除

## Issue
- https://github.com/ut-issl/c2a-core/issues/489

## 詳細
メンテ性が最悪なこの関数を削除

この後，満を持して，generate tlmの改修にはいる

## 検証結果
MOBCとAOBC (2nd OBC) で，きちんと CTP の primary header が区別されていることを手元で確認した

## 影響範囲
APID_is_other_obc_tlm_apid をすべて削除することができる
