### PR TITLE
Fix release rule for c2a-tlm-cmd-code-generator

### DIFF
--- a/Docs/General/release.md
+++ b/Docs/General/release.md
@@ -73,6 +73,7 @@ Tool のリリースには，以下に注意する．
 - release には以下を含める．
     - Release Note として簡潔な更新差分の箇条書き
     - 対応する最小 C2A Core バージョン
+      - [c2a-tlm-cmd-code-generator](https://github.com/ut-issl/c2a-tlm-cmd-code-generator) については，依存関係が逆なので除外
     - この Tool に適合させたときの C2A Core の PR へのリンク
 
 例:


### PR DESCRIPTION
## 概要
他の tool 類と異なり， [c2a-tlm-cmd-code-generator](https://github.com/ut-issl/c2a-tlm-cmd-code-generator) については依存関係が逆（C2A が code generator に依存している）ので，リリースルール中の文言を修正

## Issue
- 関連する issue

## 詳細
詳しく

## 検証結果
test へのリンクや，検証結果へのリンク

## 影響範囲
XX系の動作がガラッと変わる，とか．

## 補足
何かあれば

## 注意
- 関連する Projects が存在する場合，それの紐付けを行うこと
- Assignees を設定すること
- 可能ならば Reviewers を設定すること
- 可能ならば `priority` ラベルを付けること
