### PR TITLE
Pre Release (v3.9.0-beta.7): pytest 内の古い `GENERATE_TLM` の利用を消す

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2a-core"
-version = "3.9.0-beta.6"
+version = "3.9.0-beta.7"
 edition = "2021"
 
 links = "c2a-core"

--- a/Examples/2nd_obc_user/src/src_user/Test/test/test_comm_between_c2a.py
+++ b/Examples/2nd_obc_user/src/src_user/Test/test/test_comm_between_c2a.py
@@ -229,7 +229,7 @@ def ckeck_mobc_bct_ack(ti, exec_cmd, bct_id):
 
     g_mobc_gsc_cnt += 1
     tlm_MOBC = wings.util.generate_and_receive_tlm(
-        ope, mobc_c2a_enum.Cmd_CODE_GENERATE_TLM, mobc_c2a_enum.Tlm_CODE_MOBC
+        ope, mobc_c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, mobc_c2a_enum.Tlm_CODE_MOBC
     )
     assert tlm_MOBC["MOBC.BCT_BLK_PTR"] == bct_id
     assert tlm_MOBC["MOBC.BCT_CMD_PTR"] == 1

--- a/Examples/minimum_user/src/src_user/Test/test/src_core/Applications/test_event_utility.py
+++ b/Examples/minimum_user/src/src_user/Test/test/src_core/Applications/test_event_utility.py
@@ -20,7 +20,7 @@ ope = wings_utils.get_wings_operation()
 @pytest.mark.sils
 def test_event_utility():
     tlm_EH = wings.util.generate_and_receive_tlm(
-        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_EH
+        ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_EH
     )
     assert tlm_EH["EH.EVENT_UTIL.IS_ENABLED_EH_EXECUTION"] == "ENABLE"
 
@@ -28,7 +28,7 @@ def test_event_utility():
         ope, c2a_enum.Cmd_CODE_EVENT_UTIL_DISABLE_EH_EXEC, (), c2a_enum.Tlm_CODE_HK
     )
     tlm_EH = wings.util.generate_and_receive_tlm(
-        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_EH
+        ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_EH
     )
     assert tlm_EH["EH.EVENT_UTIL.IS_ENABLED_EH_EXECUTION"] == "DISABLE"
 
@@ -36,7 +36,7 @@ def test_event_utility():
         ope, c2a_enum.Cmd_CODE_EVENT_UTIL_ENABLE_EH_EXEC, (), c2a_enum.Tlm_CODE_HK
     )
     tlm_EH = wings.util.generate_and_receive_tlm(
-        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_EH
+        ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_EH
     )
     assert tlm_EH["EH.EVENT_UTIL.IS_ENABLED_EH_EXECUTION"] == "ENABLE"
 

--- a/Examples/minimum_user/src/src_user/Test/test/src_core/Applications/test_timeline_command_dispatcher.py
+++ b/Examples/minimum_user/src/src_user/Test/test/src_core/Applications/test_timeline_command_dispatcher.py
@@ -136,7 +136,7 @@ def test_tlcd_set_id_and_page_for_tlm():
         c2a_enum.Tlm_CODE_HK,
     )
     tlm_TL = wings.util.generate_and_receive_tlm(
-        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_TL
+        ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_TL
     )
     assert tlm_TL["TL.LINE_NO"] == target_id
     assert tlm_TL["TL.PAGE_NO"] == target_page
@@ -164,7 +164,7 @@ def test_tlcd_send_and_clear_tl():
     clear_tl_gs_and_tl_mis()
 
     tlm_TL = wings.util.generate_and_receive_tlm(
-        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_TL
+        ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_TL
     )
     ti_now = tlm_TL["TL.SH.TI"]
 
@@ -250,7 +250,7 @@ def check_registered_tl_cmds(line_no, tis, cmd_id, params):
     )
 
     tlm_TL = wings.util.generate_and_receive_tlm(
-        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_TL
+        ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_TL
     )
     assert tlm_TL["TL.LINE_NO"] == line_no
 

--- a/Examples/minimum_user/src/src_user/Test/test/src_core/System/EventManager/test_event_handler.py
+++ b/Examples/minimum_user/src/src_user/Test/test/src_core/System/EventManager/test_event_handler.py
@@ -1785,31 +1785,31 @@ def init_el_and_eh():
 
 def download_eh_tlm():
     return wings.util.generate_and_receive_tlm(
-        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_EH
+        ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_EH
     )
 
 
 def download_eh_rule_tlm():
     return wings.util.generate_and_receive_tlm(
-        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_EH_RULE
+        ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_EH_RULE
     )
 
 
 def download_eh_log_tlm():
     return wings.util.generate_and_receive_tlm(
-        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_EH_LOG
+        ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_EH_LOG
     )
 
 
 def download_eh_index_tlm():
     return wings.util.generate_and_receive_tlm(
-        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_EH_INDEX
+        ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_EH_INDEX
     )
 
 
 def download_el_tlm():
     return wings.util.generate_and_receive_tlm(
-        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_EL
+        ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_EL
     )
 
 
@@ -2081,7 +2081,7 @@ def get_latest_event():
     print("check_latest_event")
 
     tlm_EL = wings.util.generate_and_receive_tlm(
-        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_EL
+        ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_EL
     )
     return (
         tlm_EL["EL.LATEST_EVENT.GROUP"],

--- a/Examples/minimum_user/src/src_user/Test/test/src_core/System/EventManager/test_event_logger.py
+++ b/Examples/minimum_user/src/src_user/Test/test/src_core/System/EventManager/test_event_logger.py
@@ -886,7 +886,7 @@ def update_el_tlm():
     )
 
     el_tlm = wings.util.generate_and_receive_tlm(
-        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_EL
+        ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_EL
     )
 
     g_el_tlm = el_tlm
@@ -947,7 +947,7 @@ def update_el_tlog_tlm():
     )
 
     el_tlog_tlm = wings.util.generate_and_receive_tlm(
-        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_EL_TLOG
+        ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_EL_TLOG
     )
 
     g_tlog_em_tlm = el_tlog_tlm
@@ -984,7 +984,7 @@ def update_el_clog_tlm():
     )
 
     el_clog_tlm = wings.util.generate_and_receive_tlm(
-        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_EL_CLOG
+        ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_EL_CLOG
     )
 
     g_clog_em_tlm = el_clog_tlm

--- a/Examples/minimum_user/src/src_user/Test/test/src_core/System/ModeManager/test_mode_manager.py
+++ b/Examples/minimum_user/src/src_user/Test/test/src_core/System/ModeManager/test_mode_manager.py
@@ -92,7 +92,7 @@ def test_mm_nop():
 #     assert tlm_HK["HK.OBC.GS_CMD.LAST_EXEC.EXEC_STS"] == "SUC"
 
 #     tlm_MM = wings.util.generate_and_receive_tlm(
-#         ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_MM
+#         ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_MM
 #     )
 #     assert tlm_MM["MM.MODE_LIST_15"] == valid_bc - 0x100  # FIXME: 0x17Eで動くようにする
 
@@ -168,7 +168,7 @@ def test_mm_nop():
 #     assert tlm_HK["HK.OBC.GS_CMD.LAST_EXEC.EXEC_STS"] == "SUC"
 
 #     tlm_MM = wings.util.generate_and_receive_tlm(
-#         ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_MM
+#         ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_MM
 #     )
 #     # assert tlm_MM["MM.MODE_LIST_15"] == 0x17E
 #     assert (
@@ -194,7 +194,7 @@ def test_mm_nop():
 #         c2a_enum.Tlm_CODE_HK,
 #     )
 #     tlm_HK = wings.util.generate_and_receive_tlm(
-#         ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_HK
+#         ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_HK
 #     )
 #     assert tlm_HK["HK.OBC.GS_CMD.LAST_EXEC.EXEC_STS"] == "ERR"
 
@@ -206,7 +206,7 @@ def test_mm_nop():
 #         c2a_enum.Tlm_CODE_HK,
 #     )
 #     tlm_HK = wings.util.generate_and_receive_tlm(
-#         ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_HK
+#         ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_HK
 #     )
 #     assert tlm_HK["HK.OBC.GS_CMD.LAST_EXEC.EXEC_STS"] == "ERR"
 
@@ -230,7 +230,7 @@ def test_mm_nop():
 #         c2a_enum.Tlm_CODE_HK,
 #     )
 #     tlm_HK = wings.util.generate_and_receive_tlm(
-#         ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_HK
+#         ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_HK
 #     )
 #     assert tlm_HK["HK.OBC.GS_CMD.LAST_EXEC.EXEC_STS"] == "SUC"
 #     assert tlm_HK["HK.OBC.MM_OPSMODE"] == "RESERVE_3"
@@ -238,7 +238,7 @@ def test_mm_nop():
 
 #     time.sleep(5)
 #     tlm_HK = wings.util.generate_and_receive_tlm(
-#         ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_HK
+#         ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_HK
 #     )
 #     assert tlm_HK["HK.OBC.MM_STS"] == "FINISHED"
 
@@ -256,7 +256,7 @@ def test_mm_nop():
 #         c2a_enum.Tlm_CODE_HK,
 #     )
 #     tlm_HK = wings.util.generate_and_receive_tlm(
-#         ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_HK
+#         ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_HK
 #     )
 #     assert tlm_HK["HK.OBC.GS_CMD.LAST_EXEC.EXEC_STS"] == "SUC"
 #     assert tlm_HK["HK.OBC.MM_OPSMODE"] == "INITIAL"
@@ -264,7 +264,7 @@ def test_mm_nop():
 
 #     time.sleep(5)
 #     tlm_HK = wings.util.generate_and_receive_tlm(
-#         ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_HK
+#         ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_HK
 #     )
 #     assert tlm_HK["HK.OBC.MM_STS"] == "FINISHED"
 
@@ -275,7 +275,7 @@ def test_mm_nop():
 #         c2a_enum.Tlm_CODE_HK,
 #     )
 #     tlm_HK = wings.util.generate_and_receive_tlm(
-#         ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_HK
+#         ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_HK
 #     )
 #     assert tlm_HK["HK.OBC.GS_CMD.LAST_EXEC.EXEC_STS"] == "SUC"
 #     wings.util.send_cmd_and_confirm(
@@ -285,7 +285,7 @@ def test_mm_nop():
 #         c2a_enum.Tlm_CODE_HK,
 #     )
 #     tlm_HK = wings.util.generate_and_receive_tlm(
-#         ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_HK
+#         ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_HK
 #     )
 #     assert tlm_HK["HK.OBC.GS_CMD.LAST_EXEC.EXEC_STS"] == "SUC"
 

--- a/Examples/minimum_user/src/src_user/Test/test/src_core/System/TimeManager/test_time_manager.py
+++ b/Examples/minimum_user/src/src_user/Test/test/src_core/System/TimeManager/test_time_manager.py
@@ -34,7 +34,7 @@ def test_tmgr_set_time():
 
     # TL2のテレメループが途切れないように、現在時刻より未来のTIに飛ばす
     tlm_HK = wings.util.generate_and_receive_tlm(
-        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_HK
+        ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_HK
     )
     target_ti = tlm_HK["HK.SH.TI"] + 1000
 
@@ -42,7 +42,7 @@ def test_tmgr_set_time():
         ope, c2a_enum.Cmd_CODE_TMGR_SET_TIME, (target_ti,), c2a_enum.Tlm_CODE_HK
     )
     tlm_HK = wings.util.generate_and_receive_tlm(
-        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_HK
+        ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_HK
     )
     assert tlm_HK["HK.SH.TI"] > target_ti
     assert tlm_HK["HK.SH.TI"] < target_ti + 50
@@ -63,7 +63,7 @@ def test_tmgr_set_unixtime():
     )
 
     tlm_HK = wings.util.generate_and_receive_tlm(
-        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_HK
+        ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_HK
     )
     unixtime_at_ti0 = (
         current_unixtime
@@ -97,7 +97,7 @@ def test_tmgr_set_utl_unixtime_epoch():
     )
 
     tlm_MOBC = wings.util.generate_and_receive_tlm(
-        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_MOBC
+        ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_MOBC
     )
     assert tlm_MOBC["MOBC.TM_UTL_UNIXTIME_EPOCH"] == new_epoch
 
@@ -117,7 +117,7 @@ def test_tmgr_set_and_reset_cycle_correction():
     )
 
     tlm_MOBC = wings.util.generate_and_receive_tlm(
-        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_MOBC
+        ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_MOBC
     )
     assert tlm_MOBC["MOBC.TM_CYCLES_PER_SEC_FIX_RATIO"] == set_value
 
@@ -127,7 +127,7 @@ def test_tmgr_set_and_reset_cycle_correction():
     )
 
     tlm_MOBC = wings.util.generate_and_receive_tlm(
-        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_MOBC
+        ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_MOBC
     )
     assert tlm_MOBC["MOBC.TM_CYCLES_PER_SEC_FIX_RATIO"] == 1.0
 
@@ -244,7 +244,7 @@ def check_utl_cmd_with(utl_unixtime_epoch, cycle_correction):
 
     # TL_gs に正しく登録されているか確認
     tlm_TL = wings.util.generate_and_receive_tlm(
-        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_TL
+        ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_TL
     )
     assert tlm_TL["TL.LINE_NO"] == c2a_enum.TLCD_ID_FROM_GS
     assert tlm_TL["TL.PAGE_NO"] == 0

--- a/Examples/minimum_user/src/src_user/Test/test/src_core/System/TimeManager/test_time_manager.py
+++ b/Examples/minimum_user/src/src_user/Test/test/src_core/System/TimeManager/test_time_manager.py
@@ -158,8 +158,8 @@ def test_tmgr_utl_cmd():
     wings.util.send_utl_cmd(
         ope,
         time.time() + 3,
-        c2a_enum.Cmd_CODE_GENERATE_TLM,
-        (0x40, c2a_enum.Tlm_CODE_GS, 1),
+        c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM,
+        (c2a_enum.Tlm_CODE_GS,),
     )
     wings.util.send_utl_cmd(
         ope,

--- a/Examples/minimum_user/src/src_user/Test/test/src_core/System/WatchdogTimer/test_watchdog_timer.py
+++ b/Examples/minimum_user/src/src_user/Test/test/src_core/System/WatchdogTimer/test_watchdog_timer.py
@@ -19,28 +19,28 @@ ope = wings_utils.get_wings_operation()
 @pytest.mark.sils
 def test_wdt_at_sils():
     tlm_HK = wings.util.generate_and_receive_tlm(
-        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_HK
+        ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_HK
     )
     assert tlm_HK["HK.WDT.IS_ENABLE"] == "ENA"
     assert tlm_HK["HK.WDT.IS_CLEAR_ENABLE"] == "ENA"
 
     wings.util.send_cmd_and_confirm(ope, c2a_enum.Cmd_CODE_WDT_DISABLE, (), c2a_enum.Tlm_CODE_HK)
     tlm_HK = wings.util.generate_and_receive_tlm(
-        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_HK
+        ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_HK
     )
     assert tlm_HK["HK.WDT.IS_ENABLE"] == "DIS"
     assert tlm_HK["HK.WDT.IS_CLEAR_ENABLE"] == "ENA"
 
     wings.util.send_cmd_and_confirm(ope, c2a_enum.Cmd_CODE_WDT_ENABLE, (), c2a_enum.Tlm_CODE_HK)
     tlm_HK = wings.util.generate_and_receive_tlm(
-        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_HK
+        ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_HK
     )
     assert tlm_HK["HK.WDT.IS_ENABLE"] == "ENA"
     assert tlm_HK["HK.WDT.IS_CLEAR_ENABLE"] == "ENA"
 
     wings.util.send_cmd_and_confirm(ope, c2a_enum.Cmd_CODE_WDT_STOP_CLEAR, (), c2a_enum.Tlm_CODE_HK)
     tlm_HK = wings.util.generate_and_receive_tlm(
-        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_HK
+        ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_HK
     )
     assert tlm_HK["HK.WDT.IS_ENABLE"] == "ENA"
     assert tlm_HK["HK.WDT.IS_CLEAR_ENABLE"] == "DIS"
@@ -50,7 +50,7 @@ def test_wdt_at_sils():
         ope, c2a_enum.Cmd_CODE_WDT_START_CLEAR, (), c2a_enum.Tlm_CODE_HK
     )
     tlm_HK = wings.util.generate_and_receive_tlm(
-        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_HK
+        ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_HK
     )
     assert tlm_HK["HK.WDT.IS_ENABLE"] == "ENA"
     assert tlm_HK["HK.WDT.IS_CLEAR_ENABLE"] == "ENA"

--- a/Examples/minimum_user/src/src_user/Test/test/src_core/TlmCmd/test_block_command_loader.py
+++ b/Examples/minimum_user/src/src_user/Test/test/src_core/TlmCmd/test_block_command_loader.py
@@ -42,7 +42,7 @@ def test_bcl_prepare_param():
         c2a_enum.Tlm_CODE_HK,
     )
     tlm_BL = wings.util.generate_and_receive_tlm(
-        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_BL
+        ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_BL
     )
     assert tlm_BL["BL.BLOCK_NO"] == c2a_enum.BC_TEST_BCL
 

--- a/Examples/minimum_user/src/src_user/Test/test/src_core/TlmCmd/test_command_analyze.py
+++ b/Examples/minimum_user/src/src_user/Test/test/src_core/TlmCmd/test_command_analyze.py
@@ -29,7 +29,7 @@ TEST_CMD_ID = CA_MAX_CMDS - CA_TLM_PAGE_SIZE
 @pytest.mark.sils
 def test_command_analyze_set_page():
     tlm_CA = wings.util.generate_and_receive_tlm(
-        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_CA
+        ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_CA
     )
     assert tlm_CA["CA.PAGE_NO"] == 0
 
@@ -37,7 +37,7 @@ def test_command_analyze_set_page():
         ope, c2a_enum.Cmd_CODE_CA_SET_PAGE_FOR_TLM, (1,), c2a_enum.Tlm_CODE_HK
     )
     tlm_CA = wings.util.generate_and_receive_tlm(
-        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_CA
+        ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_CA
     )
     assert tlm_CA["CA.PAGE_NO"] == 1
 
@@ -55,7 +55,7 @@ def test_command_analyze_add_cmd():
 
     # これから上書きするので，NULL，つまり使われてないものでないとNG
     tlm_CA = wings.util.generate_and_receive_tlm(
-        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_CA
+        ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_CA
     )
     assert tlm_CA["CA.CMD0.FUNC"] == "0x00000000"
 
@@ -68,7 +68,7 @@ def test_command_analyze_add_cmd():
     )
 
     tlm_CA = wings.util.generate_and_receive_tlm(
-        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_CA
+        ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_CA
     )
     assert tlm_CA["CA.CMD0.FUNC"] == test_cmd_adr
     assert tlm_CA["CA.CMD0.PARAM0_SIZE"] == "1BYTE"
@@ -88,7 +88,7 @@ def test_command_analyze_add_cmd():
     )
 
     tlm_CA = wings.util.generate_and_receive_tlm(
-        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_CA
+        ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_CA
     )
     assert tlm_CA["CA.CMD0.FUNC"] == test_cmd_adr
     assert tlm_CA["CA.CMD0.PARAM0_SIZE"] == "NONE"
@@ -119,7 +119,7 @@ def test_command_analyze_final_check():
         ope, c2a_enum.Cmd_CODE_CA_SET_PAGE_FOR_TLM, (0,), c2a_enum.Tlm_CODE_HK
     )
     tlm_CA = wings.util.generate_and_receive_tlm(
-        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_CA
+        ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_CA
     )
     assert tlm_CA["CA.PAGE_NO"] == 0
 

--- a/Examples/minimum_user/src/src_user/Test/test/src_core/TlmCmd/test_command_dispatcher.py
+++ b/Examples/minimum_user/src/src_user/Test/test/src_core/TlmCmd/test_command_dispatcher.py
@@ -77,7 +77,7 @@ def check_cdis_exec_err(cmd_id, params, exec_sts_expected, err_code_expected):
 
     # === ELのチェック ===
     tlm_EL = wings.util.generate_and_receive_tlm(
-        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_EL
+        ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_EL
     )
 
     # GS_cmd_dispatcher

--- a/Examples/minimum_user/src/src_user/Test/test/src_core/TlmCmd/test_common_cmd_packet_util.py
+++ b/Examples/minimum_user/src/src_user/Test/test/src_core/TlmCmd/test_common_cmd_packet_util.py
@@ -168,7 +168,7 @@ def clear_tl_gs():
 
 def get_latest_tl_tlm():
     return wings.util.generate_and_receive_tlm(
-        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_TL
+        ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_TL
     )
 
 

--- a/Examples/minimum_user/src/src_user/Test/test/src_core/TlmCmd/test_telemetry_frame.py
+++ b/Examples/minimum_user/src/src_user/Test/test/src_core/TlmCmd/test_telemetry_frame.py
@@ -29,7 +29,7 @@ def test_telemetry_frame_set_page():
     init_tf()
 
     tlm_TF = wings.util.generate_and_receive_tlm(
-        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_TF
+        ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_TF
     )
     assert tlm_TF["TF.PAGE_NO"] == 0
 
@@ -37,7 +37,7 @@ def test_telemetry_frame_set_page():
         ope, c2a_enum.Cmd_CODE_TF_SET_PAGE_FOR_TLM, (1,), c2a_enum.Tlm_CODE_HK
     )
     tlm_TF = wings.util.generate_and_receive_tlm(
-        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_TF
+        ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_TF
     )
     assert tlm_TF["TF.PAGE_NO"] == 1
 
@@ -45,7 +45,7 @@ def test_telemetry_frame_set_page():
         ope, c2a_enum.Cmd_CODE_TF_SET_PAGE_FOR_TLM, (TF_TLM_PAGE_MAX,), c2a_enum.Tlm_CODE_HK
     )
     tlm_TF = wings.util.generate_and_receive_tlm(
-        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_TF
+        ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_TF
     )
     assert tlm_TF["TF.PAGE_NO"] == 1
 
@@ -57,7 +57,7 @@ def test_telemetry_frame_tlm_func():
 
     # 登録されている tlm func の確認
     tlm_TF = wings.util.generate_and_receive_tlm(
-        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_TF
+        ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_TF
     )
     assert int(tlm_TF["TF.TLM0"], base=16) != 0  # tlm id = 0 は MOBC tlm が普通はある
 
@@ -69,7 +69,7 @@ def test_telemetry_frame_tlm_func():
         ope, c2a_enum.Cmd_CODE_TF_SET_PAGE_FOR_TLM, (page,), c2a_enum.Tlm_CODE_HK
     )
     tlm_TF = wings.util.generate_and_receive_tlm(
-        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_TF
+        ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_TF
     )
 
     assert tlm_TF["TF.TLM" + str(offset)] == "0x00000000"
@@ -83,7 +83,7 @@ def test_telemetry_frame_tlm_func():
         c2a_enum.Tlm_CODE_HK,
     )
     tlm_TF = wings.util.generate_and_receive_tlm(
-        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_TF
+        ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_TF
     )
     assert tlm_TF["TF.TLM" + str(offset)] == func_adr
 

--- a/c2a_core_main.h
+++ b/c2a_core_main.h
@@ -10,6 +10,6 @@ void C2A_core_main(void);
 #define C2A_CORE_VER_MAJOR (3)
 #define C2A_CORE_VER_MINOR (9)
 #define C2A_CORE_VER_PATCH (0)
-#define C2A_CORE_VER_PRE   ("beta.6")
+#define C2A_CORE_VER_PRE   ("beta.7")
 
 #endif


### PR DESCRIPTION
## 概要
Pre Release (v3.9.0-beta.7): pytest 内の古い `GENERATE_TLM` の利用を消す

## Issue
- https://github.com/ut-issl/c2a-core/issues/543
- https://github.com/ut-issl/c2a-core/pull/584 のつづき
- https://github.com/ut-issl/c2a-core/issues/542

## 詳細
ツール側の修正もあるので，以下とともにマージする

- https://github.com/ut-issl/python-wings-interface/pull/34

## 検証結果
- 既存の pytest が全て通った

## 影響範囲
test の tlm 生成の書き方が全部変わる（過去のものは実行時エラーになる）

## 補足
- [x] https://github.com/ut-issl/c2a-core/pull/584 を先にマージする
- [ ] Tools のバージョンが変わるので Pre Release を打つ
- [x]  マージする前にバージョンを上げる