### PR TITLE
Pre Release (v3.9.0-beta.4): バージョンアップのやり直し

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2a-core"
-version = "3.9.0-beta.3"
+version = "3.9.0-beta.4"
 edition = "2021"
 
 description = "Core of Command Centric Architecture"


### PR DESCRIPTION
## 概要
Pre Release (v3.9.0-beta.4): バージョンアップのやり直し

## 詳細
- https://github.com/ut-issl/c2a-core/pull/561 で Cargo.toml のバージョンを上げそびれた

## 備考
- [ ] WINGS などの GS SW 側に影響があるので Pre Release を打つ
