### PR TITLE
Update version (v3.9.0)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2a-core"
-version = "3.9.0-beta.9"
+version = "3.9.0"
 edition = "2021"
 
 links = "c2a-core"

--- a/c2a_core_main.h
+++ b/c2a_core_main.h
@@ -10,6 +10,6 @@ void C2A_core_main(void);
 #define C2A_CORE_VER_MAJOR (3)
 #define C2A_CORE_VER_MINOR (9)
 #define C2A_CORE_VER_PATCH (0)
-#define C2A_CORE_VER_PRE   ("beta.9")
+#define C2A_CORE_VER_PRE   ("")
 
 #endif


### PR DESCRIPTION
## 概要
Update version (v3.9.0)

## Issue
- https://github.com/ut-issl/c2a-core/issues/514


## 詳細
v3.9.0 リリース前の，バージョン上げ

## 検証結果
すべてのテストを再度通した（minimum_user, 2nd_obc_user ともに）
