### PR TITLE
Export src dir via cargo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,8 @@ name = "c2a-core"
 version = "3.9.0-beta.6"
 edition = "2021"
 
+links = "c2a-core"
+
 description = "Core of Command Centric Architecture"
 readme = "README.md"
 license = "MIT"

--- a/build.rs
+++ b/build.rs
@@ -6,6 +6,8 @@ use semver::Version;
 use clang::{token::TokenKind::Punctuation, Clang, Index};
 
 fn main() {
+    println!("cargo:source_dir={}", env!("CARGO_MANIFEST_DIR"));
+
     let ver = env!("CARGO_PKG_VERSION");
     let ver = Version::parse(ver).unwrap();
     dbg!(&ver);


### PR DESCRIPTION
## 概要
Cargo を経由して `c2a-core` crate のソースファイルのディレクトリを依存先の crate に公開する

## Issue/PR
- #568 

## 詳細
- https://doc.rust-lang.org/cargo/reference/build-scripts.html#the-links-manifest-key


## 影響範囲
- `c2a-core` crate のユーザー

## 補足
リリースしたい