### PR TITLE
Fix crate package license config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 description = "Core of Command Centric Architecture"
 readme = "README.md"
+license = "MIT"
 license-file = "LICENSE"
 
 repository = "https://github.com/ut-issl/c2a-core"


### PR DESCRIPTION
## 概要
crate の metadata が `non-standard` となってしまっているので，明示的に `license = "MIT"` も追加する

## Issue/PR
- #564 