### PR TITLE
Fix function prototype mismatch in Applications

### DIFF
--- a/Applications/event_utility.c
+++ b/Applications/event_utility.c
@@ -26,7 +26,7 @@ static void EVENT_UTIL_init_(void)
   event_utility_.is_enabled_eh_execution = 1;
 }
 
-static void EVENT_UTIL_update_()
+static void EVENT_UTIL_update_(void)
 {
   if (event_utility_.is_enabled_eh_execution)
   {

--- a/Applications/nop.c
+++ b/Applications/nop.c
@@ -16,7 +16,7 @@ AppInfo NOP_create_app(void)
   return AI_create_app_info("nop", NULL, NOP_nop_);
 }
 
-static void NOP_nop_() {
+static void NOP_nop_(void) {
   // no operation
 }
 


### PR DESCRIPTION
## 概要
プロトタイプ宣言と定義の表記揺れ（というか `void` の有無）を修正

## 詳細
see diff

## 検証結果

## 影響範囲
warning が減る

## 補足
マージ後 3.9.2 をリリースしたい