### PR TITLE
endian.c の include の修正

### DIFF
--- a/Library/endian.c
+++ b/Library/endian.c
@@ -6,6 +6,7 @@
 #include "endian.h"
 #include <src_user/Settings/build_settings.h>
 #include <stdint.h>
+#include <string.h>
 
 void* ENDIAN_memcpy(void* dest, const void* src, size_t size)
 {


### PR DESCRIPTION
## 概要
endian.c の include の修正

## Issue
NA

## 詳細
memcpy をつかってるのに string.h が include されてないのはおかしい
あるマイコンでエラーが出た

## 検証結果
CIがとおればよし