### PR TITLE
異なる型の enum を比較している箇所を修正する

### DIFF
--- a/TlmCmd/common_cmd_packet_util.c
+++ b/TlmCmd/common_cmd_packet_util.c
@@ -266,7 +266,7 @@ PH_ACK CCP_register_tlc(cycle_t ti, TLCD_ID tlcd_id, CMD_CODE cmd_id, const uint
 {
   CCP_EXEC_TYPE type = CCP_get_exec_type_from_tlcd_id(tlcd_id);
 
-  if (type == CCP_EXEC_UNKNOWN)
+  if (type == CCP_EXEC_TYPE_UNKNOWN)
   {
     return PH_ACK_INVALID_PACKET;
   }


### PR DESCRIPTION
## 概要

主に c2a-user 側でビルドする際に問題となる:

- C としてビルドする場合: `-Werror` オプションでも（何故か）引っかからないが，潜在的には NG
- C++ としてビルドする場合: そもそもビルドに通らない．

## Issue

なし．

## 詳細

コミットログを参照．

## 影響範囲

common_command_packet 周り．

## 補足

類似の問題を網羅的に解決する訳ではないが，今後似たようなエラーに遭遇したら都度対処予定です．
