### PR TITLE
Pre Release (v3.9.0-beta.3): Packaging as Rust crate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,9 @@ Examples/minimum_user/build
 Examples/2nd_obc_user/src/src_core
 Examples/2nd_obc_user/build
 *.pyc
+
+
+# Added by cargo
+
+/target
+/Cargo.lock

--- a/.gitignore
+++ b/.gitignore
@@ -64,8 +64,6 @@ Examples/2nd_obc_user/src/src_core
 Examples/2nd_obc_user/build
 *.pyc
 
-
 # Added by cargo
-
 /target
 /Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2a-core"
-version = "3.9.0-beta.2"
+version = "3.9.0-beta.3"
 edition = "2021"
 
 description = "Core of Command Centric Architecture"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "c2a-core"
+version = "3.9.0-beta.2"
+edition = "2021"
+
+description = "Core of Command Centric Architecture"
+readme = "README.md"
+license-file = "LICENSE"
+
+repository = "https://github.com/ut-issl/c2a-core"
+documentation = "https://ut-issl.github.io/c2a-reference/c2a-core"

--- a/Docs/General/release.md
+++ b/Docs/General/release.md
@@ -17,7 +17,9 @@
 
 ### 本 Release
 
-1. [c2a_core_main.h](https://github.com/ut-issl/c2a-core/blob/develop/c2a_core_main.h) 内の `C2A_CORE_VER_*` をインクリメントする PR (Pull Request) を発行し， `develop` ブランチへマージする．
+1. バージョン番号をインクリメントする PR (Pull Request) を発行し，`develop` ブランチへマージする
+    - [c2a_core_main.h](https://github.com/ut-issl/c2a-core/blob/develop/c2a_core_main.h) 内の `C2A_CORE_VER_*` をインクリメントする
+    - [Cargo.toml](https://github.com/ut-issl/c2a-core/blob/develop/Cargo.toml) 内の `package.version` をインクリメントする
     - この後リリースを控えるので，念の為すべてのテストを再度回す．
     - `#define C2A_CORE_VER_PRE` は `("")` とする．
     - PR 名は `Update version (v3.4.0)` のようにする．
@@ -34,6 +36,7 @@
     - release には以下を含める．
         - Release Note として簡潔な更新差分の箇条書き
         - `main` にマージしたときの PR のリンク
+1. `cargo publish` する
 
 
 これを，だいたい以下のような粒度で行う．
@@ -49,6 +52,7 @@
     - 対応する Tools の PR のリンクを貼る．
     - `#define C2A_CORE_VER_PRE` に `("beta.0")` などをセットする．
     - 本 Release 後最初の Pre-release の場合， `C2A_CORE_VER_*` をインクリメントする．
+    - [Cargo.toml](https://github.com/ut-issl/c2a-core/blob/develop/Cargo.toml) 内の `package.version` をインクリメントする
     - PR 名は以下のようにする．
         - `Pre Release (v3.5.0-beta.0): 通常のPRのタイトル`
     - 例: https://github.com/ut-issl/c2a-core/pulls?q=is%3Apr+Pre+Release
@@ -58,6 +62,7 @@
     - release には以下を含める．
         - 非互換となった Tools の新しい バージョン (Release) へのリンク
         - `develop` にマージしたときの PR のリンク
+1. `cargo publish` する
 1. Bug fix や 大きな機能更新などで，本 Release 前に User サイドで最新の Core が必要になった際にも， Pre-release を行うことができる．
 
 

--- a/Docs/General/release.md
+++ b/Docs/General/release.md
@@ -38,7 +38,6 @@
         - `main` にマージしたときの PR のリンク
 1. `cargo publish` する．
 
-
 これを，だいたい以下のような粒度で行う．
 
 - 最後のリリースからおおよそ１ヶ月程度が経過した場合（更新が少ない場合を除く）
@@ -52,7 +51,7 @@
     - 対応する Tools の PR のリンクを貼る．
     - `#define C2A_CORE_VER_PRE` に `("beta.0")` などをセットする．
     - 本 Release 後最初の Pre-release の場合， `C2A_CORE_VER_*` をインクリメントする．
-    - [Cargo.toml](https://github.com/ut-issl/c2a-core/blob/develop/Cargo.toml) 内の `package.version` をインクリメントする．
+    - [Cargo.toml](https://github.com/ut-issl/c2a-core/blob/develop/Cargo.toml) 内の `package.version` を同様にインクリメントする．
     - PR 名は以下のようにする．
         - `Pre Release (v3.5.0-beta.0): 通常のPRのタイトル`
     - 例: https://github.com/ut-issl/c2a-core/pulls?q=is%3Apr+Pre+Release
@@ -63,7 +62,8 @@
         - 非互換となった Tools の新しい バージョン (Release) へのリンク
         - `develop` にマージしたときの PR のリンク
 1. `cargo publish` する．
-1. Bug fix や 大きな機能更新などで，本 Release 前に User サイドで最新の Core が必要になった際にも， Pre-release を行うことができる．
+
+なお，Bug fix や 大きな機能更新などで，本 Release 前に User サイドで最新の Core が必要になった際にも， Pre-release を行うことができる．
 
 
 ## バージョニング

--- a/Docs/General/release.md
+++ b/Docs/General/release.md
@@ -17,9 +17,9 @@
 
 ### 本 Release
 
-1. バージョン番号をインクリメントする PR (Pull Request) を発行し，`develop` ブランチへマージする
-    - [c2a_core_main.h](https://github.com/ut-issl/c2a-core/blob/develop/c2a_core_main.h) 内の `C2A_CORE_VER_*` をインクリメントする
-    - [Cargo.toml](https://github.com/ut-issl/c2a-core/blob/develop/Cargo.toml) 内の `package.version` をインクリメントする
+1. バージョン番号をインクリメントする PR (Pull Request) を発行し，`develop` ブランチへマージする．
+    - [c2a_core_main.h](https://github.com/ut-issl/c2a-core/blob/develop/c2a_core_main.h) 内の `C2A_CORE_VER_*` をインクリメントする．
+    - [Cargo.toml](https://github.com/ut-issl/c2a-core/blob/develop/Cargo.toml) 内の `package.version` をインクリメントする．
     - この後リリースを控えるので，念の為すべてのテストを再度回す．
     - `#define C2A_CORE_VER_PRE` は `("")` とする．
     - PR 名は `Update version (v3.4.0)` のようにする．
@@ -36,7 +36,7 @@
     - release には以下を含める．
         - Release Note として簡潔な更新差分の箇条書き
         - `main` にマージしたときの PR のリンク
-1. `cargo publish` する
+1. `cargo publish` する．
 
 
 これを，だいたい以下のような粒度で行う．
@@ -52,7 +52,7 @@
     - 対応する Tools の PR のリンクを貼る．
     - `#define C2A_CORE_VER_PRE` に `("beta.0")` などをセットする．
     - 本 Release 後最初の Pre-release の場合， `C2A_CORE_VER_*` をインクリメントする．
-    - [Cargo.toml](https://github.com/ut-issl/c2a-core/blob/develop/Cargo.toml) 内の `package.version` をインクリメントする
+    - [Cargo.toml](https://github.com/ut-issl/c2a-core/blob/develop/Cargo.toml) 内の `package.version` をインクリメントする．
     - PR 名は以下のようにする．
         - `Pre Release (v3.5.0-beta.0): 通常のPRのタイトル`
     - 例: https://github.com/ut-issl/c2a-core/pulls?q=is%3Apr+Pre+Release
@@ -62,7 +62,7 @@
     - release には以下を含める．
         - 非互換となった Tools の新しい バージョン (Release) へのリンク
         - `develop` にマージしたときの PR のリンク
-1. `cargo publish` する
+1. `cargo publish` する．
 1. Bug fix や 大きな機能更新などで，本 Release 前に User サイドで最新の Core が必要になった際にも， Pre-release を行うことができる．
 
 

--- a/c2a_core_main.h
+++ b/c2a_core_main.h
@@ -10,6 +10,6 @@ void C2A_core_main(void);
 #define C2A_CORE_VER_MAJOR (3)
 #define C2A_CORE_VER_MINOR (9)
 #define C2A_CORE_VER_PATCH (0)
-#define C2A_CORE_VER_PRE   ("beta.2")
+#define C2A_CORE_VER_PRE   ("beta.3")
 
 #endif


### PR DESCRIPTION
## 概要
c2a-core を Rust の crate としてパッケージングする

## 詳細
c2a-core は現状あくまでC言語で書かれており，Rustのプロジェクト **ではない** が，Cargo などのエコシステムだけでも Rust のものに載せる価値は十分にある．
その前準備として，`Cargo.toml` だけを追加し，crate として公開する．

## 影響範囲
リリースの手順が変わる．具体的には，バージョン番号を`Cargo.toml` でも管理するようにする．

## 補足
- この PR のマージ後，Pre Release でよいのでリリースを打ってほしい（`Cargo.toml` も更新する必要があるので注意）

## 備考
- [ ] crate としてリリースするので Pre Release を打つ
- [x]  マージする前にバージョンを上げる