### PR TITLE
ci: allow MacRoman misjudgement

### DIFF
--- a/Script/CI/check_encoding.py
+++ b/Script/CI/check_encoding.py
@@ -81,7 +81,7 @@ def check_encoding(path, encoding):
         enc = ret["encoding"]
     # print(enc)
     if encoding == "utf-8":
-        if enc == "utf-8" or enc == "ascii":
+        if enc == "utf-8" or enc == "ascii" or enc == "MacRoman":
             return True
         # なぜか以下のような誤認もあるので
         if enc == "Windows-1252" or enc == "ISO-8859-1" or enc is None:


### PR DESCRIPTION
## 概要

ある特定のパターンのテキストファイルの場合，UTF-8 として保存していても MacRoman として判定されてしまうことがある．これを chardet の誤判定として許容し，CI では迂回する．

## Issue

なし．

## 詳細

UTF-8 の判定閉包に MacRoman を含める．

## 検証結果

> 書く．

## 影響範囲

真に UTF-8 でないエンコーディングのファイルが CI で通る可能性が出てくる．

## 注意
- 関連する Projects が存在する場合，それの紐付けを行うこと
- Assignees を設定すること
- 可能ならば Reviewers を設定すること
- 可能ならば `priority` ラベルを付けること
