### PR TITLE
Split obc time config header

### DIFF
--- a/System/TaskManager/task_dispatcher.c
+++ b/System/TaskManager/task_dispatcher.c
@@ -15,6 +15,7 @@
 #include "../../TlmCmd/common_cmd_packet_util.h"
 #include "../ModeManager/mode_manager.h"
 #include "../TimeManager/time_manager.h"
+#include "../TimeManager/obc_time_config.h"
 #include "../EventManager/event_logger.h"
 #include <src_user/TlmCmd/block_command_definitions.h>
 #include <src_user/TlmCmd/command_definitions.h>

--- a/System/TimeManager/obc_time.c
+++ b/System/TimeManager/obc_time.c
@@ -4,6 +4,7 @@
  * @brief OBCの時刻情報の定義と演算
  */
 #include "obc_time.h"
+#include "obc_time_config.h"
 #include "../../Library/print.h"
 
 ObcTime OBCT_create(cycle_t total_cycle,

--- a/System/TimeManager/obc_time.h
+++ b/System/TimeManager/obc_time.h
@@ -7,14 +7,6 @@
 
 #include <stdint.h>
 
-// step, cycleについてはTimeManagerを参照のこと
-#define OBCT_STEP_IN_MSEC (1)                                                    //!< 1 step で何 ms か
-#define OBCT_STEPS_PER_CYCLE (100)                                               //!< 何 step で 1 cycle か
-#define OBCT_CYCLES_PER_SEC (1000 / OBCT_STEP_IN_MSEC / OBCT_STEPS_PER_CYCLE)    //!< 1 s で何 cycle か
-#define OBCT_MAX_CYCLE (0xfffffff0u)                                             //!< 最大 cycle 数．つまり TI がいくつでオーバーフローするか
-
-#include <src_user/Settings/System/obc_time_params.h>
-
 typedef uint32_t cycle_t;
 typedef uint32_t step_t;
 

--- a/System/TimeManager/obc_time_config.h
+++ b/System/TimeManager/obc_time_config.h
@@ -1,0 +1,14 @@
+#ifndef OBC_TIME_CONFIG_H_
+#define OBC_TIME_CONFIG_H_
+
+// step, cycleについてはTimeManagerを参照のこと
+// デフォルト設定
+#define OBCT_STEP_IN_MSEC (1)                                                    //!< 1 step で何 ms か
+#define OBCT_STEPS_PER_CYCLE (100)                                               //!< 何 step で 1 cycle か
+#define OBCT_CYCLES_PER_SEC (1000 / OBCT_STEP_IN_MSEC / OBCT_STEPS_PER_CYCLE)    //!< 1 s で何 cycle か
+#define OBCT_MAX_CYCLE (0xfffffff0u)                                             //!< 最大 cycle 数．つまり TI がいくつでオーバーフローするか
+
+// user 設定
+#include <src_user/Settings/System/obc_time_params.h>
+
+#endif // OBC_TIME_CONFIG_H_

--- a/System/TimeManager/time_manager.c
+++ b/System/TimeManager/time_manager.c
@@ -4,6 +4,7 @@
  * @brief OBC時刻のカウントアップと，各種衛星時刻関連処理
  */
 #include "time_manager.h"
+#include "obc_time_config.h"
 #include <string.h>
 #include "../../Library/c2a_round.h"
 #include "../TaskManager/task_dispatcher.h"


### PR DESCRIPTION
## 概要
`ObcTime` の設定を `obc_time.h` から分割する

## Issue
- #581 

## 詳細
- `obc_time.h` が C2A user に依存しなくなる
- `ObcTime` のデフォルト設定は `obc_time_config.h` で定義するようになる

## 検証結果
CI が通ればよし