### PR TITLE
古い `GENERATE_TLM` の利用を消す（telemetry manager , pytest 以外）

### DIFF
--- a/Examples/2nd_obc_user/src/src_user/Settings/TlmCmd/DataBase/CMDFILE/sample.ops
+++ b/Examples/2nd_obc_user/src/src_user/Settings/TlmCmd/DataBase/CMDFILE/sample.ops
@@ -6,37 +6,37 @@
 .# =======================================
  #  NOP
  # =======================================
-.MOBC_RT.Cmd_NOP
-.AOBC_RT.Cmd_NOP
+.MOBC_RT.NOP
+.AOBC_RT.NOP
 .#
 .# =======================================
  #  HK の生成
  #  AOBC > MOBC に AOBC HK が定期送信されている前提
  # =======================================
-.MOBC_RT.Cmd_BCT_CLEAR_BLOCK 77     # BCT 77 を使用
+.MOBC_RT.BCT_CLEAR_BLOCK 77     # BCT 77 を使用
  wait_sec 1
- MOBC_BL.Cmd_GENERATE_TLM 1 0x40 0xf0 1 # HK
+ MOBC_BL.TG_GENERATE_MS_TLM 1 0xf0 # HK
  wait_sec 1
- MOBC_BL.Cmd_GENERATE_TLM 3 0x40 0x91 1 # AOBC HK
+ MOBC_BL.TG_FORWARD_AS_MS_TLM 3 0x511 0x91 # AOBC HK
  wait_sec 1
- MOBC_BL.Cmd_TLCD_DEPLOY_BLOCK 10 2 77
+ MOBC_BL.TLCD_DEPLOY_BLOCK 10 2 77
  wait_sec 1
- MOBC_RT.Cmd_BCE_ACTIVATE_BLOCK
+ MOBC_RT.BCE_ACTIVATE_BLOCK
  wait_sec 1
- MOBC_RT.Cmd_TLCD_CLEAR_ALL_TIMELINE 2
+ MOBC_RT.TLCD_CLEAR_ALL_TIMELINE 2
  wait_sec 1
  # BCを展開し，TLM出力開始
- MOBC_RT.Cmd_TLCD_DEPLOY_BLOCK 2 77
+ MOBC_RT.TLCD_DEPLOY_BLOCK 2 77
 .#
 .# =======================================
  #  AOBC Tlm
  # =======================================
-.MOBC_RT.Cmd_GENERATE_TLM 0x40 0x90 1 # AOBC AOBC   → CNT ERR が出るはず
-.AOBC_RT.Cmd_GENERATE_TLM 0x40 0x90 1 # AOBC AOBC
-.MOBC_RT.Cmd_GENERATE_TLM 0x40 0x90 1 # AOBC AOBC
+.MOBC_RT.TG_FORWARD_AS_MS_TLM 0x511 0x90  # AOBC AOBC   → CNT ERR が出るはず
+.AOBC_RT.TG_GENERATE_MS_TLM         0x90  # AOBC AOBC
+.MOBC_RT.TG_FORWARD_AS_MS_TLM 0x511 0x90  # AOBC AOBC
 .#
 .# AOBCリセット
-.MOBC_RT.Cmd_AM_INITIALIZE_APP 4      # AR_DI_AOBC
-.MOBC_RT.Cmd_GENERATE_TLM 0x40 0x90 1 # AOBC AOBC   → CNT ERR が出るはず
-.AOBC_RT.Cmd_GENERATE_TLM 0x40 0x90 1 # AOBC AOBC
-.MOBC_RT.Cmd_GENERATE_TLM 0x40 0x90 1 # AOBC AOBC
+.MOBC_RT.AM_INITIALIZE_APP 4              # AR_DI_AOBC
+.MOBC_RT.TG_FORWARD_AS_MS_TLM 0x511 0x90  # AOBC AOBC   → CNT ERR が出るはず
+.AOBC_RT.TG_GENERATE_MS_TLM         0x90  # AOBC AOBC
+.MOBC_RT.TG_FORWARD_AS_MS_TLM 0x511 0x90  # AOBC AOBC

--- a/Examples/2nd_obc_user/src/src_user/Test/test/conftest.py
+++ b/Examples/2nd_obc_user/src/src_user/Test/test/conftest.py
@@ -38,8 +38,8 @@ def _increase_hk_frequency():
     for ti in range(1, 10, 2):
         ope.send_bl_cmd(
             ti,
-            mobc_c2a_enum.Cmd_CODE_GENERATE_TLM,
-            (0x40, mobc_c2a_enum.Tlm_CODE_HK, 1),
+            mobc_c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM,
+            (mobc_c2a_enum.Tlm_CODE_HK,),
         )
         time.sleep(0.1)
 

--- a/Examples/2nd_obc_user/src/src_user/TlmCmd/NormalBlockCommandDefinition/nbc_start_hk_tlm.c
+++ b/Examples/2nd_obc_user/src/src_user/TlmCmd/NormalBlockCommandDefinition/nbc_start_hk_tlm.c
@@ -11,10 +11,8 @@
 
 void BCL_load_start_hk_tlm(void)
 {
-  BCL_tool_prepare_param_uint8(0x40);
   BCL_tool_prepare_param_uint8(Tlm_CODE_AOBC_HK);
-  BCL_tool_prepare_param_uint8(1);
-  BCL_tool_register_cmd(1, Cmd_CODE_GENERATE_TLM);
+  BCL_tool_register_cmd(1, Cmd_CODE_TG_GENERATE_MS_TLM);
 
   BCL_tool_register_deploy (10, BC_HK_CYCLIC_TLM, TLCD_ID_DEPLOY_TLM);
 }

--- a/Examples/minimum_user/src/src_user/Drivers/Aocs/aobc.c
+++ b/Examples/minimum_user/src/src_user/Drivers/Aocs/aobc.c
@@ -140,13 +140,23 @@ DS_CMD_ERR_CODE AOBC_send_cmd(AOBC_Driver* aobc_driver, const CommonCmdPacket* p
 
   // [TODO] ここではコマンドが実際に存在するか，ということはフィルタしない！（でいいよね？）
   // 必要があれば，AOBC 側で弾くべき．
-  if (cmd_code == AOBC_Cmd_CODE_GENERATE_TLM)
+
+  switch (cmd_code)
   {
+  case AOBC_Cmd_CODE_GENERATE_TLM:            // FALLTHROUGH
+  case AOBC_Cmd_CODE_TG_GENERATE_TLM:         // FALLTHROUGH
+  case AOBC_Cmd_CODE_TG_GENERATE_HK_TLM:      // FALLTHROUGH
+  case AOBC_Cmd_CODE_TG_GENERATE_MS_TLM:      // FALLTHROUGH
+  case AOBC_Cmd_CODE_TG_GENERATE_ST_TLM:      // FALLTHROUGH
+  case AOBC_Cmd_CODE_TG_FORWARD_TLM:          // FALLTHROUGH
+  case AOBC_Cmd_CODE_TG_FORWARD_AS_HK_TLM:    // FALLTHROUGH
+  case AOBC_Cmd_CODE_TG_FORWARD_AS_MS_TLM:    // FALLTHROUGH
+  case AOBC_Cmd_CODE_TG_FORWARD_AS_ST_TLM:
     ret = DS_send_req_tlm_cmd(&(aobc_driver->driver.super), AOBC_STREAM_TLM_CMD);
-  }
-  else
-  {
+    break;
+  default:
     ret = DS_send_general_cmd(&(aobc_driver->driver.super), AOBC_STREAM_TLM_CMD);
+    break;
   }
 
   if (ret == DS_ERR_CODE_OK)

--- a/Examples/minimum_user/src/src_user/Settings/TlmCmd/DataBase/CMDFILE/sample.ops
+++ b/Examples/minimum_user/src/src_user/Settings/TlmCmd/DataBase/CMDFILE/sample.ops
@@ -5,40 +5,40 @@
 .# =======================================
  #  NOP
  # =======================================
-.MOBC_RT.Cmd_NOP
+.MOBC_RT.NOP
 .#
 .#
 .# =======================================
  #  テレメダウンリンク
  # =======================================
-.MOBC_RT.Cmd_GENERATE_TLM 0x40 0x00 1   # MOBC
-.MOBC_RT.Cmd_GENERATE_TLM 0x40 0x56 1   # EL
-.MOBC_RT.Cmd_GENERATE_TLM 0x40 0x5a 1   # EH
-.MOBC_RT.Cmd_GENERATE_TLM 0x40 0x46 1   # App Time
+.MOBC_RT.TG_GENERATE_MS_TLM 0x00   # MOBC
+.MOBC_RT.TG_GENERATE_MS_TLM 0x56   # EL
+.MOBC_RT.TG_GENERATE_MS_TLM 0x5a   # EH
+.MOBC_RT.TG_GENERATE_MS_TLM 0x46   # App Time
 .#
 .#
 .# =======================================
  #  定期的なテレメダウンリンク
  # =======================================
-.MOBC_RT.Cmd_BCT_CLEAR_BLOCK 77     # BCT 77 を使用
+.MOBC_RT.BCT_CLEAR_BLOCK 77     # BCT 77 を使用
  wait_sec 1
- MOBC_BL.Cmd_GENERATE_TLM 1 0x40 0xf0 1 # HK
+ MOBC_BL.TG_GENERATE_MS_TLM 1 0xf0 # HK
  wait_sec 1
- MOBC_BL.Cmd_GENERATE_TLM 3 0x40 0x56 1 # EL
+ MOBC_BL.TG_GENERATE_MS_TLM 3 0x56 # EL
  wait_sec 1
- MOBC_BL.Cmd_TLCD_DEPLOY_BLOCK 10 2 77
+ MOBC_BL.TLCD_DEPLOY_BLOCK 10 2 77
  wait_sec 1
- MOBC_RT.Cmd_BCE_ACTIVATE_BLOCK
+ MOBC_RT.BCE_ACTIVATE_BLOCK
  wait_sec 1
- MOBC_RT.Cmd_TLCD_CLEAR_ALL_TIMELINE 2
+ MOBC_RT.TLCD_CLEAR_ALL_TIMELINE 2
  wait_sec 1
  # BCを展開し，TLM出力開始
- MOBC_RT.Cmd_TLCD_DEPLOY_BLOCK 2 77
+ MOBC_RT.TLCD_DEPLOY_BLOCK 2 77
 .#
 .#
 .# =======================================
  #  イベント登録
  # =======================================
-.MOBC_RT.Cmd_EL_RECORD_EVENT 255 1 0 0
-.MOBC_RT.Cmd_EL_RECORD_EVENT 255 2 1 0
-.MOBC_RT.Cmd_EL_RECORD_EVENT 255 3 2 1
+.MOBC_RT.EL_RECORD_EVENT 255 1 0 0
+.MOBC_RT.EL_RECORD_EVENT 255 2 1 0
+.MOBC_RT.EL_RECORD_EVENT 255 3 2 1

--- a/Examples/minimum_user/src/src_user/Test/test/conftest.py
+++ b/Examples/minimum_user/src/src_user/Test/test/conftest.py
@@ -37,8 +37,8 @@ def _increase_hk_frequency():
     for ti in range(1, 10, 2):
         ope.send_bl_cmd(
             ti,
-            c2a_enum.Cmd_CODE_GENERATE_TLM,
-            (0x40, c2a_enum.Tlm_CODE_HK, 1),
+            c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM,
+            (c2a_enum.Tlm_CODE_HK,),
         )
         time.sleep(0.1)
 

--- a/Examples/minimum_user/src/src_user/TlmCmd/NormalBlockCommandDefinition/nbc_start_hk_tlm.c
+++ b/Examples/minimum_user/src/src_user/TlmCmd/NormalBlockCommandDefinition/nbc_start_hk_tlm.c
@@ -11,10 +11,8 @@
 
 void BCL_load_start_hk_tlm(void)
 {
-  BCL_tool_prepare_param_uint8(0x40);
   BCL_tool_prepare_param_uint8(Tlm_CODE_HK);
-  BCL_tool_prepare_param_uint8(1);
-  BCL_tool_register_cmd(1, Cmd_CODE_GENERATE_TLM);
+  BCL_tool_register_cmd(1, Cmd_CODE_TG_GENERATE_MS_TLM);
 
   BCL_tool_register_deploy (10, BC_HK_CYCLIC_TLM, TLCD_ID_DEPLOY_TLM);
 }


### PR DESCRIPTION
## 概要
古い `GENERATE_TLM` の利用を消す（telemetry manager , pytest 以外）

## Issue
- https://github.com/ut-issl/c2a-core/issues/543

## 詳細
- サンプルコマンドファイルの修正
- その他あったものを削除

## 検証結果
既存のテストが全て通ればOK

## 補足
- pytest は https://github.com/ut-issl/c2a-core/pull/588 で
- tlm mgr については https://github.com/ut-issl/c2a-core/issues/556 で
