### PR TITLE
Pre Release (v3.9.0-beta.4): CCP_DEST_TYPE_TO_APID を追加し，コマンドのルーティングを見直す

### DIFF
--- a/Docs/Core/communication.md
+++ b/Docs/Core/communication.md
@@ -124,12 +124,12 @@ https://github.com/ut-issl/c2a-core/blob/b84c3d051a1e15ab62c8f1a9744957daa4a62a3
     - コマンドID
     - APID 内でユニークであればいい
 - Destination Type
-    - `0x0` 以外はユーザー定義
+    - `0x0`, `0xe`, `0xf` 以外はユーザー定義
     - 例えば次のように定義する
-        - `0x0`: 自分宛
-        - `0x1`: MOBC 宛
-        - `0x2`: AOBC 宛
-        - `0x3`: 不明
+        - `0x0`: 自分宛 (`CCP_DEST_TYPE_TO_ME`)
+        - `0x1` - `0xd` : `CCP_DEST_TYPE_TO_ME`, `CCP_DEST_TYPE_TO_APID` では表現できない宛先
+        - `0xe`: 不明 (`CCP_DEST_TYPE_TO_UNKOWN`)
+        - `0xf`: APID で示す宛先宛 (`CCP_DEST_TYPE_TO_APID`)
     - ここで言う，宛先はコマンド実行場所ではなく，キューイングされる先のことである（詳細は後述）
 - Execution Type
     - 現時点では以下（将来拡張予定あり）
@@ -151,7 +151,7 @@ https://github.com/ut-issl/c2a-core/blob/b84c3d051a1e15ab62c8f1a9744957daa4a62a3
 - 一方で， BC や TLC などでのキューイングは， Destination Type によって決定される
     - https://github.com/ut-issl/c2a-core/blob/6d71249dcdb3aefa1d67ffe8ce946e8d8d8b2a33/Examples/minimum_user/src/src_user/Settings/TlmCmd/common_cmd_packet_define.h#L20-L27
 - 具体例（GS と接続される OBC は MOBC とし，AOBC は MOBC にぶら下がってるものとする）
-    - APID: MOBC, Destination Type: TO_ME or MOBC
+    - APID: MOBC, Destination Type: TO_ME or TO_APID or MOBC
         - GSC: GS から MOBC に届き， MOBC で GSC としてエンキューされる．デキューした後， MOBC 内で GSC として実行される．
         - TLC: GS から MOBC に届き， MOBC で TLC としてエンキューされる．デキューした後， MOBC 内で RTC として実行される．
         - BC: GS から MOBC に届き， MOBC で BC 登録される．BC 展開した後， TL にエンキューされ，デキューした後， MOBC 内で RTC として実行される．
@@ -159,7 +159,7 @@ https://github.com/ut-issl/c2a-core/blob/b84c3d051a1e15ab62c8f1a9744957daa4a62a3
         - GSC: GS から MOBC に届き， MOBC で GSC としてエンキューされる．デキューした後， APID を元に， AOBC へ配送される．配送時， Destination Type は自分宛 (TO_ME) に上書きされ， AOBC で RTC としてキューイング & 実行される．
         - TLC: GS から MOBC に届き， MOBC で TLC としてエンキューされる．デキューした後， APID を元に， AOBC へ配送される．配送時， Destination Type は自分宛 (TO_ME) に上書きされ， AOBC で RTC としてキューイング & 実行される．
         - BC: GS から MOBC に届き， MOBC で BC 登録される．BC 展開した後， TL にエンキューされ，デキューした後， APID を元に， AOBC へ配送される．配送時， Destination Type は自分宛 (TO_ME) に上書きされ， AOBC で RTC としてキューイング & 実行される．
-    - APID: AOBC, Destination Type: AOBC
+    - APID: AOBC, Destination Type: TO_APID or AOBC
         - GSC: GS から MOBC に届き， MOBC でエンキューされずに，そのまま AOBC へ配送される．配送時， Destination Type は自分宛 (TO_ME) に上書きされ， AOBC で GSC としてキューイング & 実行される．
         - TLC: GS から MOBC に届き， MOBC でエンキューされずに，そのまま AOBC へ配送される．配送時， Destination Type は自分宛 (TO_ME) に上書きされ， AOBC で TLC としてキューイング & 実行される．
         - BC: GS から MOBC に届き， MOBC で BC 登録されずに，そのまま AOBC へ配送される．配送時， Destination Type は自分宛 (TO_ME) に上書きされ， AOBC で BC として登録 & 実行される．

--- a/Examples/2nd_obc_user/src/src_user/Drivers/Etc/mobc.c
+++ b/Examples/2nd_obc_user/src/src_user/Drivers/Etc/mobc.c
@@ -113,7 +113,7 @@ static DS_ERR_CODE MOBC_analyze_rec_data_(DS_StreamConfig* p_stream_config, void
   //      CCP_EXEC_TYPE_MC    <- GS から MOBC のキューに入らず直接転送されたもの
   //      CCP_EXEC_TYPE_RT    <- これが GS → MOBC との違いで， MOBC の TLC/BC キューに溜まって実行されたもの
   // CCP_DEST_TYPE:
-  //      CCP_DEST_TYPE_TO_ME (CCP_DEST_TYPE_TO_AOBC の可能性はなくはないが， ME に上書きされているはず)
+  //      CCP_DEST_TYPE_TO_ME (CCP_DEST_TYPE_TO_APID, CCP_DEST_TYPE_TO_AOBC の可能性はなくはないが， ME に上書きされているはず)
 
   // FIXME: ここで返り値が NG だった場合，なにを return するかは議論の余地あり
   //        通信的には OK なので， OK を返すのでいいという認識

--- a/Examples/2nd_obc_user/src/src_user/Settings/TlmCmd/common_cmd_packet_define.c
+++ b/Examples/2nd_obc_user/src/src_user/Settings/TlmCmd/common_cmd_packet_define.c
@@ -12,7 +12,8 @@ CCP_DEST_TYPE CCP_get_dest_type_from_uint8(uint8_t dest_type)
   case CCP_DEST_TYPE_TO_ME:   // FALL THROUGH
   case CCP_DEST_TYPE_TO_MOBC: // FALL THROUGH
   case CCP_DEST_TYPE_TO_AOBC: // FALL THROUGH
-  case CCP_DEST_TYPE_TO_TOBC:
+  case CCP_DEST_TYPE_TO_TOBC: // FALL THROUGH
+  case CCP_DEST_TYPE_TO_APID:
     return (CCP_DEST_TYPE)dest_type;
   default:
     return CCP_DEST_TYPE_TO_UNKOWN;

--- a/Examples/2nd_obc_user/src/src_user/Settings/TlmCmd/common_cmd_packet_define.h
+++ b/Examples/2nd_obc_user/src/src_user/Settings/TlmCmd/common_cmd_packet_define.h
@@ -20,18 +20,17 @@ typedef CmdSpacePacket CommonCmdPacket;
 /**
  * @enum   CCP_DEST_TYPE
  * @brief  コマンドの解釈の宛先を規定
- * @note   TO_ME: 自分自身 → 自分自身の TLC や BC として解釈．コマンド実行時に必要に応じて別 OBC へ配送 （この定義は C2A Core で使うため，どんな C2A でも必須）
- * @note   TO_*:  転送先の TL や BC として解釈 （直接指定 OBC へ配送． GS から来たコマンドを自身のキューにいれない）
- *         なお，自分自身宛だった場合は，キューに入れる
+ * @note   詳細は https://github.com/ut-issl/c2a-core/blob/develop/Docs/Core/communication.md を参照
  * @note   4bit を想定
  */
 typedef enum
 {
-  CCP_DEST_TYPE_TO_ME     = 0,
-  CCP_DEST_TYPE_TO_MOBC   = 1,
-  CCP_DEST_TYPE_TO_AOBC   = 2,
-  CCP_DEST_TYPE_TO_TOBC   = 3,
-  CCP_DEST_TYPE_TO_UNKOWN = 4
+  CCP_DEST_TYPE_TO_ME     = 0x0,
+  CCP_DEST_TYPE_TO_MOBC   = 0x1,    // CCP_DEST_TYPE_TO_APID の追加に伴い deprecated
+  CCP_DEST_TYPE_TO_AOBC   = 0x2,    // CCP_DEST_TYPE_TO_APID の追加に伴い deprecated
+  CCP_DEST_TYPE_TO_TOBC   = 0x3,    // CCP_DEST_TYPE_TO_APID の追加に伴い deprecated
+  CCP_DEST_TYPE_TO_UNKOWN = 0xe,
+  CCP_DEST_TYPE_TO_APID   = 0xf
 } CCP_DEST_TYPE;
 
 /**

--- a/Examples/2nd_obc_user/src/src_user/TlmCmd/user_packet_handler.c
+++ b/Examples/2nd_obc_user/src/src_user/TlmCmd/user_packet_handler.c
@@ -17,10 +17,7 @@ PH_ACK PH_user_analyze_cmd(const CommonCmdPacket* packet)
   switch (CCP_get_dest_type(packet))
   {
   default:
-    // CCP_DEST_TYPE_TO_ME
-    // CCP_DEST_TYPE_TO_MOBC （自分）
-    // 宛先不明
-    // はここに
+    // 2nd OBC なので，自分宛て以外のパケットはないはず
     return PH_ACK_UNKNOWN;
   }
 }

--- a/Examples/minimum_user/src/src_user/Applications/DriverInstances/di_aobc.c
+++ b/Examples/minimum_user/src/src_user/Applications/DriverInstances/di_aobc.c
@@ -105,6 +105,7 @@ CCP_CmdRet DI_AOBC_dispatch_command(const CommonCmdPacket* packet)
   default:
     // MOBC のキューに入らず直接転送
     // そのままの EXEC_TYPE で転送．なにもしない
+    break;
   }
 
   // 配送先 OBC が最終到達地なので

--- a/Examples/minimum_user/src/src_user/Applications/DriverInstances/di_aobc.c
+++ b/Examples/minimum_user/src/src_user/Applications/DriverInstances/di_aobc.c
@@ -94,16 +94,17 @@ CCP_CmdRet DI_AOBC_dispatch_command(const CommonCmdPacket* packet)
   CommonCmdPacket* pckt = (CommonCmdPacket*)packet; // const_cast
   // ここで CCP_DEST_TYPE を宛先で受理できるように変更（なので const cast が発生している．．．）
 
-  if (CCP_get_dest_type(pckt) != CCP_DEST_TYPE_TO_ME)
+  switch (CCP_get_dest_type(pckt))
   {
-    // MOBC のキューに入らず直接転送
-    // そのままの EXEC_TYPE で転送．なにもしない
-  }
-  else
-  {
+  case CCP_DEST_TYPE_TO_ME:       // FALL THROUGH
+  case CCP_DEST_TYPE_TO_MOBC:     // CCP_DEST_TYPE_TO_APID の追加に伴い deprecated
     // MOBC のキューに溜まった後に実行されたもの
     // 配送先 OBC では MOBC 側の TL などの影響は受けないはずなので RTC へ変換
     CCP_set_exec_type(pckt, CCP_EXEC_TYPE_RT);
+    break;
+  default:
+    // MOBC のキューに入らず直接転送
+    // そのままの EXEC_TYPE で転送．なにもしない
   }
 
   // 配送先 OBC が最終到達地なので

--- a/Examples/minimum_user/src/src_user/Settings/TlmCmd/common_cmd_packet_define.c
+++ b/Examples/minimum_user/src/src_user/Settings/TlmCmd/common_cmd_packet_define.c
@@ -12,7 +12,8 @@ CCP_DEST_TYPE CCP_get_dest_type_from_uint8(uint8_t dest_type)
   case CCP_DEST_TYPE_TO_ME:   // FALL THROUGH
   case CCP_DEST_TYPE_TO_MOBC: // FALL THROUGH
   case CCP_DEST_TYPE_TO_AOBC: // FALL THROUGH
-  case CCP_DEST_TYPE_TO_TOBC:
+  case CCP_DEST_TYPE_TO_TOBC: // FALL THROUGH
+  case CCP_DEST_TYPE_TO_APID:
     return (CCP_DEST_TYPE)dest_type;
   default:
     return CCP_DEST_TYPE_TO_UNKOWN;

--- a/Examples/minimum_user/src/src_user/Settings/TlmCmd/common_cmd_packet_define.h
+++ b/Examples/minimum_user/src/src_user/Settings/TlmCmd/common_cmd_packet_define.h
@@ -20,18 +20,17 @@ typedef CmdSpacePacket CommonCmdPacket;
 /**
  * @enum   CCP_DEST_TYPE
  * @brief  コマンドの解釈の宛先を規定
- * @note   TO_ME: 自分自身 → 自分自身の TLC や BC として解釈．コマンド実行時に必要に応じて別 OBC へ配送 （この定義は C2A Core で使うため，どんな C2A でも必須）
- * @note   TO_*:  転送先の TL や BC として解釈 （直接指定 OBC へ配送． GS から来たコマンドを自身のキューにいれない）
- *         なお，自分自身宛だった場合は，キューに入れる
+ * @note   詳細は https://github.com/ut-issl/c2a-core/blob/develop/Docs/Core/communication.md を参照
  * @note   4bit を想定
  */
 typedef enum
 {
-  CCP_DEST_TYPE_TO_ME     = 0,
-  CCP_DEST_TYPE_TO_MOBC   = 1,
-  CCP_DEST_TYPE_TO_AOBC   = 2,
-  CCP_DEST_TYPE_TO_TOBC   = 3,
-  CCP_DEST_TYPE_TO_UNKOWN = 4
+  CCP_DEST_TYPE_TO_ME     = 0x0,
+  CCP_DEST_TYPE_TO_MOBC   = 0x1,    // CCP_DEST_TYPE_TO_APID の追加に伴い deprecated
+  CCP_DEST_TYPE_TO_AOBC   = 0x2,    // CCP_DEST_TYPE_TO_APID の追加に伴い deprecated
+  CCP_DEST_TYPE_TO_TOBC   = 0x3,    // CCP_DEST_TYPE_TO_APID の追加に伴い deprecated
+  CCP_DEST_TYPE_TO_UNKOWN = 0xe,
+  CCP_DEST_TYPE_TO_APID   = 0xf
 } CCP_DEST_TYPE;
 
 /**

--- a/Examples/minimum_user/src/src_user/TlmCmd/user_packet_handler.c
+++ b/Examples/minimum_user/src/src_user/TlmCmd/user_packet_handler.c
@@ -32,18 +32,39 @@ void PH_user_init(void)
 
 PH_ACK PH_user_analyze_cmd(const CommonCmdPacket* packet)
 {
-  switch (CCP_get_dest_type(packet))
+  CCP_DEST_TYPE dest_type = CCP_get_dest_type(packet);
+  APID apid = CCP_get_apid(packet);
+
+  if (dest_type == CCP_DEST_TYPE_TO_APID)
   {
-  case CCP_DEST_TYPE_TO_AOBC:
-    return (PH_add_aobc_cmd_(packet) == PH_ACK_SUCCESS) ? PH_ACK_FORWARDED : PH_ACK_PL_LIST_FULL;
-  case CCP_DEST_TYPE_TO_TOBC:
-    return (PH_add_tobc_cmd_(packet) == PH_ACK_SUCCESS) ? PH_ACK_FORWARDED : PH_ACK_PL_LIST_FULL;
-  default:
-    // CCP_DEST_TYPE_TO_ME
-    // CCP_DEST_TYPE_TO_MOBC （自分）
-    // 宛先不明
-    // はここに
-    return PH_ACK_UNKNOWN;
+    switch (apid)
+    {
+    case APID_AOBC_CMD:
+      return (PH_add_aobc_cmd_(packet) == PH_ACK_SUCCESS) ? PH_ACK_FORWARDED : PH_ACK_PL_LIST_FULL;
+    case APID_TOBC_CMD:
+      return (PH_add_tobc_cmd_(packet) == PH_ACK_SUCCESS) ? PH_ACK_FORWARDED : PH_ACK_PL_LIST_FULL;
+    default:
+      // APID_MOBC_CMD
+      // 不正な APID
+      // はここに
+      return PH_ACK_UNKNOWN;
+    }
+  }
+  else
+  {
+    switch (dest_type)
+    {
+    case CCP_DEST_TYPE_TO_AOBC:    // CCP_DEST_TYPE_TO_APID の追加に伴い deprecated
+      return (PH_add_aobc_cmd_(packet) == PH_ACK_SUCCESS) ? PH_ACK_FORWARDED : PH_ACK_PL_LIST_FULL;
+    case CCP_DEST_TYPE_TO_TOBC:    // CCP_DEST_TYPE_TO_APID の追加に伴い deprecated
+      return (PH_add_tobc_cmd_(packet) == PH_ACK_SUCCESS) ? PH_ACK_FORWARDED : PH_ACK_PL_LIST_FULL;
+    default:
+      // CCP_DEST_TYPE_TO_ME
+      // CCP_DEST_TYPE_TO_MOBC などの自分宛．なお， CCP_DEST_TYPE_TO_APID の追加に伴い deprecated
+      // 宛先不明
+      // はここに
+      return PH_ACK_UNKNOWN;
+    }
   }
 }
 

--- a/TlmCmd/common_cmd_packet.h
+++ b/TlmCmd/common_cmd_packet.h
@@ -10,15 +10,19 @@
 #include <src_user/TlmCmd/command_definitions.h>
 
 // ここで CCP_DEST_TYPE を定義する
-// 詳細は /Examples/minimum_user/src/src_user/Settings/TlmCmd/common_cmd_packet_define.h 参照
+// 詳細は
+// - /Examples/minimum_user/src/src_user/Settings/TlmCmd/common_cmd_packet_define.h
+// - https://github.com/ut-issl/c2a-core/blob/develop/Docs/Core/communication.md
+// を参照
 /* 例
 typedef enum
 {
-  CCP_DEST_TYPE_TO_ME     = 0,
-  CCP_DEST_TYPE_TO_MOBC   = 1,
-  CCP_DEST_TYPE_TO_AOBC   = 2,
-  CCP_DEST_TYPE_TO_TOBC   = 3,
-  CCP_DEST_TYPE_TO_UNKOWN = 4
+  CCP_DEST_TYPE_TO_ME     = 0x0,
+  CCP_DEST_TYPE_TO_MOBC   = 0x1,
+  CCP_DEST_TYPE_TO_AOBC   = 0x2,
+  CCP_DEST_TYPE_TO_TOBC   = 0x3,
+  CCP_DEST_TYPE_TO_UNKOWN = 0xe,
+  CCP_DEST_TYPE_TO_APID   = 0xf
 } CCP_DEST_TYPE;
 */
 // さらに， CCP_APID_TO_ME, CCP_MAX_LEN, CommonCmdPacket として使うパケット型を指定する

--- a/TlmCmd/packet_handler.c
+++ b/TlmCmd/packet_handler.c
@@ -131,9 +131,10 @@ PH_ACK PH_analyze_cmd_packet(const CommonCmdPacket* packet)
   }
 
   // ここまで来たら自分宛て
-  // 例えば以下のどちらか
-  //   - CCP_DEST_TYPE_TO_ME
-  //   - CCP_DEST_TYPE_TO_MOBC （自分）
+  // 例えば以下のどれか
+  // - CCP_DEST_TYPE_TO_ME
+  // - CCP_DEST_TYPE_TO_APID でかつ， APID が自分宛てのもの
+  // - CCP_DEST_TYPE_TO_MOBC などの自分宛
   // 統一するため上書きする
   CCP_set_dest_type((CommonCmdPacket*)packet, CCP_DEST_TYPE_TO_ME);   // const_cast
 

--- a/c2a_core_main.h
+++ b/c2a_core_main.h
@@ -10,6 +10,6 @@ void C2A_core_main(void);
 #define C2A_CORE_VER_MAJOR (3)
 #define C2A_CORE_VER_MINOR (9)
 #define C2A_CORE_VER_PATCH (0)
-#define C2A_CORE_VER_PRE   ("beta.3")
+#define C2A_CORE_VER_PRE   ("beta.4")
 
 #endif


### PR DESCRIPTION
## 概要
CCP_DEST_TYPE_TO_APID を追加し，コマンドのルーティングを見直す

## Issue
- https://github.com/ut-issl/c2a-core/issues/512

## 詳細
`CCP_DEST_TYPE_TO_APID` を追加し，APID の最終到達地点がキューイングの宛先の場合，個別に DEST_TYPE を設定することが不要になった

## 検証結果
既存のテストが全て通った

## 影響範囲
- `PH_user_analyze_cmd` の書き換えが必要
- MOBC にある 2nd OBC の driver の微修正が必要

## 備考
- [ ] WINGS などの GS SW 側に影響があるので Pre Release を打つ
- [ ]  マージする前にバージョンを上げる