### PR TITLE
Add export src interface (c2a-core crate)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,7 @@ license-file = "LICENSE"
 
 repository = "https://github.com/ut-issl/c2a-core"
 documentation = "https://ut-issl.github.io/c2a-reference/c2a-core"
+
+[features]
+std = []
+export-src = ["std"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,1 @@
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(feature = "export-src")]
+pub fn source_dir() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR")).to_path_buf()
+}


### PR DESCRIPTION
## 概要
- `c2a-core` crate に `export-src` feature を追加
- `export-src` feature のときのみ，この crate のソースコードがあるディレクトリを露出させるためのユーティリティ関数を追加

## Issue/PR
- #564 
- #567 

## 影響範囲
- `c2a-core` crate のみ
- `export-src` feature の時は `no_std` ではなくなる

## 補足
マージ後リリースしてほしい