### PR TITLE
Add clang runtime feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,11 +18,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: install dependencies
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -y libclang-dev
-
       - uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/ut-issl/c2a-core"
 documentation = "https://ut-issl.github.io/c2a-reference/c2a-core"
 
 [features]
+default = ["clang-runtime"]
 std = []
 export-src = ["std"]
 clang-runtime = ["clang/runtime"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ documentation = "https://ut-issl.github.io/c2a-reference/c2a-core"
 [features]
 std = []
 export-src = ["std"]
+clang-runtime = ["clang/runtime"]
 
 [build-dependencies]
 semver = "1.0.17"


### PR DESCRIPTION
## 概要
`clang` crate（正確にはその dependency の `clang-sys` crate）の `runtime` feature を使って libclang をリンクする



## 詳細
- `clang-runtime` feature を追加
  - ここで `clang` crate に  `runtime` feature を指定
- `clang-runtime` を default feature にした

## 検証結果
test へのリンクや，検証結果へのリンク

## 影響範囲
CI や `c2a-core` crate のユーザが `libclang` のリンクのことを考えなくてよくなる

## 備考
一連のPRマージ後にPre Release したい