### PR TITLE
TG_generate_sub_obc_tlm を追加

### DIFF
--- a/TlmCmd/common_cmd_packet_util.c
+++ b/TlmCmd/common_cmd_packet_util.c
@@ -345,6 +345,18 @@ CCP_CmdRet CCP_form_and_exec_rtc(CMD_CODE cmd_id, const uint8_t* param, uint16_t
 }
 
 
+CCP_CmdRet CCP_form_and_exec_rtc_to_other_obc(APID apid, CMD_CODE cmd_id, const uint8_t* param, uint16_t len)
+{
+  CCP_UTIL_ACK ret = CCP_form_rtc_to_other_obc(&CCP_util_packet_, apid, cmd_id, param, len);
+  if (ret != CCP_UTIL_ACK_OK)
+  {
+    return CCP_make_cmd_ret_without_err_code(CCP_EXEC_PACKET_FMT_ERR);
+  }
+
+  return PH_dispatch_command(&CCP_util_packet_);
+}
+
+
 CCP_CmdRet CCP_form_and_exec_block_deploy_cmd(TLCD_ID tl_no, bct_id_t block_no)
 {
   CCP_UTIL_ACK ret = CCP_form_block_deploy_cmd(&CCP_util_packet_, tl_no, block_no);

--- a/TlmCmd/common_cmd_packet_util.h
+++ b/TlmCmd/common_cmd_packet_util.h
@@ -164,6 +164,18 @@ PH_ACK CCP_register_tlc_asap(cycle_t ti, TLCD_ID tlcd_id, CMD_CODE cmd_id, const
 CCP_CmdRet CCP_form_and_exec_rtc(CMD_CODE cmd_id, const uint8_t* param, uint16_t len);
 
 /**
+ * @brief 他の OBC のコマンドを RT として生成し, 即時実行する
+ * @note  生成される command は RTC だが，キューイングされずに即時実行されるため RTC Dispatcher にはログは残らない
+ * @param[in]     apid:   APID
+ * @param[in]     cmd_id: CMD_CODE
+ * @param[in]     param:  パラメタ
+ * @param[in]     len:    パラメタ長
+ * @retval CCP_CmdRet{CCP_EXEC_PACKET_FMT_ERR, *}: 引数が不正なとき
+ * @retval それ以外: PH_dispatch_command の返り値
+ */
+CCP_CmdRet CCP_form_and_exec_rtc_to_other_obc(APID apid, CMD_CODE cmd_id, const uint8_t* param, uint16_t len);
+
+/**
  * @brief BC展開 command を生成し，即時実行する
  * @param[in]     tl_no:    Timeline no
  * @param[in]     block_no: BC ID

--- a/TlmCmd/telemetry_generator.h
+++ b/TlmCmd/telemetry_generator.h
@@ -57,6 +57,6 @@ CCP_CmdRet Cmd_TG_FORWARD_AS_ST_TLM(const CommonCmdPacket* packet);
 /**
  * @brief 2nd OBC のテレメを生成したのち MS テレメとして転送する
  */
-CCP_CmdRet Cmd_TG_GENERATE_SUB_OBC_TLM(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_TG_GENERATE_2ND_OBC_MS_TLM(const CommonCmdPacket* packet);
 
 #endif

--- a/TlmCmd/telemetry_generator.h
+++ b/TlmCmd/telemetry_generator.h
@@ -54,4 +54,9 @@ CCP_CmdRet Cmd_TG_FORWARD_AS_MS_TLM(const CommonCmdPacket* packet);
  */
 CCP_CmdRet Cmd_TG_FORWARD_AS_ST_TLM(const CommonCmdPacket* packet);
 
+/**
+ * @brief 2nd OBC のテレメを生成したのち MS テレメとして転送する
+ */
+CCP_CmdRet Cmd_TG_GENERATE_SUB_OBC_TLM(const CommonCmdPacket* packet);
+
 #endif


### PR DESCRIPTION
## 概要
TG_generate_sub_obc_tlm を追加

## Issue
- https://github.com/ut-issl/c2a-core/issues/481

## 詳細
現状、sub OBC で generate してから MOBC で forwardする必要がある。それをセットにしたコマンドを作る
1. sub OBC にテレメ生成コマンドを送る
2. 生成されたテレメを forward するように TL で仕込む

## 検証結果
まだ. 後で検証する

## 影響範囲
XX系の動作がガラッと変わる，とか．

## 補足
https://github.com/ut-issl/c2a-core/pull/593 の後にマージすること