### PR TITLE
Switch action-clippy reporter on event

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,7 +34,7 @@ jobs:
       - name: reviewdog / clippy
         uses: sksat/action-clippy@v0.2.1
         with:
-          reporter: github-pr-review
+          reporter: ${{ github.event_name == 'pull_request' && 'github-pr-review' || 'github-check' }}
           clippy_flags: --all-features
 
       - name: unit test


### PR DESCRIPTION
## 概要
Rust CI が push event で trigger された時にエラーになるので，reviewdog の reporter をスイッチする

## 詳細
詳しく

## 検証結果
- 壊れていたもの: https://github.com/ut-issl/c2a-core/actions/runs/5005590605/jobs/8970091778

## 影響範囲
`on: push` 時の Rust CI workflow のみ