### PR TITLE
Add rust ci

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,6 +18,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: install dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y libclang-dev
+
       - uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: stable

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,36 @@
+name: Rust
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - v*
+  pull_request:
+
+env:
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  rust:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+          components: clippy, rustfmt
+
+      - name: cache dependencies
+        uses: Swatinem/rust-cache@v2.3.0
+
+      - name: reviewdog / clippy
+        uses: sksat/action-clippy@v0.2.1
+        with:
+          reporter: github-pr-review
+          clippy_flags: --all-features
+
+      - name: unit test
+        run: cargo test

--- a/c2a_core_main.h
+++ b/c2a_core_main.h
@@ -10,6 +10,6 @@ void C2A_core_main(void);
 #define C2A_CORE_VER_MAJOR (3)
 #define C2A_CORE_VER_MINOR (9)
 #define C2A_CORE_VER_PATCH (0)
-#define C2A_CORE_VER_PRE   ("beta.5")
+#define C2A_CORE_VER_PRE   ("beta.6")
 
 #endif

--- a/c2a_core_main.h
+++ b/c2a_core_main.h
@@ -10,6 +10,6 @@ void C2A_core_main(void);
 #define C2A_CORE_VER_MAJOR (3)
 #define C2A_CORE_VER_MINOR (9)
 #define C2A_CORE_VER_PATCH (0)
-#define C2A_CORE_VER_PRE   ("beta.6")
+#define C2A_CORE_VER_PRE   ("beta.5")
 
 #endif


### PR DESCRIPTION
## 概要
Rust の CI workflow を追加

## Issue
- Resolve #570 

## 詳細
- `c2a-core` crate 向けの普通の Rust の CI を追加
- #573 により，バージョンの不整合があるとビルドがコケるのでこの CI で検知できる

