### PR TITLE
Remove unused -rdynamic link option

### DIFF
--- a/common.cmake
+++ b/common.cmake
@@ -48,7 +48,6 @@ else()
 
   # debug
   target_compile_options(${PROJECT_NAME} PUBLIC "-g")
-  target_link_options(${PROJECT_NAME} PUBLIC "-rdynamic")
 
   # warning
   target_compile_options(${PROJECT_NAME} PUBLIC "-Wpedantic")


### PR DESCRIPTION
## 概要
不要な `-rdynamic` リンクオプションを削除

## 詳細
- `-rdynamic` は実行ファイルないし共用ライブラリにのみ効果のあるリンクオプション
- そのため，単体ではビルドできない c2a-core で指定しても意味が無い
- `PUBLIC` 指定されているので `add_subdirectory()` 先にも波及するが，c2a-core の責務を逸脱している
  - このオプションの主な用途である SILS-S2E の場合は S2E 側でそもそも指定されているため，このオプションが必要なケースでもここには不要（ref: https://github.com/ut-issl/s2e-core/blob/3a2f3fcc290848e6246cab2b1284645f8ff62f2a/common.cmake#L24-L25）
- 一方で，`-rdynamic` をサポートしないようなターゲットでは，このオプションがこのような形で存在することによってビルドに失敗するケースがある

## 検証結果
CI が通ればよし

## 影響範囲
- CMake でのビルド環境

## 補足
- リリースしたい
  - まだ breaking なものが 3.9.0 以降マージされていないため，3.9.1 としたい